### PR TITLE
Add patch for libressl TLS1.3 cert error fix

### DIFF
--- a/ports/libressl/patches/0003-Avoid-clobbering-the-error-code-when-sending-an-alert.patch
+++ b/ports/libressl/patches/0003-Avoid-clobbering-the-error-code-when-sending-an-alert.patch
@@ -1,0 +1,14 @@
+diff --git a/ssl/tls13_lib.c b/ssl/tls13_lib.c
+index 9dbb7d6430..f064521c8b 100644
+--- a/ssl/tls13_lib.c
++++ b/ssl/tls13_lib.c
+@@ -147,7 +147,8 @@ tls13_alert_sent_cb(uint8_t alert_desc, void *arg)
+ 	}
+ 
+ 	/* All other alerts are treated as fatal in TLSv1.3. */
+-	SSLerror(ctx->ssl, SSL_AD_REASON_OFFSET + alert_desc);
++	if (ctx->error.code == 0)
++		SSLerror(ctx->ssl, SSL_AD_REASON_OFFSET + alert_desc);
+ }
+ 
+ static void

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_download_distfile(ARCHIVE
 set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Remove-postfix-from-archive-name.patch
     ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Disable-additional-warnings-for-Visual-Studio.patch
+    # Remove after next libressl release
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Avoid-clobbering-the-error-code-when-sending-an-alert.patch
 )
 
 # Extract archive


### PR DESCRIPTION
Pulling in https://github.com/openbsd/src/commit/caffe9b53bbba8abff2fd1c0df83b8e76a6ef282 until the next libressl release