### PR TITLE
Add cairo post v1.17.4 patches

### DIFF
--- a/ports/cairo/patches/0001-Rename-stat-to-stats.patch
+++ b/ports/cairo/patches/0001-Rename-stat-to-stats.patch
@@ -1,7 +1,7 @@
-From f66dcdf0567f087b7e4bc63d06e9ece1d1c7ef51 Mon Sep 17 00:00:00 2001
+From 5f8a2874c8cec0aa3d7fa3c1064a0027c994020a Mon Sep 17 00:00:00 2001
 From: Don <don.j.olmstead@gmail.com>
 Date: Mon, 2 Apr 2018 14:58:45 -0700
-Subject: [PATCH] Rename stat to stats
+Subject: [PATCH 01/11] Rename stat to stats
 
 There is a struct stat in sys/stat.h that can conflict when building cairo-surface-observer. Rename to avoid this issue.
 ---
@@ -41,7 +41,7 @@ index 6ed0c18d1..7d7dd8d4c 100644
  	unsigned int noop;
  
 diff --git a/src/cairo-surface-observer.c b/src/cairo-surface-observer.c
-index 89c7525c7..d63094e51 100644
+index 9c4432e24..6bd2d4ec7 100644
 --- a/src/cairo-surface-observer.c
 +++ b/src/cairo-surface-observer.c
 @@ -58,7 +58,7 @@ static const cairo_surface_backend_t _cairo_surface_observer_backend;
@@ -63,5 +63,5 @@ index 89c7525c7..d63094e51 100644
      if (v < s->min)
  	s->min = v;
 -- 
-2.14.1.windows.1
+2.33.0.windows.2
 

--- a/ports/cairo/patches/0002-boilerplate-Use-_cairo_malloc-instead-of-malloc.patch
+++ b/ports/cairo/patches/0002-boilerplate-Use-_cairo_malloc-instead-of-malloc.patch
@@ -1,0 +1,176 @@
+From ca613dc5f15ed74573ec821b72c97c021d5073d5 Mon Sep 17 00:00:00 2001
+From: Bryce Harrington <bryce@osg.samsung.com>
+Date: Mon, 7 May 2018 17:11:24 -0700
+Subject: [PATCH 02/11] boilerplate: Use _cairo_malloc instead of malloc
+
+This changes most instances of malloc() calls to use Cairo's safer
+_cairo_malloc().  The malloc() call in the implementation of
+boilerplate's xmalloc() is not changed since it already includes a
+size=0 check.
+
+Signed-off-by: Bryce Harrington <bryce@osg.samsung.com>
+---
+ boilerplate/cairo-boilerplate-cogl.c           | 5 +++--
+ boilerplate/cairo-boilerplate-vg.c             | 3 ++-
+ boilerplate/cairo-boilerplate-win32-printing.c | 3 ++-
+ boilerplate/cairo-boilerplate-xcb.c            | 3 ++-
+ boilerplate/cairo-boilerplate-xlib.c           | 3 ++-
+ boilerplate/cairo-boilerplate.c                | 7 ++++---
+ 6 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/boilerplate/cairo-boilerplate-cogl.c b/boilerplate/cairo-boilerplate-cogl.c
+index 0982e4133..2339dd883 100644
+--- a/boilerplate/cairo-boilerplate-cogl.c
++++ b/boilerplate/cairo-boilerplate-cogl.c
+@@ -31,6 +31,7 @@
+  */
+ 
+ #include "cairo-boilerplate-private.h"
++#include "cairo-malloc-private.h"
+ 
+ #include <cairo-cogl.h>
+ #include <cogl/cogl2-experimental.h>
+@@ -80,7 +81,7 @@ _cairo_boilerplate_cogl_create_offscreen_color_surface (const char		*name,
+     /* The device will take a reference on the context */
+     cogl_object_unref (context);
+ 
+-    closure = malloc (sizeof (cogl_closure_t));
++    closure = _cairo_malloc (sizeof (cogl_closure_t));
+     *abstract_closure = closure;
+     closure->device = device;
+     closure->surface = cairo_cogl_offscreen_surface_create (device,
+@@ -151,7 +152,7 @@ _cairo_boilerplate_cogl_create_onscreen_color_surface (const char	       *name,
+     /* The device will take a reference on the context */
+     cogl_object_unref (context);
+ 
+-    closure = malloc (sizeof (cogl_closure_t));
++    closure = _cairo_malloc (sizeof (cogl_closure_t));
+     *abstract_closure = closure;
+     closure->device = device;
+     closure->surface = cairo_cogl_onscreen_surface_create (device,
+diff --git a/boilerplate/cairo-boilerplate-vg.c b/boilerplate/cairo-boilerplate-vg.c
+index 692765745..4ea6ba46b 100644
+--- a/boilerplate/cairo-boilerplate-vg.c
++++ b/boilerplate/cairo-boilerplate-vg.c
+@@ -31,6 +31,7 @@
+  */
+ 
+ #include "cairo-boilerplate-private.h"
++#include "cairo-malloc-private.h"
+ 
+ #include <cairo-vg.h>
+ 
+@@ -105,7 +106,7 @@ _cairo_boilerplate_vg_create_surface_glx (const char		    *name,
+     cairo_vg_context_t *context;
+     vg_closure_glx_t *vgc;
+ 
+-    vgc = malloc (sizeof (vg_closure_glx_t));
++    vgc = _cairo_malloc (sizeof (vg_closure_glx_t));
+     *closure = vgc;
+ 
+     if (width == 0)
+diff --git a/boilerplate/cairo-boilerplate-win32-printing.c b/boilerplate/cairo-boilerplate-win32-printing.c
+index 4bc1dd459..3d815167f 100644
+--- a/boilerplate/cairo-boilerplate-win32-printing.c
++++ b/boilerplate/cairo-boilerplate-win32-printing.c
+@@ -35,6 +35,7 @@
+ #endif
+ 
+ #include "cairo-boilerplate-private.h"
++#include "cairo-malloc-private.h"
+ 
+ #if CAIRO_CAN_TEST_WIN32_PRINTING_SURFACE
+ 
+@@ -131,7 +132,7 @@ create_printer_dc (win32_target_closure_t *ptc)
+ 
+     ptc->dc = NULL;
+     GetDefaultPrinter (NULL, &size);
+-    printer_name = malloc (size);
++    printer_name = _cairo_malloc (size);
+ 
+     if (printer_name == NULL)
+ 	return;
+diff --git a/boilerplate/cairo-boilerplate-xcb.c b/boilerplate/cairo-boilerplate-xcb.c
+index cc9b422e9..de9583ff3 100644
+--- a/boilerplate/cairo-boilerplate-xcb.c
++++ b/boilerplate/cairo-boilerplate-xcb.c
+@@ -25,6 +25,7 @@
+  */
+ 
+ #include "cairo-boilerplate-private.h"
++#include "cairo-malloc-private.h"
+ 
+ #include <cairo-xcb.h>
+ 
+@@ -206,7 +207,7 @@ _cairo_boilerplate_xcb_create_similar (cairo_surface_t *other,
+     xcb_render_pictforminfo_t *render_format;
+     int depth;
+ 
+-    similar = malloc (sizeof (*similar));
++    similar = _cairo_malloc (sizeof (*similar));
+ 
+     switch (content) {
+     default:
+diff --git a/boilerplate/cairo-boilerplate-xlib.c b/boilerplate/cairo-boilerplate-xlib.c
+index f3d559806..5d2498ccd 100644
+--- a/boilerplate/cairo-boilerplate-xlib.c
++++ b/boilerplate/cairo-boilerplate-xlib.c
+@@ -26,6 +26,7 @@
+ 
+ #include "cairo-boilerplate-private.h"
+ #include "cairo-boilerplate-xlib.h"
++#include "cairo-malloc-private.h"
+ 
+ #include <cairo-xlib.h>
+ #if CAIRO_HAS_XLIB_XRENDER_SURFACE
+@@ -244,7 +245,7 @@ _cairo_boilerplate_xlib_create_similar (cairo_surface_t		*other,
+     struct similar *similar;
+     cairo_surface_t *surface;
+ 
+-    similar = malloc (sizeof (*similar));
++    similar = _cairo_malloc (sizeof (*similar));
+     similar->dpy = cairo_xlib_surface_get_display (other);
+ 
+     switch (content) {
+diff --git a/boilerplate/cairo-boilerplate.c b/boilerplate/cairo-boilerplate.c
+index 383606177..30f0f6b01 100644
+--- a/boilerplate/cairo-boilerplate.c
++++ b/boilerplate/cairo-boilerplate.c
+@@ -26,6 +26,7 @@
+ 
+ #include "cairo-boilerplate-private.h"
+ #include "cairo-boilerplate-scaled-font.h"
++#include "cairo-malloc-private.h"
+ 
+ #include <pixman.h>
+ 
+@@ -177,7 +178,7 @@ _cairo_boilerplate_image_create_similar (cairo_surface_t *other,
+     }
+ 
+     stride = cairo_format_stride_for_width(format, width);
+-    ptr = malloc (stride* height);
++    ptr = _cairo_malloc (stride * height);
+ 
+     surface = cairo_image_surface_create_for_data (ptr, format,
+ 						   width, height, stride);
+@@ -226,7 +227,7 @@ _cairo_boilerplate_image16_create_similar (cairo_surface_t *other,
+     }
+ 
+     stride = cairo_format_stride_for_width(format, width);
+-    ptr = malloc (stride* height);
++    ptr = _cairo_malloc (stride * height);
+ 
+     surface = cairo_image_surface_create_for_data (ptr, format,
+ 						   width, height, stride);
+@@ -239,7 +240,7 @@ static char *
+ _cairo_boilerplate_image_describe (void *closure)
+ {
+     char *s;
+-  
++
+     xasprintf (&s, "pixman %s", pixman_version_string ());
+ 
+     return s;
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0003-Add-a-bounds-check-to-cairo_cff_parse_charstring.patch
+++ b/ports/cairo/patches/0003-Add-a-bounds-check-to-cairo_cff_parse_charstring.patch
@@ -1,0 +1,41 @@
+From b9d58e31e3fbfe9d4a1b1080b457986df9d7250b Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Fri, 25 Dec 2020 16:09:19 +0100
+Subject: [PATCH 03/11] Add a bounds check to cairo_cff_parse_charstring()
+
+The code in cairo-cff-subset.c parses a binary font format without
+seeming to bother much verifying the data. The result is that poppler
+can be used to cause an out-of-bounds access in
+cairo_cff_parse_charstring() via a crafted font file. Fix this by adding
+the needed length check.
+
+The other code in the file also contains lots of similar things. Since I
+cannot really fix everything properly, I'll just fix the one instance
+that was found by a fuzzer.
+
+No testcase is added, because this depends on a broken font that is
+quite large. Adding something this big to the test suite does not seem
+sensible.
+
+Fixes: https://gitlab.freedesktop.org/cairo/cairo/-/issues/444
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-cff-subset.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/cairo-cff-subset.c b/src/cairo-cff-subset.c
+index fce4195e9..f85190f77 100644
+--- a/src/cairo-cff-subset.c
++++ b/src/cairo-cff-subset.c
+@@ -1604,6 +1604,8 @@ cairo_cff_parse_charstring (cairo_cff_font_t *font,
+ 		}
+             } else {
+                 sub_num = font->type2_stack_top_value + font->local_sub_bias;
++		if (sub_num >= _cairo_array_num_elements(&font->local_sub_index))
++		    return CAIRO_INT_STATUS_UNSUPPORTED;
+                 element = _cairo_array_index (&font->local_sub_index, sub_num);
+                 if (! font->local_subs_used[sub_num] ||
+ 		    (need_width && !font->type2_found_width))
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0004-Slightly-improve-dealing-with-error-snapshots.patch
+++ b/ports/cairo/patches/0004-Slightly-improve-dealing-with-error-snapshots.patch
@@ -1,0 +1,56 @@
+From a5c049bbd5b00ad8c3a5e199369324152a526bc2 Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Sat, 26 Dec 2020 16:09:16 +0100
+Subject: [PATCH 04/11] Slightly improve dealing with error snapshots
+
+An error in _cairo_surface_snapshot_copy_on_write() results in a
+snapshot in an error state and the snapshot's ->target could now point
+to a surface from _cairo_surface_create_in_error(). These surfaces e.g.
+have ->backend == NULL. Thus, anything looking at ->backend->type now
+explodes. This commit deals with two places which caused segfaults in
+this situation.
+
+There is no test case for this, because
+_cairo_surface_snapshot_copy_on_write() really is not supposed to fail.
+
+Found-while-investigating: https://gitlab.freedesktop.org/cairo/cairo/-/issues/448
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-recording-surface.c | 5 +++++
+ src/cairo-surface-snapshot.c  | 4 +++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/cairo-recording-surface.c b/src/cairo-recording-surface.c
+index 6df8b0821..3e8b8e780 100644
+--- a/src/cairo-recording-surface.c
++++ b/src/cairo-recording-surface.c
+@@ -1764,6 +1764,11 @@ _cairo_recording_surface_merge_source_attributes (cairo_recording_surface_t  *su
+ 	if (_cairo_surface_is_snapshot (surf))
+ 	    free_me = surf = _cairo_surface_snapshot_get_target (surf);
+ 
++	if (unlikely (surf->status))
++	    // There was some kind of error and the surface could be a nil error
++	    // surface with various "problems" (e.g. ->backend == NULL).
++	    return;
++
+ 	if (surf->type == CAIRO_SURFACE_TYPE_RECORDING) {
+ 	    cairo_recording_surface_t *rec_surf = (cairo_recording_surface_t *) surf;
+ 
+diff --git a/src/cairo-surface-snapshot.c b/src/cairo-surface-snapshot.c
+index a8b8c0e45..b2908f6bc 100644
+--- a/src/cairo-surface-snapshot.c
++++ b/src/cairo-surface-snapshot.c
+@@ -71,7 +71,9 @@ _cairo_surface_snapshot_flush (void *abstract_surface, unsigned flags)
+     cairo_status_t status;
+ 
+     target = _cairo_surface_snapshot_get_target (&surface->base);
+-    status = _cairo_surface_flush (target, flags);
++    status = target->status;
++    if (status == CAIRO_STATUS_SUCCESS)
++	status = _cairo_surface_flush (target, flags);
+     cairo_surface_destroy (target);
+ 
+     return status;
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0005-Add-a-bounds-check-to-cairo_cff_font_read_fdselect.patch
+++ b/ports/cairo/patches/0005-Add-a-bounds-check-to-cairo_cff_font_read_fdselect.patch
@@ -1,0 +1,40 @@
+From fc6acb981fbf74a1677209f168c2758704dfdbcd Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Wed, 6 Jan 2021 10:38:42 +0100
+Subject: [PATCH 05/11] Add a bounds check to cairo_cff_font_read_fdselect()
+
+The code in cairo-cff-subset.c parses a binary format without seeming to
+bother much with verifying the data. The result is that poppler can be
+used to cause an out-of-bounds write in cairo_cff_font_read_fdselect()
+via a crafted font file. Fix this by adding the needed length check.
+
+The other code in the file also contains lots of similar things. Since I
+cannot really fix everything properly, I'll just fix the one instance
+that was found by a fuzzer.
+
+No testcase is added, because this depends on a broken font that is
+quite large. Adding something this big to the test suite does not seem
+sensible.
+
+Fixes: https://gitlab.freedesktop.org/cairo/cairo/-/issues/451
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-cff-subset.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/cairo-cff-subset.c b/src/cairo-cff-subset.c
+index f85190f77..d536f25c9 100644
+--- a/src/cairo-cff-subset.c
++++ b/src/cairo-cff-subset.c
+@@ -991,6 +991,8 @@ cairo_cff_font_read_fdselect (cairo_cff_font_t *font, unsigned char *p)
+             p += 2;
+             fd = *p++;
+             last = get_unaligned_be16 (p);
++            if (last > font->num_glyphs)
++                return CAIRO_INT_STATUS_UNSUPPORTED;
+             for (j = first; j < last; j++)
+                 font->fdselect[j] = fd;
+         }
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0006-Avoid-a-use-after-free.patch
+++ b/ports/cairo/patches/0006-Avoid-a-use-after-free.patch
@@ -1,0 +1,51 @@
+From a6004723986256c0ef6bfe2b34aa6828afb89d50 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Fri, 22 Jan 2021 13:28:44 -0500
+Subject: [PATCH 06/11] Avoid a use-after-free
+
+asan was complaining that the limits struct goes out
+of scope before it is used via the pointer in the polygon struct,
+and it is right:
+
+==386746==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffd3ccebdfc at pc 0x7f783d5eaaee bp 0x7ffd3cceba80 sp 0x7ffd3cceba70
+READ of size 4 at 0x7ffd3ccebdfc thread T0
+    #0 0x7f783d5eaaed in _add_clipped_edge ../src/cairo-polygon.c:351
+    #1 0x7f783d5ebba3 in _cairo_polygon_add_edge ../src/cairo-polygon.c:520
+    #2 0x7f783d5ebc82 in _cairo_polygon_add_external_edge ../src/cairo-polygon.c:530
+    #3 0x7f783d582149 in _cairo_filler_line_to ../src/cairo-path-fill.c:63
+    #4 0x7f783d588d9c in _cairo_path_fixed_interpret ../src/cairo-path-fixed.c:831
+    #5 0x7f783d582a44 in _cairo_path_fixed_fill_to_polygon ../src/cairo-path-fill.c:147
+    #6 0x7f783d6204fe in _cairo_spans_compositor_fill ../src/cairo-spans-compositor.c:1151
+    #7 0x7f783d5126de in _cairo_compositor_fill ../src/cairo-compositor.c:203
+    #8 0x7f783d5571f9 in _cairo_image_surface_fill ../src/cairo-image-surface.c:1003
+    #9 0x7f783d647f2f in _cairo_surface_fill ../src/cairo-surface.c:2424
+    #10 0x7f783d52ebea in _cairo_gstate_fill ../src/cairo-gstate.c:1312
+    #11 0x7f783d51cca4 in _cairo_default_context_fill ../src/cairo-default-context.c:1057
+    #12 0x7f783d6812d6 in cairo_fill ../src/cairo.c:2421
+---
+ src/cairo-spans-compositor.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cairo-spans-compositor.c b/src/cairo-spans-compositor.c
+index efbae254b..5f956ca98 100644
+--- a/src/cairo-spans-compositor.c
++++ b/src/cairo-spans-compositor.c
+@@ -1128,6 +1128,7 @@ _cairo_spans_compositor_fill (const cairo_compositor_t		*_compositor,
+     }
+     if (status == CAIRO_INT_STATUS_UNSUPPORTED) {
+ 	cairo_polygon_t polygon;
++	cairo_box_t limits;
+ 
+ 	TRACE((stderr, "%s - polygon\n", __FUNCTION__));
+ 
+@@ -1138,7 +1139,6 @@ _cairo_spans_compositor_fill (const cairo_compositor_t		*_compositor,
+ 	    if (extents->clip->num_boxes == 1) {
+ 		_cairo_polygon_init (&polygon, extents->clip->boxes, 1);
+ 	    } else {
+-		cairo_box_t limits;
+ 		_cairo_box_from_rectangle (&limits, &extents->unbounded);
+ 		_cairo_polygon_init (&polygon, &limits, 1);
+ 	    }
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0007-Avoid-a-use-after-scope.patch
+++ b/ports/cairo/patches/0007-Avoid-a-use-after-scope.patch
@@ -1,0 +1,37 @@
+From 6c431dc9ddaf16d9b743fef42623beec9700d65d Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Tue, 9 Mar 2021 07:53:50 +0100
+Subject: [PATCH 07/11] Avoid a use-after-scope
+
+This is the same fix as commit b345be5afee, but in a different place in
+the same file.
+
+Fixes: https://gitlab.freedesktop.org/cairo/cairo/-/issues/453
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-spans-compositor.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cairo-spans-compositor.c b/src/cairo-spans-compositor.c
+index 5f956ca98..50c92b25c 100644
+--- a/src/cairo-spans-compositor.c
++++ b/src/cairo-spans-compositor.c
+@@ -1041,6 +1041,7 @@ _cairo_spans_compositor_stroke (const cairo_compositor_t	*_compositor,
+ 
+     if (status == CAIRO_INT_STATUS_UNSUPPORTED) {
+ 	cairo_polygon_t polygon;
++	cairo_box_t limits;
+ 	cairo_fill_rule_t fill_rule = CAIRO_FILL_RULE_WINDING;
+ 
+ 	if (! _cairo_rectangle_contains_rectangle (&extents->unbounded,
+@@ -1049,7 +1050,6 @@ _cairo_spans_compositor_stroke (const cairo_compositor_t	*_compositor,
+ 	    if (extents->clip->num_boxes == 1) {
+ 		_cairo_polygon_init (&polygon, extents->clip->boxes, 1);
+ 	    } else {
+-		cairo_box_t limits;
+ 		_cairo_box_from_rectangle (&limits, &extents->unbounded);
+ 		_cairo_polygon_init (&polygon, &limits, 1);
+ 	    }
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0008-Fix-undefined-left-shifts.patch
+++ b/ports/cairo/patches/0008-Fix-undefined-left-shifts.patch
@@ -1,0 +1,370 @@
+From efef7ee575accb6390f26ce41bd152e228dcdb5d Mon Sep 17 00:00:00 2001
+From: Heiko Lewin <hlewin@worldiety.de>
+Date: Wed, 31 Mar 2021 12:20:34 +0200
+Subject: [PATCH 08/11] Fix undefined left-shifts
+
+---
+ src/cairo-base85-stream.c           | 2 +-
+ src/cairo-beos-surface.cpp          | 2 +-
+ src/cairo-box-inline.h              | 2 +-
+ src/cairo-cff-subset.c              | 2 +-
+ src/cairo-gl-gradient.c             | 6 +++---
+ src/cairo-gl-shaders.c              | 2 +-
+ src/cairo-image-compositor.c        | 4 ++--
+ src/cairo-png.c                     | 4 ++--
+ src/cairo-truetype-subset-private.h | 2 +-
+ src/cairo-type1-subset.c            | 8 ++++----
+ src/cairo-vg-surface.c              | 2 +-
+ src/cairo-xcb-surface-render.c      | 2 +-
+ src/cairo-xlib-render-compositor.c  | 2 +-
+ src/cairo-xlib-source.c             | 4 ++--
+ src/cairo-xlib-surface.c            | 2 +-
+ src/cairoint.h                      | 2 +-
+ src/drm/cairo-drm-i915-private.h    | 4 ++--
+ src/drm/cairo-drm-i915-shader.c     | 4 ++--
+ src/drm/cairo-drm-i965-shader.c     | 2 +-
+ src/win32/cairo-win32-font.c        | 2 +-
+ 20 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/src/cairo-base85-stream.c b/src/cairo-base85-stream.c
+index 3202f1e5f..c7f02ca50 100644
+--- a/src/cairo-base85-stream.c
++++ b/src/cairo-base85-stream.c
+@@ -53,7 +53,7 @@ _expand_four_tuple_to_five (unsigned char four_tuple[4],
+     uint32_t value;
+     int digit, i;
+ 
+-    value = four_tuple[0] << 24 | four_tuple[1] << 16 | four_tuple[2] << 8 | four_tuple[3];
++    value = (uint32_t)four_tuple[0] << 24 | four_tuple[1] << 16 | four_tuple[2] << 8 | four_tuple[3];
+     if (all_zero)
+ 	*all_zero = TRUE;
+     for (i = 0; i < 5; i++) {
+diff --git a/src/cairo-beos-surface.cpp b/src/cairo-beos-surface.cpp
+index c97641685..65db0b97a 100644
+--- a/src/cairo-beos-surface.cpp
++++ b/src/cairo-beos-surface.cpp
+@@ -284,7 +284,7 @@ premultiply_bgra (unsigned char* data,
+ 		    green = multiply_alpha (alpha, green);
+ 		    red   = multiply_alpha (alpha, red);
+ 		}
+-		p = (alpha << 0) | (red << 8) | (green << 16) | (blue << 24);
++		p = (alpha << 0) | (red << 8) | (green << 16) | ((uint32_t)blue << 24);
+ 	    }
+ 	    memcpy (&out[4*i], &p, sizeof (uint32_t));
+ 	}
+diff --git a/src/cairo-box-inline.h b/src/cairo-box-inline.h
+index 59e5a0d5f..40bfdd74f 100644
+--- a/src/cairo-box-inline.h
++++ b/src/cairo-box-inline.h
+@@ -111,7 +111,7 @@ static inline cairo_bool_t
+ _cairo_box_is_pixel_aligned (const cairo_box_t *box)
+ {
+ #if CAIRO_FIXED_FRAC_BITS <= 8 && 0
+-    return ((box->p1.x & CAIRO_FIXED_FRAC_MASK) << 24 |
++    return ((uint32_t)(box->p1.x & CAIRO_FIXED_FRAC_MASK) << 24 |
+ 	    (box->p1.y & CAIRO_FIXED_FRAC_MASK) << 16 |
+ 	    (box->p2.x & CAIRO_FIXED_FRAC_MASK) << 8 |
+ 	    (box->p2.y & CAIRO_FIXED_FRAC_MASK) << 0) == 0;
+diff --git a/src/cairo-cff-subset.c b/src/cairo-cff-subset.c
+index d536f25c9..d0597c213 100644
+--- a/src/cairo-cff-subset.c
++++ b/src/cairo-cff-subset.c
+@@ -250,7 +250,7 @@ decode_integer (unsigned char *p, int *integer)
+         *integer = (int)(p[1]<<8 | p[2]);
+         p += 3;
+     } else if (*p == 29) {
+-        *integer = (int)((p[1] << 24) | (p[2] << 16) | (p[3] << 8) | p[4]);
++        *integer = (int)(((uint32_t)p[1] << 24) | (p[2] << 16) | (p[3] << 8) | p[4]);
+         p += 5;
+     } else if (*p >= 32 && *p <= 246) {
+         *integer = *p++ - 139;
+diff --git a/src/cairo-gl-gradient.c b/src/cairo-gl-gradient.c
+index 6107bea1e..1bbd8dd0e 100644
+--- a/src/cairo-gl-gradient.c
++++ b/src/cairo-gl-gradient.c
+@@ -39,7 +39,7 @@
+  */
+ 
+ #include "cairoint.h"
+-
++#include <stdint.h>
+ #include "cairo-error-private.h"
+ #include "cairo-gl-gradient-private.h"
+ #include "cairo-gl-private.h"
+@@ -99,9 +99,9 @@ static uint32_t color_stop_to_pixel(const cairo_gradient_stop_t *stop)
+     b = premultiply(stop->color.blue,  stop->color.alpha);
+ 
+     if (_cairo_is_little_endian ())
+-	return a << 24 | r << 16 | g << 8 | b << 0;
++	return (uint32_t)a << 24 | r << 16 | g << 8 | b << 0;
+     else
+-	return a << 0 | r << 8 | g << 16 | b << 24;
++	return a << 0 | r << 8 | g << 16 | (uint32_t)b << 24;
+ }
+ 
+ static cairo_status_t
+diff --git a/src/cairo-gl-shaders.c b/src/cairo-gl-shaders.c
+index f789ae1d9..513ad8543 100644
+--- a/src/cairo-gl-shaders.c
++++ b/src/cairo-gl-shaders.c
+@@ -122,7 +122,7 @@ _cairo_gl_shader_cache_equal_gles2 (const void *key_a, const void *key_b)
+ static unsigned long
+ _cairo_gl_shader_cache_hash (const cairo_shader_cache_entry_t *entry)
+ {
+-    return ((entry->src << 24) | (entry->mask << 16) | (entry->dest << 8) | (entry->in << 1) | entry->use_coverage) ^ entry->vertex;
++    return (((uint32_t)entry->src << 24) | (entry->mask << 16) | (entry->dest << 8) | (entry->in << 1) | entry->use_coverage) ^ entry->vertex;
+ }
+ 
+ static void
+diff --git a/src/cairo-image-compositor.c b/src/cairo-image-compositor.c
+index 79ad69f68..4d94018e4 100644
+--- a/src/cairo-image-compositor.c
++++ b/src/cairo-image-compositor.c
+@@ -130,7 +130,7 @@ static inline uint32_t
+ color_to_uint32 (const cairo_color_t *color)
+ {
+     return
+-        (color->alpha_short >> 8 << 24) |
++        ((uint32_t)color->alpha_short >> 8 << 24) |
+         (color->red_short >> 8 << 16)   |
+         (color->green_short & 0xff00)   |
+         (color->blue_short >> 8);
+@@ -891,7 +891,7 @@ composite_glyphs (void				*_dst,
+     for (i = 0; i < info->num_glyphs; i++) {
+ 	unsigned long index = info->glyphs[i].index;
+ 	const void *glyph;
+-        int xphase, yphase;
++        uint32_t xphase, yphase;
+ 
+         xphase = PHASE(info->glyphs[i].x);
+         yphase = PHASE(info->glyphs[i].y);
+diff --git a/src/cairo-png.c b/src/cairo-png.c
+index 0037dd531..f576047b1 100644
+--- a/src/cairo-png.c
++++ b/src/cairo-png.c
+@@ -595,7 +595,7 @@ premultiply_data (png_structp   png,
+ 		green = multiply_alpha (alpha, green);
+ 		blue  = multiply_alpha (alpha, blue);
+ 	    }
+-	    p = (alpha << 24) | (red << 16) | (green << 8) | (blue << 0);
++	    p = ((uint32_t)alpha << 24) | (red << 16) | (green << 8) | (blue << 0);
+ 	}
+ 	memcpy (base, &p, sizeof (uint32_t));
+     }
+@@ -614,7 +614,7 @@ convert_bytes_to_data (png_structp png, png_row_infop row_info, png_bytep data)
+ 	uint8_t  blue  = base[2];
+ 	uint32_t pixel;
+ 
+-	pixel = (0xff << 24) | (red << 16) | (green << 8) | (blue << 0);
++	pixel = (0xffu << 24) | (red << 16) | (green << 8) | (blue << 0);
+ 	memcpy (base, &pixel, sizeof (uint32_t));
+     }
+ }
+diff --git a/src/cairo-truetype-subset-private.h b/src/cairo-truetype-subset-private.h
+index dc9573216..d97cf9162 100644
+--- a/src/cairo-truetype-subset-private.h
++++ b/src/cairo-truetype-subset-private.h
+@@ -52,7 +52,7 @@
+  * if you add new tables/structs that should be packed.
+  */
+ 
+-#define MAKE_TT_TAG(a, b, c, d)    (a<<24 | b<<16 | c<<8 | d)
++#define MAKE_TT_TAG(a, b, c, d)    ((int)((uint32_t)a<<24 | b<<16 | c<<8 | d))
+ #define TT_TAG_CFF    MAKE_TT_TAG('C','F','F',' ')
+ #define TT_TAG_cmap   MAKE_TT_TAG('c','m','a','p')
+ #define TT_TAG_cvt    MAKE_TT_TAG('c','v','t',' ')
+diff --git a/src/cairo-type1-subset.c b/src/cairo-type1-subset.c
+index 068b59e99..2f04c8e10 100644
+--- a/src/cairo-type1-subset.c
++++ b/src/cairo-type1-subset.c
+@@ -222,18 +222,18 @@ cairo_type1_font_subset_find_segments (cairo_type1_font_subset_t *font)
+     font->type1_end = font->type1_data + font->type1_length;
+     if (p[0] == 0x80 && p[1] == 0x01) {
+ 	font->header_segment_size =
+-	    p[2] | (p[3] << 8) | (p[4] << 16) | (p[5] << 24);
++	    p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
+ 	font->header_segment = (char *) p + 6;
+ 
+ 	p += 6 + font->header_segment_size;
+ 	font->eexec_segment_size =
+-	    p[2] | (p[3] << 8) | (p[4] << 16) | (p[5] << 24);
++	    p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
+ 	font->eexec_segment = (char *) p + 6;
+ 	font->eexec_segment_is_ascii = (p[1] == 1);
+ 
+         p += 6 + font->eexec_segment_size;
+         while (p < (unsigned char *) (font->type1_end) && p[1] != 0x03) {
+-            size = p[2] | (p[3] << 8) | (p[4] << 16) | (p[5] << 24);
++            size = p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
+             p += 6 + size;
+         }
+         font->type1_end = (char *) p;
+@@ -714,7 +714,7 @@ cairo_type1_font_subset_decode_integer (const unsigned char *p, int *integer)
+         *integer = -(p[0] - 251) * 256 - p[1] - 108;
+         p += 2;
+     } else {
+-        *integer = (p[1] << 24) | (p[2] << 16) | (p[3] << 8) | p[4];
++        *integer = ((uint32_t)p[1] << 24) | (p[2] << 16) | (p[3] << 8) | p[4];
+         p += 5;
+     }
+ 
+diff --git a/src/cairo-vg-surface.c b/src/cairo-vg-surface.c
+index 77986331a..cbff748fe 100644
+--- a/src/cairo-vg-surface.c
++++ b/src/cairo-vg-surface.c
+@@ -1373,7 +1373,7 @@ premultiply_argb (uint8_t   *data,
+ 		uint8_t r = multiply_alpha (alpha, (p >> 16) & 0xff);
+ 		uint8_t g = multiply_alpha (alpha, (p >>  8) & 0xff);
+ 		uint8_t b = multiply_alpha (alpha, (p >>  0) & 0xff);
+-		row[i] = (alpha << 24) | (r << 16) | (g << 8) | (b << 0);
++		row[i] = ((uint32_t)alpha << 24) | (r << 16) | (g << 8) | (b << 0);
+ 	    }
+ 	}
+ 
+diff --git a/src/cairo-xcb-surface-render.c b/src/cairo-xcb-surface-render.c
+index 42f27c71f..09137814a 100644
+--- a/src/cairo-xcb-surface-render.c
++++ b/src/cairo-xcb-surface-render.c
+@@ -627,7 +627,7 @@ _solid_picture (cairo_xcb_surface_t *target,
+ 	    gc = _cairo_xcb_screen_get_gc (target->screen, pixmap, 32);
+ 
+ 	    /* XXX byte ordering? */
+-	    pixel = ((color->alpha_short >> 8) << 24) |
++	    pixel = (((uint32_t)color->alpha_short >> 8) << 24) |
+ 		    ((color->red_short   >> 8) << 16) |
+ 		    ((color->green_short >> 8) << 8) |
+ 		    ((color->blue_short  >> 8) << 0);
+diff --git a/src/cairo-xlib-render-compositor.c b/src/cairo-xlib-render-compositor.c
+index bce0ff6db..d9f3233e4 100644
+--- a/src/cairo-xlib-render-compositor.c
++++ b/src/cairo-xlib-render-compositor.c
+@@ -1607,7 +1607,7 @@ composite_glyphs (void				*surface,
+     op = _render_operator (op),
+     _cairo_xlib_surface_ensure_picture (dst);
+     for (i = 0; i < num_glyphs; i++) {
+-        int xphase, yphase;
++        uint32_t xphase, yphase;
+ 	int this_x, this_y;
+ 	int old_width;
+ 
+diff --git a/src/cairo-xlib-source.c b/src/cairo-xlib-source.c
+index 6269edca5..4c3b99d9e 100644
+--- a/src/cairo-xlib-source.c
++++ b/src/cairo-xlib-source.c
+@@ -487,7 +487,7 @@ color_source (cairo_xlib_surface_t *dst, const cairo_color_t *color)
+ 	    }
+ 
+ 	    gcv.foreground = 0;
+-	    gcv.foreground |= color->alpha_short >> 8 << 24;
++	    gcv.foreground |= (uint32_t)color->alpha_short >> 8 << 24;
+ 	    gcv.foreground |= color->red_short   >> 8 << 16;
+ 	    gcv.foreground |= color->green_short >> 8 << 8;
+ 	    gcv.foreground |= color->blue_short  >> 8 << 0;
+@@ -567,7 +567,7 @@ transparent_source (cairo_xlib_surface_t *dst, const cairo_color_t *color)
+ {
+     cairo_xlib_display_t *display = dst->display;
+     uint32_t pixel =
+-	color->alpha_short >> 8 << 24 |
++	(uint32_t)color->alpha_short >> 8 << 24 |
+ 	color->red_short   >> 8 << 16 |
+ 	color->green_short >> 8 << 8 |
+ 	color->blue_short  >> 8 << 0;
+diff --git a/src/cairo-xlib-surface.c b/src/cairo-xlib-surface.c
+index 2a6d896d3..b3314d4a5 100644
+--- a/src/cairo-xlib-surface.c
++++ b/src/cairo-xlib-surface.c
+@@ -986,7 +986,7 @@ _get_image_surface (cairo_xlib_surface_t    *surface,
+ 		in_pixel = XGetPixel (ximage, x, y);
+ 		if (visual_info == NULL) {
+ 		    out_pixel = (
+-			_field_to_8 (in_pixel & a_mask, a_width, a_shift) << 24 |
++			(uint32_t)_field_to_8 (in_pixel & a_mask, a_width, a_shift) << 24 |
+ 			_field_to_8_undither (in_pixel & r_mask, r_width, r_shift, dither_adjustment) << 16 |
+ 			_field_to_8_undither (in_pixel & g_mask, g_width, g_shift, dither_adjustment) << 8 |
+ 			_field_to_8_undither (in_pixel & b_mask, b_width, b_shift, dither_adjustment));
+diff --git a/src/cairoint.h b/src/cairoint.h
+index 7c1000556..c97ad57fa 100644
+--- a/src/cairoint.h
++++ b/src/cairoint.h
+@@ -256,7 +256,7 @@ static inline uint16_t get_unaligned_be16 (const unsigned char *p)
+ 
+ static inline uint32_t get_unaligned_be32 (const unsigned char *p)
+ {
+-    return p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
++    return (uint32_t)p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
+ }
+ 
+ static inline void put_unaligned_be16 (uint16_t v, unsigned char *p)
+diff --git a/src/drm/cairo-drm-i915-private.h b/src/drm/cairo-drm-i915-private.h
+index c750cf4cf..7585756dc 100644
+--- a/src/drm/cairo-drm-i915-private.h
++++ b/src/drm/cairo-drm-i915-private.h
+@@ -147,7 +147,7 @@
+ #define SRC_ZERO     4
+ #define SRC_ONE      5
+ 
+-#define A1_SRC0_CHANNEL_X_NEGATE         (1<<31)
++#define A1_SRC0_CHANNEL_X_NEGATE         ((int)(1u<<31))
+ #define A1_SRC0_CHANNEL_X_SHIFT          28
+ #define A1_SRC0_CHANNEL_Y_NEGATE         (1<<27)
+ #define A1_SRC0_CHANNEL_Y_SHIFT          24
+@@ -162,7 +162,7 @@
+ #define A1_SRC1_CHANNEL_Y_NEGATE         (1<<3)
+ #define A1_SRC1_CHANNEL_Y_SHIFT          0
+ 
+-#define A2_SRC1_CHANNEL_Z_NEGATE         (1<<31)
++#define A2_SRC1_CHANNEL_Z_NEGATE         ((int)(1u<<31))
+ #define A2_SRC1_CHANNEL_Z_SHIFT          28
+ #define A2_SRC1_CHANNEL_W_NEGATE         (1<<27)
+ #define A2_SRC1_CHANNEL_W_SHIFT          24
+diff --git a/src/drm/cairo-drm-i915-shader.c b/src/drm/cairo-drm-i915-shader.c
+index 045ca5264..a3f01fdf2 100644
+--- a/src/drm/cairo-drm-i915-shader.c
++++ b/src/drm/cairo-drm-i915-shader.c
+@@ -2239,7 +2239,7 @@ i915_set_shader_constants (i915_device_t *device,
+ 	uint32_t diffuse;
+ 
+ 	diffuse =
+-	    ((shader->source.solid.color.alpha_short >> 8) << 24) |
++	    ((uint32_t)(shader->source.solid.color.alpha_short >> 8) << 24) |
+ 	    ((shader->source.solid.color.red_short   >> 8) << 16) |
+ 	    ((shader->source.solid.color.green_short >> 8) << 8) |
+ 	    ((shader->source.solid.color.blue_short  >> 8) << 0);
+@@ -2364,7 +2364,7 @@ i915_shader_needs_update (const i915_shader_t *shader,
+ 	uint32_t diffuse;
+ 
+ 	diffuse =
+-	    ((shader->source.solid.color.alpha_short >> 8) << 24) |
++	    ((uint32_t)(shader->source.solid.color.alpha_short >> 8) << 24) |
+ 	    ((shader->source.solid.color.red_short   >> 8) << 16) |
+ 	    ((shader->source.solid.color.green_short >> 8) << 8) |
+ 	    ((shader->source.solid.color.blue_short  >> 8) << 0);
+diff --git a/src/drm/cairo-drm-i965-shader.c b/src/drm/cairo-drm-i965-shader.c
+index eed5f5f09..8fa3b4bd2 100644
+--- a/src/drm/cairo-drm-i965-shader.c
++++ b/src/drm/cairo-drm-i965-shader.c
+@@ -1370,7 +1370,7 @@ i965_wm_kernel_hash (const i965_shader_t *shader)
+ 	(shader->mask.type.fragment & 0xff) << 8 |
+ 	(shader->clip.type.fragment & 0xff) << 16;
+     if (shader->need_combine)
+-	hash |= (1 + shader->op) << 24;
++	hash |= (1u + shader->op) << 24;
+ 
+     return hash;
+ }
+diff --git a/src/win32/cairo-win32-font.c b/src/win32/cairo-win32-font.c
+index 1f217573b..41f236b23 100644
+--- a/src/win32/cairo-win32-font.c
++++ b/src/win32/cairo-win32-font.c
+@@ -1344,7 +1344,7 @@ _cairo_win32_scaled_font_load_truetype_table (void	       *abstract_font,
+     hdc = _get_global_font_dc ();
+     assert (hdc != NULL);
+ 
+-    tag = (tag&0x000000ff)<<24 | (tag&0x0000ff00)<<8 | (tag&0x00ff0000)>>8 | (tag&0xff000000)>>24;
++    tag = (tag&0x000000ffu)<<24 | (tag&0x0000ff00)<<8 | (tag&0x00ff0000)>>8 | (tag&0xff000000)>>24;
+     status = cairo_win32_scaled_font_select_font (&scaled_font->base, hdc);
+     if (status)
+ 	return status;
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0009-Fix-out-of-bounds-access-in-cairo_type1_font_subset_.patch
+++ b/ports/cairo/patches/0009-Fix-out-of-bounds-access-in-cairo_type1_font_subset_.patch
@@ -1,0 +1,92 @@
+From 2c946fd51c05a05c521f6fbed4caaa666e56c53b Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Sun, 11 Apr 2021 16:35:02 +0000
+Subject: [PATCH 09/11] Fix out of bounds access in
+ cairo_type1_font_subset_find_segments
+
+This function parses some raw font data and it trusts the font to be
+well-formed. This means that a font can just say "this segment is a
+gigabyte large" and the code will happily jump ahead in memory. Bad
+things then happen in practice.
+
+Fix this by adding lots of bounds check.
+
+Also, an existing bounds check makes sure we are still before the end of
+the data, but then happily reads the next six bytes. Fix this by making
+sure we actually have six bytes of data.
+
+No regression test since the last few times I tried to do this for font
+issues, I ended up with a large/huge blob of font data. Too large for
+the test suite.
+
+Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27969
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-type1-subset.c | 26 ++++++++++++++++----------
+ 1 file changed, 16 insertions(+), 10 deletions(-)
+
+diff --git a/src/cairo-type1-subset.c b/src/cairo-type1-subset.c
+index 2f04c8e10..a51e34f62 100644
+--- a/src/cairo-type1-subset.c
++++ b/src/cairo-type1-subset.c
+@@ -121,15 +121,15 @@ typedef struct _cairo_type1_font_subset {
+     char *type1_end;
+ 
+     char *header_segment;
+-    int header_segment_size;
++    unsigned int header_segment_size;
+     char *eexec_segment;
+-    int eexec_segment_size;
++    unsigned int eexec_segment_size;
+     cairo_bool_t eexec_segment_is_ascii;
+ 
+     char *cleartext;
+     char *cleartext_end;
+ 
+-    int header_size;
++    unsigned int header_size;
+ 
+     unsigned short eexec_key;
+     cairo_bool_t hex_encode;
+@@ -216,25 +216,31 @@ cairo_type1_font_subset_find_segments (cairo_type1_font_subset_t *font)
+ {
+     unsigned char *p;
+     const char *eexec_token;
+-    int size, i;
++    unsigned int size, i;
+ 
+     p = (unsigned char *) font->type1_data;
+     font->type1_end = font->type1_data + font->type1_length;
+-    if (p[0] == 0x80 && p[1] == 0x01) {
++    if (font->type1_length >= 2 && p[0] == 0x80 && p[1] == 0x01) {
++	if (font->type1_end < (char *)(p + 6))
++	    return CAIRO_INT_STATUS_UNSUPPORTED;
+ 	font->header_segment_size =
+-	    p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
++	    p[2] | (p[3] << 8) | (p[4] << 16) | ((unsigned int) p[5] << 24);
+ 	font->header_segment = (char *) p + 6;
+ 
+ 	p += 6 + font->header_segment_size;
++	if (font->type1_end < (char *)(p + 6))
++	    return CAIRO_INT_STATUS_UNSUPPORTED;
+ 	font->eexec_segment_size =
+-	    p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
++	    p[2] | (p[3] << 8) | (p[4] << 16) | ((unsigned int) p[5] << 24);
+ 	font->eexec_segment = (char *) p + 6;
+ 	font->eexec_segment_is_ascii = (p[1] == 1);
+ 
+         p += 6 + font->eexec_segment_size;
+-        while (p < (unsigned char *) (font->type1_end) && p[1] != 0x03) {
+-            size = p[2] | (p[3] << 8) | (p[4] << 16) | ((uint32_t)p[5] << 24);
+-            p += 6 + size;
++	while (font->type1_end >= (char *)(p + 6) && p[1] != 0x03) {
++	    size = p[2] | (p[3] << 8) | (p[4] << 16) | ((unsigned int) p[5] << 24);
++	    if (font->type1_end < (char *)(p + 6 + size))
++		return CAIRO_INT_STATUS_UNSUPPORTED;
++	    p += 6 + size;
+         }
+         font->type1_end = (char *) p;
+     } else {
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0010-Fix-memory-leak-in-cairo_cff_font_read_cid_fontdict.patch
+++ b/ports/cairo/patches/0010-Fix-memory-leak-in-cairo_cff_font_read_cid_fontdict.patch
@@ -1,0 +1,58 @@
+From 5d4c29666167359af31ae56f54df78b063d35b54 Mon Sep 17 00:00:00 2001
+From: Uli Schlachter <psychon@znc.in>
+Date: Sat, 26 Jun 2021 14:03:34 +0200
+Subject: [PATCH 10/11] Fix memory leak in cairo_cff_font_read_cid_fontdict
+
+The function cairo_cff_font_read_cid_fontdict() has a local variable
+"cairo_array_t index". This array is first filled with data from the
+font with cff_index_read(). Later in this function, each resulting entry
+is given to cff_dict_read(). Nothing else is done with the array.
+
+Thus, nothing can keep a reference to "index" and thus this array has to
+be finalised at the end of the function to avoid a memory leak.
+
+This commit does that by falling through to the call to cff_index_fini()
+that is already there in the error case. This function checks for each
+element if its ->is_copy is true and then frees the data. However,
+cff_index_read() only creates elements with ->is_copy = FALSE, thus this
+does not do anything. At the end, this calls _cairo_array_fini() which
+frees the array's memory.
+
+Fixes the following memory leak according to valgrind:
+
+ 24 bytes in 1 blocks are definitely lost in loss record 173 of 490
+    at 0x48386AF: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
+    by 0x483ADE7: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
+    by 0x4A5ECC3: _cairo_array_grow_by (cairo-array.c:115)
+    by 0x4A5EEEE: _cairo_array_allocate (cairo-array.c:317)
+    by 0x4A5EE95: _cairo_array_append_multiple (cairo-array.c:288)
+    by 0x4A5EE6B: _cairo_array_append (cairo-array.c:265)
+    by 0x4AFB12E: cff_index_read (cairo-cff-subset.c:438)
+    by 0x4AFC280: cairo_cff_font_read_cid_fontdict (cairo-cff-subset.c:1022)
+    by 0x4AFCD42: cairo_cff_font_read_top_dict (cairo-cff-subset.c:1232)
+    by 0x4AFD145: cairo_cff_font_read_font (cairo-cff-subset.c:1351)
+    by 0x4AFFDC0: cairo_cff_font_generate (cairo-cff-subset.c:2583)
+    by 0x4B00D71: _cairo_cff_subset_init (cairo-cff-subset.c:2975)
+
+Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30650
+Signed-off-by: Uli Schlachter <psychon@znc.in>
+---
+ src/cairo-cff-subset.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cairo-cff-subset.c b/src/cairo-cff-subset.c
+index d0597c213..32a22ee3e 100644
+--- a/src/cairo-cff-subset.c
++++ b/src/cairo-cff-subset.c
+@@ -1108,7 +1108,7 @@ cairo_cff_font_read_cid_fontdict (cairo_cff_font_t *font, unsigned char *ptr)
+             goto fail;
+     }
+ 
+-    return CAIRO_STATUS_SUCCESS;
++    status = CAIRO_STATUS_SUCCESS;
+ 
+ fail:
+     cff_index_fini (&index);
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/patches/0011-cff-Check-subroutine-number-is-valid-before-using-as.patch
+++ b/ports/cairo/patches/0011-cff-Check-subroutine-number-is-valid-before-using-as.patch
@@ -1,0 +1,46 @@
+From e956f034163aa1c45e0d8804d1d3cb3eca96c4c1 Mon Sep 17 00:00:00 2001
+From: Adrian Johnson <ajohnson@redneon.com>
+Date: Tue, 20 Jul 2021 21:44:24 +0930
+Subject: [PATCH 11/11] cff: Check subroutine number is valid before using as
+ an array index
+
+Fixes #413
+---
+ src/cairo-cff-subset.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/cairo-cff-subset.c b/src/cairo-cff-subset.c
+index 32a22ee3e..fecaee114 100644
+--- a/src/cairo-cff-subset.c
++++ b/src/cairo-cff-subset.c
+@@ -1598,14 +1598,16 @@ cairo_cff_parse_charstring (cairo_cff_font_t *font,
+ 
+             if (font->is_cid) {
+                 fd = font->fdselect[glyph_id];
+-                sub_num = font->type2_stack_top_value + font->fd_local_sub_bias[fd];
++		sub_num = font->type2_stack_top_value + font->fd_local_sub_bias[fd];
++		if (sub_num >= _cairo_array_num_elements(&font->fd_local_sub_index[fd]))
++		    return CAIRO_INT_STATUS_UNSUPPORTED;
+                 element = _cairo_array_index (&font->fd_local_sub_index[fd], sub_num);
+                 if (! font->fd_local_subs_used[fd][sub_num]) {
+ 		    font->fd_local_subs_used[fd][sub_num] = TRUE;
+ 		    cairo_cff_parse_charstring (font, element->data, element->length, glyph_id, need_width);
+ 		}
+             } else {
+-                sub_num = font->type2_stack_top_value + font->local_sub_bias;
++		sub_num = font->type2_stack_top_value + font->local_sub_bias;
+ 		if (sub_num >= _cairo_array_num_elements(&font->local_sub_index))
+ 		    return CAIRO_INT_STATUS_UNSUPPORTED;
+                 element = _cairo_array_index (&font->local_sub_index, sub_num);
+@@ -1632,6 +1634,8 @@ cairo_cff_parse_charstring (cairo_cff_font_t *font,
+ 		font->type2_seen_first_int = FALSE;
+ 
+ 	    sub_num = font->type2_stack_top_value + font->global_sub_bias;
++	    if (sub_num >= _cairo_array_num_elements(&font->global_sub_index))
++		return CAIRO_INT_STATUS_UNSUPPORTED;
+ 	    element = _cairo_array_index (&font->global_sub_index, sub_num);
+             if (! font->global_subs_used[sub_num] ||
+ 		(need_width && !font->type2_found_width))
+-- 
+2.33.0.windows.2
+

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -16,6 +16,17 @@ vcpkg_download_distfile(ARCHIVE
 # Patches
 set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Rename-stat-to-stats.patch
+    # Remove after next release
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-boilerplate-Use-_cairo_malloc-instead-of-malloc.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Add-a-bounds-check-to-cairo_cff_parse_charstring.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0004-Slightly-improve-dealing-with-error-snapshots.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0005-Add-a-bounds-check-to-cairo_cff_font_read_fdselect.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0006-Avoid-a-use-after-free.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0007-Avoid-a-use-after-scope.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0008-Fix-undefined-left-shifts.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0009-Fix-out-of-bounds-access-in-cairo_type1_font_subset_.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0010-Fix-memory-leak-in-cairo_cff_font_read_cid_fontdict.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0011-cff-Check-subroutine-number-is-valid-before-using-as.patch
 )
 
 # Extract archive


### PR DESCRIPTION
There is no ETA for a post 1.17.4 release as the planned releases have all slipped. Because of this cherry pick security patches.