### PR TITLE
Apply patches for zlib

### DIFF
--- a/ports/zlib/patches/0002-Add-__has_declspec_attribute.patch
+++ b/ports/zlib/patches/0002-Add-__has_declspec_attribute.patch
@@ -29,7 +29,7 @@ index 49075b7..a469a1c 100644
  /* Maximum value for memLevel in deflateInit2 */
  #ifndef MAX_MEM_LEVEL
  #  define MAX_MEM_LEVEL 9
-@@ -53,29 +60,29 @@
+@@ -53,29 +60,28 @@
                          /* Type declarations */
  
  
@@ -78,7 +78,7 @@ index 49075b7..a469a1c 100644
 +   /* For complete Windows compatibility, use WINAPI, not __stdcall. */
 +#  define ZEXPORT WINAPI
 +#  define ZEXPORTVA WINAPIV
- #  endif
+-#  endif
  #endif
  
 diff --git a/zconf.h.in b/zconf.h.in
@@ -99,7 +99,7 @@ index f890fcd..1489477 100644
  /* Maximum value for memLevel in deflateInit2 */
  #ifndef MAX_MEM_LEVEL
  #  define MAX_MEM_LEVEL 9
-@@ -57,29 +64,29 @@
+@@ -57,29 +64,28 @@
  #  define OF(args)  args
  #endif
  
@@ -148,7 +148,7 @@ index f890fcd..1489477 100644
 +   /* For complete Windows compatibility, use WINAPI, not __stdcall. */
 +#  define ZEXPORT WINAPI
 +#  define ZEXPORTVA WINAPIV
- #  endif
+-#  endif
  #endif
  
 diff --git a/zutil.h b/zutil.h

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_from_github(
     REPO zlib-ng/zlib-ng
     REF ${ZLIB_GIT_REF}
     SHA512 bd2af682a80fea01ab3f7d1843e1944da69a524fb983522716883f74efb430d1ceb578bab1c70b945715850ca5722896c84fdc886c2d4e736987e98139fac188
-    PATCHES ${PATCHES}
+    PATCHES ${ZLIB_PATCHES}
 )
 
 # Run CMake build


### PR DESCRIPTION
Make zlib portfile apply the ZLIB_PATCHES. The 0002 patch appeared to cause a compile error, with an
extra level of endif, so update patch.