### PR TITLE
Remove vcpkg_common_functions

### DIFF
--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.0.9)
 
 # Get archive

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.17.1)
 string(REPLACE "." "_" TAG ${VERSION})
 

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.17.4)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cairo-${VERSION})
 

--- a/ports/cflite/portfile.cmake
+++ b/ports/cflite/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 0.0.2)
 
 # Get archive

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 7.75.0)
 string(REPLACE "." "_" TAG ${VERSION})
 

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 2.10.4)
 
 # Get archive

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 2.7.4)
 
 # Get archive

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION_MAJOR 68)
 set(VERSION_MINOR 2)
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 include(${CMAKE_CURRENT_LIST_DIR}/vcpkg_acquire_gnuwin32_program.cmake)
 
 set(VERSION 2.0.6)

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.6.37)
 
 # Get archive

--- a/ports/libpsl/portfile.cmake
+++ b/ports/libpsl/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 include(${CMAKE_CURRENT_LIST_DIR}/psl.cmake)
 
 set(VERSION 0.21.1)

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 3.3.1)
 
 # Get archive

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.2.0)
 
 # Get archive

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 2.9.10)
 
 # Get archive

--- a/ports/libxslt/portfile.cmake
+++ b/ports/libxslt/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.1.34)
 
 # Get archive

--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.43.0)
 
 # Get archive

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 2.4.0)
 
 # Get archive

--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 0.40.0)
 
 # Get archive

--- a/ports/pthreads/portfile.cmake
+++ b/ports/pthreads/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
   message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 3.34.01)
 string(REPLACE "." "" TAG ${VERSION})
 string(CONCAT TAG ${TAG} "00")

--- a/ports/woff2/portfile.cmake
+++ b/ports/woff2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 1.0.2)
 
 # The woff2 library does not support shared libraries

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VERSION 2.0.0-RC2)
 
 # Get archive


### PR DESCRIPTION
The vcpkg_common_functions is now deprecated and all values are automatically provided in all portfile.cmake invocations.