### PR TITLE
Fix the curl static build

### DIFF
--- a/ports/curl/patches/0002-Dont-set-_USRDLL-on-a-static-Windows-build.patch
+++ b/ports/curl/patches/0002-Dont-set-_USRDLL-on-a-static-Windows-build.patch
@@ -1,0 +1,32 @@
+From c70bb0ecfcf823320301dd52b1e69b5451a11915 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Wed, 17 Nov 2021 13:21:28 -0800
+Subject: [PATCH] Don't set _USRDLL on a static Windows build
+
+---
+ lib/CMakeLists.txt | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 2575288f7091..46973bf2b875 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -95,10 +95,6 @@ endif()
+ 
+ target_link_libraries(${LIB_NAME} ${CURL_LIBS})
+ 
+-if(WIN32)
+-  add_definitions(-D_USRDLL)
+-endif()
+-
+ set_target_properties(${LIB_NAME} PROPERTIES
+   COMPILE_DEFINITIONS BUILDING_LIBCURL
+   OUTPUT_NAME ${LIBCURL_OUTPUT_NAME}
+@@ -121,6 +117,7 @@ endif()
+ 
+ if(WIN32)
+   if(BUILD_SHARED_LIBS)
++    set_property(TARGET ${LIB_NAME} APPEND PROPERTY COMPILE_DEFINITIONS "_USRDLL")
+     if(MSVC)
+       # Add "_imp" as a suffix before the extension to avoid conflicting with
+       # the statically linked "libcurl.lib"

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_download_distfile(ARCHIVE
 # Patches
 set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Adjust-CMake-for-vcpkg.patch
+    # Remove after next release
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Dont-set-_USRDLL-on-a-static-Windows-build.patch
 )
 
 # Extract archive
@@ -29,7 +31,6 @@ set(BUILD_OPTIONS
     # CMAKE options
     -DCMAKE_USE_GSSAPI=OFF
     -DCMAKE_USE_LIBSSH2=OFF
-    -DCMAKE_USE_OPENLDAP=OFF
     # CURL options
     -DCURL_BROTLI=ON
     -DCURL_ZLIB=ON
@@ -149,6 +150,18 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 # Prepare distribution
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/curl/curl.h"
+        "#ifdef CURL_STATICLIB"
+        "#if 1"
+    )
+
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+else ()
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/curl-config")
+endif()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/curl RENAME copyright)


### PR DESCRIPTION
Fixed all package warnings for the port. Encorporated some of the vcpkg curl port to ensure a successful static build.