### PR TITLE
Add highway port

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 | [curl](https://curl.se) | 7.80.0 | 2021-11-10 |
 | [libxml2](http://xmlsoft.org/) | 2.9.11 | 2021-05-13 |
 | [libxslt](http://xmlsoft.org/libxslt) | 1.1.34 | 2019-10-30 |
+| [highway](https://github.com/google/highway) | 0.15.0 | 2021-11-11 |
 | [libpng](http://www.libpng.org/pub/png/libpng.html) | 1.6.37 | 2019-04-15 |
 | [libjpeg-turbo](http://libjpeg-turbo.virtualgl.org) | 2.1.1 | 2021-08-09 |
 | [libwebp](https://github.com/webmproject/libwebp) | 1.2.1 | 2021-08-13 |

--- a/ports/highway/CONTROL
+++ b/ports/highway/CONTROL
@@ -1,0 +1,4 @@
+Source: highway
+Version: 0.15.0
+Description: |
+  Performance-portable, length-agnostic SIMD with runtime dispatch.

--- a/ports/highway/patches/0001-Only-run-hwy_list_targets-if-its-possible-to-do-so.patch
+++ b/ports/highway/patches/0001-Only-run-hwy_list_targets-if-its-possible-to-do-so.patch
@@ -1,0 +1,28 @@
+From 3ef9f6a08b6c9f4579db0a4a8465fb4b990fac0f Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Thu, 11 Nov 2021 17:30:35 -0800
+Subject: [PATCH 1/4] Only run hwy_list_targets if its possible to do so
+
+When `CMAKE_CROSSCOMPILING` there may not be any value for `CMAKE_CROSSCOMPILING_EMULATOR`. Only run the command if its not a cross compile or when an emulator is available.
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d910e3c..43047aa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,8 +219,10 @@ target_include_directories(hwy_list_targets PRIVATE
+ # Naked target also not always could be run (due to the lack of '.\' prefix)
+ # Thus effective command to run should contain the full path
+ # and emulator prefix (if any).
++if (NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+ add_custom_command(TARGET hwy_list_targets POST_BUILD
+     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:hwy_list_targets> || (exit 0))
++endif()
+ 
+ # --------------------------------------------------------
+ # Allow skipping the following sections for projects that do not need them:
+-- 
+2.33.0.windows.2
+

--- a/ports/highway/patches/0002-Set-RUNTIME_OUTPUT_DIRECTORY-for-test-executables.patch
+++ b/ports/highway/patches/0002-Set-RUNTIME_OUTPUT_DIRECTORY-for-test-executables.patch
@@ -1,0 +1,26 @@
+From 2605d477d95efe1cc2ce4895f88333def6b2371a Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Fri, 12 Nov 2021 11:09:37 -0800
+Subject: [PATCH 2/4] Set RUNTIME_OUTPUT_DIRECTORY for test executables
+
+Setting the target's PREFIX causes ninja to fail claiming multiple rules generate the same executable. The prefix is just a directory name so use RUNTIME_OUTPUT_DIRECTORY instead.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 43047aa..faaf424 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -379,7 +379,7 @@ foreach (TESTFILE IN LISTS HWY_TEST_FILES)
+     target_link_libraries(${TESTNAME} hwy hwy_contrib hwy_test gtest gtest_main)
+   endif()
+   # Output test targets in the test directory.
+-  set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
++  set_target_properties(${TESTNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "tests")
+ 
+   if (HWY_EMSCRIPTEN)
+     set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "-s SINGLE_FILE=1")
+-- 
+2.33.0.windows.2
+

--- a/ports/highway/patches/0003-Provide-individual-toggles-for-build-options.patch
+++ b/ports/highway/patches/0003-Provide-individual-toggles-for-build-options.patch
@@ -1,0 +1,63 @@
+From fb03f1c8b03dfb6ce2649668f3f54897fa4ecc83 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Fri, 12 Nov 2021 11:24:11 -0800
+Subject: [PATCH 3/4] Provide individual toggles for build options
+
+Split `HWY_EXAMPLES_TESTS_INSTALL` into `HWY_ENABLE_EXAMPLES`, `BUILD_TESTING` and `HWY_ENABLE_INSTALL`. The `HWY_ENABLE_*` values are set to `ON` by default to mirror previous behavior. `BUILD_TESTING` which is created when CTest is included, is set to `ON` by default so use that rather than creating a `HWY_ENABLE_TESTING` value.
+---
+ CMakeLists.txt | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index faaf424..9058f48 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,7 +46,8 @@ set(HWY_CMAKE_ARM7 OFF CACHE BOOL "Set copts for ARMv7 with NEON?")
+ # arise due to compiler/platform changes. Enable this in CI/tests.
+ set(HWY_WARNINGS_ARE_ERRORS OFF CACHE BOOL "Add -Werror flag?")
+ 
+-set(HWY_EXAMPLES_TESTS_INSTALL ON CACHE BOOL "Build examples, tests, install?")
++set(HWY_ENABLE_EXAMPLES ON CACHE BOOL "Build examples")
++set(HWY_ENABLE_INSTALL ON CACHE BOOL "Install library")
+ 
+ include(CheckCXXSourceCompiles)
+ check_cxx_source_compiles(
+@@ -227,9 +228,10 @@ endif()
+ # --------------------------------------------------------
+ # Allow skipping the following sections for projects that do not need them:
+ # tests, examples, benchmarks and installation.
+-if (HWY_EXAMPLES_TESTS_INSTALL)
+ 
+ # -------------------------------------------------------- install library
++if (HWY_ENABLE_INSTALL)
++
+ install(TARGETS hwy
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ # Install all the headers keeping the relative path to the current directory
+@@ -274,7 +276,9 @@ foreach (pc libhwy.pc libhwy-contrib.pc libhwy-test.pc)
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ endforeach()
+ 
++endif() # HWY_ENABLE_INSTALL
+ # -------------------------------------------------------- Examples
++if (HWY_ENABLE_EXAMPLES)
+ 
+ # Avoids mismatch between GTest's static CRT and our dynamic.
+ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+@@ -291,6 +295,7 @@ target_link_libraries(hwy_benchmark hwy)
+ set_target_properties(hwy_benchmark
+     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "examples/")
+ 
++endif() # HWY_ENABLE_EXAMPLES
+ # -------------------------------------------------------- Tests
+ 
+ include(CTest)
+@@ -396,5 +401,3 @@ endforeach ()
+ target_sources(skeleton_test PRIVATE hwy/examples/skeleton.cc)
+ 
+ endif() # BUILD_TESTING
+-
+-endif() # HWY_EXAMPLES_TESTS_INSTALL
+-- 
+2.33.0.windows.2
+

--- a/ports/highway/patches/0004-Make-additional-libraries-optional.patch
+++ b/ports/highway/patches/0004-Make-additional-libraries-optional.patch
@@ -1,0 +1,81 @@
+From 1faa8c6b2fcd52b314010fd80cdd5f49f0154ffd Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Fri, 12 Nov 2021 12:18:24 -0800
+Subject: [PATCH 4/4] Make additional libraries optional
+
+---
+ CMakeLists.txt | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9058f48..3ad0843 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,6 +46,9 @@ set(HWY_CMAKE_ARM7 OFF CACHE BOOL "Set copts for ARMv7 with NEON?")
+ # arise due to compiler/platform changes. Enable this in CI/tests.
+ set(HWY_WARNINGS_ARE_ERRORS OFF CACHE BOOL "Add -Werror flag?")
+ 
++set(HWY_CONTRIB ON CACHE BOOL "Build hwy_contrib")
++set(HWY_TEST ON CACHE BOOL "Build hwy_test")
++
+ set(HWY_ENABLE_EXAMPLES ON CACHE BOOL "Build examples")
+ set(HWY_ENABLE_INSTALL ON CACHE BOOL "Install library")
+ 
+@@ -198,15 +201,19 @@ target_compile_options(hwy PRIVATE ${HWY_FLAGS})
+ set_property(TARGET hwy PROPERTY POSITION_INDEPENDENT_CODE ON)
+ target_include_directories(hwy PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+ 
++if (HWY_CONTRIB)
+ add_library(hwy_contrib STATIC ${HWY_CONTRIB_SOURCES})
+ target_compile_options(hwy_contrib PRIVATE ${HWY_FLAGS})
+ set_property(TARGET hwy_contrib PROPERTY POSITION_INDEPENDENT_CODE ON)
+ target_include_directories(hwy_contrib PUBLIC ${CMAKE_CURRENT_LIST_DIR})
++endif()
+ 
++if (HWY_TEST)
+ add_library(hwy_test STATIC ${HWY_TEST_SOURCES})
+ target_compile_options(hwy_test PRIVATE ${HWY_FLAGS})
+ set_property(TARGET hwy_test PROPERTY POSITION_INDEPENDENT_CODE ON)
+ target_include_directories(hwy_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
++endif()
+ 
+ # -------------------------------------------------------- hwy_list_targets
+ # Generate a tool to print the compiled-in targets as defined by the current
+@@ -244,6 +251,9 @@ foreach (source ${HWY_SOURCES})
+   endif()
+ endforeach()
+ 
++set(HWY_PC libhwy.pc)
++
++if (HWY_CONTRIB)
+ install(TARGETS hwy_contrib
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ # Install all the headers keeping the relative path to the current directory
+@@ -255,7 +265,10 @@ foreach (source ${HWY_CONTRIB_SOURCES})
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${dirname}")
+   endif()
+ endforeach()
++list(APPEND HWY_PC libhwy-contrib.pc)
++endif()
+ 
++if (HWY_TEST)
+ install(TARGETS hwy_test
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ # Install all the headers keeping the relative path to the current directory
+@@ -267,10 +280,12 @@ foreach (source ${HWY_TEST_SOURCES})
+         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${dirname}")
+   endif()
+ endforeach()
++list(APPEND HWY_PC libhwy-test.pc)
++endif()
+ 
+ # Add a pkg-config file for libhwy and the contrib/test libraries.
+ set(HWY_LIBRARY_VERSION "${CMAKE_PROJECT_VERSION}")
+-foreach (pc libhwy.pc libhwy-contrib.pc libhwy-test.pc)
++foreach (pc ${HWY_PC})
+   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${pc}.in" "${pc}" @ONLY)
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${pc}"
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+-- 
+2.33.0.windows.2
+

--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -1,0 +1,51 @@
+set(VERSION 0.15.0)
+
+# Get archive
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/google/highway/archive/refs/tags/${VERSION}.tar.gz"
+    FILENAME "highway-${VERSION}.tar.gz"
+    SHA512 ed07e855721f87ea67d762b30e001643a76bd16d70372415023c8e6f1a43c58759a14a638e8eb20566863d8358d994153bf7a660fcf604e808adfea5f938a013
+)
+
+# Patches
+set(PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Only-run-hwy_list_targets-if-its-possible-to-do-so.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Set-RUNTIME_OUTPUT_DIRECTORY-for-test-executables.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Provide-individual-toggles-for-build-options.patch
+    # Remove above in next release
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0004-Make-additional-libraries-optional.patch
+)
+
+# Extract archive
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${VERSION}
+    PATCHES ${PATCHES}
+)
+
+# Run CMake build
+set(BUILD_OPTIONS
+    -DHWY_CONTRIB=OFF
+    -DHWY_TEST=OFF
+
+    -DHWY_ENABLE_EXAMPLES=OFF
+    -DHWY_ENABLE_INSTALL=ON
+    -DBUILD_TESTING=OFF
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        ${BUILD_OPTIONS}
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+# Prepare distribution
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/highway RENAME copyright)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/highway/version ${VERSION})

--- a/triplets/x64-windows-webkit.cmake
+++ b/triplets/x64-windows-webkit.cmake
@@ -3,7 +3,9 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 # The following libraries should always be static
-if (PORT MATCHES "libwebp")
+if (PORT MATCHES "highway")
+  set(VCPKG_LIBRARY_LINKAGE static)
+elseif (PORT MATCHES "libwebp")
   set(VCPKG_LIBRARY_LINKAGE static)
 elseif (PORT MATCHES "pixman")
   set(VCPKG_LIBRARY_LINKAGE static)

--- a/triplets/x86-windows-webkit.cmake
+++ b/triplets/x86-windows-webkit.cmake
@@ -3,7 +3,9 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 # The following libraries should always be static
-if (PORT MATCHES "libwebp")
+if (PORT MATCHES "highway")
+  set(VCPKG_LIBRARY_LINKAGE static)
+elseif (PORT MATCHES "libwebp")
   set(VCPKG_LIBRARY_LINKAGE static)
 elseif (PORT MATCHES "pixman")
   set(VCPKG_LIBRARY_LINKAGE static)


### PR DESCRIPTION
The highway library is a requirement for libjxl which is needed to support JPEG XL images in WebKit.