### PR TITLE
Delete share directory from the distribution

### DIFF
--- a/Delete-ShareDirectory.ps1
+++ b/Delete-ShareDirectory.ps1
@@ -1,0 +1,17 @@
+<#
+  .Synopsis
+  Deletes 'share' directory
+  .Details
+  Removes 'share' directory from the distribution.
+  .Parameter Triplet
+  The vcpkg triplet to use.
+#>
+
+param(
+  [Parameter()]
+  [string]$triplet
+)
+
+$ErrorActionPreference = 'Stop';
+
+Remove-Item -Path (Join-Path $PSScriptRoot "installed\${triplet}\share") -Recurse

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,16 +47,9 @@ The `Install-Requirements.ps1` script is a wrapper around `vcpkg` which will
 invoke `vcpkg install` with a list of requirements. The requirements are
 defined in a .json file which is nothing more than a list of port names.
 
-## Renaming bin/lib
-
-The WebKit Windows port assumes that the bin and lib directory both contain a
-suffix for whether it is a 64-bit or 32-bit build. The
-`Rename-WithBitSuffix.ps1` script will rename according to the triplet passed
-in.
-
 ## Creating the zip
 
-The `Package-Requirements.ps1` script creates a zip file containing the
+The `Release-Requirements.ps1` script creates a zip file containing the
 dependencies. If a different filename is required then set the `-Output` flag
 accordingly.
 
@@ -68,8 +61,5 @@ accordingly.
 # TODO Remove cflite from distribution
 .\vcpkg.exe install cflite --triplet x64-windows-webkit
 
-& Rename-WithBitSuffix.ps1
-& Delete-PthreadHeaders.ps1
-
-& Package-Requirements.ps1
+& Release-Requirements.ps1 -triplet x64-windows-webkit
 ```

--- a/Release-Requirements.ps1
+++ b/Release-Requirements.ps1
@@ -30,6 +30,10 @@ if ($platform -eq 'windows') {
   return;
 }
 
+$command = ('Delete-ShareDirectory.ps1 -triplet {0}' -f $triplet)
+Write-Host $command;
+Invoke-Expression -Command ('{0}/{1}' -f $PSScriptRoot,$command);
+
 $command = ('Package-Requirements.ps1 -triplet {0}' -f $triplet);
 Write-Host $command;
 Invoke-Expression -Command ('{0}/{1}' -f $PSScriptRoot,$command);


### PR DESCRIPTION
Added Delete-ShareDirectory.ps1 to delete the unnecessary 'share'
directory from the distribution, which is causing a problem for
Windows WebKit compiled with CMake 3.17.

Bug 209638 – [WinCairo] CMake 3.17.0 reports an error in WebKitLibraries/win/share/curl/cmake/CURLTargets.cmake
<https://bugs.webkit.org/show_bug.cgi?id=209638>