### PR TITLE
Fix the static build of libxml2

### DIFF
--- a/ports/libxml2/patches/0001-Adjust-CMake-for-vcpkg.patch
+++ b/ports/libxml2/patches/0001-Adjust-CMake-for-vcpkg.patch
@@ -1,7 +1,7 @@
 From 5e42b80496783ab597c00df0fca466eb3fa40864 Mon Sep 17 00:00:00 2001
 From: Don <don.j.olmstead@gmail.com>
 Date: Tue, 27 Apr 2021 13:35:02 -0700
-Subject: [PATCH] Adjust CMake for vcpkg
+Subject: [PATCH 1/2] Adjust CMake for vcpkg
 
 ---
  CMakeLists.txt | 12 ++++++------
@@ -58,5 +58,5 @@ index a437717b..2051621b 100644
  set(CPACK_COMPONENT_DEVELOPMENT_DEPENDS runtime)
  set(CPACK_COMPONENT_PROGRAMS_DEPENDS runtime)
 -- 
-2.29.2.windows.1
+2.34.0.windows.1
 

--- a/ports/libxml2/patches/0002-Remove-library-suffix-on-Windows.patch
+++ b/ports/libxml2/patches/0002-Remove-library-suffix-on-Windows.patch
@@ -1,0 +1,42 @@
+From cbc4ea23f3b4cb6e6b28cc910747027ca7a3b6db Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Tue, 16 Nov 2021 17:03:18 -0800
+Subject: [PATCH 2/2] Remove library suffix on Windows
+
+---
+ CMakeLists.txt | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2051621b..b444d4eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -496,25 +496,6 @@ set_target_properties(
+ 	VERSION ${PROJECT_VERSION}
+ )
+ 
+-if(MSVC)
+-	if(BUILD_SHARED_LIBS)
+-		set_target_properties(
+-			LibXml2
+-			PROPERTIES
+-			DEBUG_POSTFIX d
+-		)
+-	else()
+-		set_target_properties(
+-			LibXml2
+-			PROPERTIES
+-			DEBUG_POSTFIX sd
+-			MINSIZEREL_POSTFIX s
+-			RELEASE_POSTFIX s
+-			RELWITHDEBINFO_POSTFIX s
+-		)
+-	endif()
+-endif()
+-
+ install(FILES ${LIBXML2_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxml2/libxml COMPONENT development)
+ 
+ install(
+-- 
+2.34.0.windows.1
+

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_download_distfile(ARCHIVE
 # Patches
 set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Adjust-CMake-for-vcpkg.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Remove-library-suffix-on-Windows.patch
 )
 
 # Extract archive


### PR DESCRIPTION
Remove the library suffix from the Windows build.