### PR TITLE
Allow building of openssl executable

### DIFF
--- a/WindowsRequirements.json
+++ b/WindowsRequirements.json
@@ -1,7 +1,7 @@
 [
     "zlib",
     "brotli",
-    "libressl",
+    "libressl[tools]",
     "nghttp2",
     "curl[ares,ssl,ipv6]",
     "icu",

--- a/ports/libressl/CONTROL
+++ b/ports/libressl/CONTROL
@@ -4,3 +4,7 @@ Description: |
   LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014,
   with goals of modernizing the codebase, improving security, and applying
   best practice development processes.
+
+Feature: tools
+Description: |
+  Build openssl and ocspcheck executables.

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -23,28 +23,47 @@ vcpkg_extract_source_archive_ex(
     PATCHES ${PATCHES}
 )
 
+if (tools IN_LIST FEATURES)
+    message(STATUS "Enabling tools")
+    set(LIBRESSL_APPS ON)
+else ()
+    set(LIBRESSL_APPS OFF)
+endif ()
+
 # Run CMake build
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DLIBRESSL_APPS=OFF
         -DLIBRESSL_TESTS=OFF
+    OPTIONS_RELEASE
+        -DLIBRESSL_APPS=${LIBRESSL_APPS}
+    OPTIONS_DEBUG
+        -DLIBRESSL_APPS=OFF
 )
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 # Prepare distribution
+if (tools IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES openssl AUTO_CLEAN)
+
+    # Empty directory created during install to house certificated
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/etc/ssl/certs)
+else ()
+    # Config and pem files are not installed without the apps
+    file(
+        INSTALL
+            ${SOURCE_PATH}/apps/openssl/cert.pem
+            ${SOURCE_PATH}/apps/openssl/openssl.cnf
+            ${SOURCE_PATH}/apps/openssl/x509v3.cnf
+        DESTINATION ${CURRENT_PACKAGES_DIR}/etc/ssl
+    )
+endif ()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/man)
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libressl RENAME copyright)
-file(
-    INSTALL 
-        ${SOURCE_PATH}/apps/openssl/cert.pem
-        ${SOURCE_PATH}/apps/openssl/openssl.cnf
-        ${SOURCE_PATH}/apps/openssl/x509v3.cnf
-    DESTINATION ${CURRENT_PACKAGES_DIR}/etc/ssl
-)
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/libressl/version ${VERSION})


### PR DESCRIPTION
WebKit tests use `openssl` to test SSL functionality in http tests.