### PR TITLE
Copy full triplet directory in Install-Vcpkg

### DIFF
--- a/Install-Vcpkg.ps1
+++ b/Install-Vcpkg.ps1
@@ -90,8 +90,8 @@ Copy-DirectoryStructure `
    -Path (Join-Path $vcpkgPath 'scripts') `
    -Destination (Join-Path $PSScriptRoot 'scripts');
 Copy-DirectoryStructure `
-   -Path (Join-Path $vcpkgPath -ChildPath 'triplets' | Join-Path -ChildPath 'community') `
-   -Destination (Join-Path $PSScriptRoot -ChildPath 'triplets' | Join-Path -ChildPath 'community');
+   -Path (Join-Path $vcpkgPath -ChildPath 'triplets') `
+   -Destination (Join-Path $PSScriptRoot -ChildPath 'triplets');
 
 # Restore location
 Set-Location $currentPath;


### PR DESCRIPTION
If the x64-windows triplet is not present in the root of triplets then vcpkg will refuse to run. Copy all of triplets not just the community subfolder.