### PR TITLE
Add option to enable cookies in curl

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -12,6 +12,10 @@ Feature: ca-bundle
 Description: |
   Use the provided certificate bundle.
 
+Feature: cookies
+Description: |
+  Enable cookie support.
+
 Feature: ipv6
 Description: |
   Enable IPV6 support.

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -34,7 +34,6 @@ set(BUILD_OPTIONS
     -DCURL_BROTLI=ON
     -DCURL_ZLIB=ON
     -DCURL_DISABLE_ALTSVC=OFF
-    -DCURL_DISABLE_COOKIES=ON
     -DCURL_DISABLE_CRYPTO_AUTH=OFF
     -DCURL_DISABLE_DICT=ON
     -DCURL_DISABLE_DOH=ON
@@ -77,6 +76,15 @@ if (ca-bundle IN_LIST FEATURES)
 else ()
     message(STATUS "Disabling CA bundle")
     list(APPEND BUILD_OPTIONS -DCURL_CA_BUNDLE=none -DCURL_CA_PATH=none)
+endif ()
+
+# Check for cookies feature
+if (cookies IN_LIST FEATURES)
+    message(STATUS "Enabling cookie handling")
+    list(APPEND BUILD_OPTIONS -DCURL_DISABLE_COOKIES=OFF)
+else ()
+    message(STATUS "Disabling cookie handling")
+    list(APPEND BUILD_OPTIONS -DCURL_DISABLE_COOKIES=ON)
 endif ()
 
 # Check for IPV6 feature


### PR DESCRIPTION
At this time this does not require enabling PSL as that requires ICU as well to be present. This option may change in the future to support that.