### PR TITLE
Disable c-ares by default on windows

### DIFF
--- a/WindowsRequirements.json
+++ b/WindowsRequirements.json
@@ -3,7 +3,7 @@
     "brotli",
     "libressl[tools]",
     "nghttp2",
-    "curl[ares,ssl,ipv6]",
+    "curl[ssl,ipv6]",
     "icu",
     "libxml2[xslt]",
     "libxslt",


### PR DESCRIPTION
There are issues resolving localhost on windows causing HTTP tests to fail https://github.com/c-ares/c-ares/issues/399.
The old workaround patch mentioned has some issues where it resolves localhost to ::1 when a port is only bound to the v4 loopback address.
WPT http tests are only bound to the v4 loopback.