### PR TITLE
Use cmake-format on ICU files

### DIFF
--- a/ports/icu/patches/0001-Add-CMake-platform.patch
+++ b/ports/icu/patches/0001-Add-CMake-platform.patch
@@ -1,66 +1,64 @@
-From 672774b5b832efe5a5cc037eea848588d7f16e02 Mon Sep 17 00:00:00 2001
+From 93dcb593a3d4947e9b69f7b56e1a75744a0a60cf Mon Sep 17 00:00:00 2001
 From: foopoiuyt <github@zombiestormtrooper.com>
 Date: Tue, 3 Nov 2020 08:58:19 -0800
-Subject: [PATCH 1/2] Add CMake platform
+Subject: [PATCH 1/8] Add CMake platform
 
 Modified version of the LibCMaker ICU files.
 ---
- icu4c/CMakeLists.txt                          |    7 +
- icu4c/LICENSE_CMakeLists                      |   60 +
- icu4c/README_CMakeLists.txt                   |  146 +
- source/CMakeLists.txt                         |  202 +
- source/cmake/Config.in.cmake                  |  134 +
- source/common/CMakeLists.txt                  |  107 +
- source/common_icu_lib_flags.cmake             |   91 +
- source/common_icu_lib_includes.cmake          |   10 +
- source/common_tools_exe_flags.cmake           |   62 +
- source/common_tools_exe_libs.cmake            |    9 +
- source/configure_1st.cmake                    |  137 +
- source/configure_2nd.cmake                    | 1193 +++
- source/data/CMakeLists.txt                    |  358 +
- source/data/cmake-brkitr-index-txt-content.in |   21 +
- source/data/cmake-coll-index-txt-content.in   |  168 +
- source/data/cmake-curr-index-txt-content.in   |  550 ++
- source/data/cmake-icudata-list-content.in     | 3815 ++++++++
- source/data/cmake-lang-index-txt-content.in   |  480 +
+ LICENSE_CMakeLists                      |   60 +
+ README_CMakeLists.txt                   |  146 +
+ source/CMakeLists.txt                   |  175 +
+ source/cmake/Config.in.cmake            |  127 +
+ source/common/CMakeLists.txt            |   98 +
+ source/common_icu_lib_flags.cmake       |  127 +
+ source/common_icu_lib_includes.cmake    |    8 +
+ source/common_tools_exe_flags.cmake     |   86 +
+ source/common_tools_exe_libs.cmake      |    8 +
+ source/configure_1st.cmake              |  137 +
+ source/configure_2nd.cmake              | 1208 +++
+ source/data/CMakeLists.txt              |  340 +
+ .../data/cmake-brkitr-index-txt-content.in    |   21 +
+ .../data/cmake-coll-index-txt-content.in      |  168 +
+ .../data/cmake-curr-index-txt-content.in      |  550 ++
+ .../source/data/cmake-icudata-list-content.in | 3815 ++++++++
+ .../data/cmake-lang-index-txt-content.in      |  480 +
  .../data/cmake-locales-index-txt-content.in   |  841 ++
- source/data/cmake-rbnf-index-txt-content.in   |  113 +
- source/data/cmake-region-index-txt-content.in |  479 +
- source/data/cmake-unit-index-txt-content.in   |  470 +
- source/data/cmake-zone-index-txt-content.in   |  480 +
- source/data/icupkg.inc.cmake                  |   17 +
- source/data/rules.cmake                       | 8509 +++++++++++++++++
- source/i18n/CMakeLists.txt                    |   88 +
- source/icudefs.cmake                          |  268 +
- source/icufunctions.cmake                     |   67 +
- source/io/CMakeLists.txt                      |   78 +
- source/layoutex/CMakeLists.txt                |   87 +
- source/stubdata/CMakeLists.txt                |   67 +
- source/test/CMakeLists.txt                    |   34 +
- source/test/testdata/CMakeLists.txt           |   52 +
- source/test/testdata/rules.cmake              |  187 +
- source/tools/CMakeLists.txt                   |   39 +
- source/tools/ctestfw/CMakeLists.txt           |   65 +
- source/tools/escapesrc/CMakeLists.txt         |   38 +
- source/tools/genbrk/CMakeLists.txt            |   31 +
- source/tools/genccode/CMakeLists.txt          |   31 +
- source/tools/gencfu/CMakeLists.txt            |   32 +
- source/tools/gencmn/CMakeLists.txt            |   31 +
- source/tools/gencnval/CMakeLists.txt          |   31 +
- source/tools/gendict/CMakeLists.txt           |   31 +
- source/tools/gennorm2/CMakeLists.txt          |   32 +
- source/tools/genrb/CMakeLists.txt             |   63 +
- source/tools/gensprep/CMakeLists.txt          |   32 +
- source/tools/gentest/CMakeLists.txt           |   40 +
- source/tools/icuinfo/CMakeLists.txt           |   54 +
- source/tools/icupkg/CMakeLists.txt            |   31 +
- source/tools/makeconv/CMakeLists.txt          |   32 +
- source/tools/pkgdata/CMakeLists.txt           |   41 +
- source/tools/toolutil/CMakeLists.txt          |   61 +
- 52 files changed, 20102 insertions(+)
- create mode 100644 icu4c/CMakeLists.txt
- create mode 100644 icu4c/LICENSE_CMakeLists
- create mode 100644 icu4c/README_CMakeLists.txt
+ .../data/cmake-rbnf-index-txt-content.in      |  113 +
+ .../data/cmake-region-index-txt-content.in    |  479 +
+ .../data/cmake-unit-index-txt-content.in      |  470 +
+ .../data/cmake-zone-index-txt-content.in      |  480 +
+ source/data/icupkg.inc.cmake            |   17 +
+ source/data/rules.cmake                 | 8561 +++++++++++++++++
+ source/i18n/CMakeLists.txt              |   80 +
+ source/icudefs.cmake                    |  245 +
+ source/icufunctions.cmake               |   99 +
+ source/io/CMakeLists.txt                |   67 +
+ source/layoutex/CMakeLists.txt          |   71 +
+ source/stubdata/CMakeLists.txt          |   77 +
+ source/test/CMakeLists.txt              |   34 +
+ source/test/testdata/CMakeLists.txt     |   52 +
+ source/test/testdata/rules.cmake        |  216 +
+ source/tools/CMakeLists.txt             |   38 +
+ source/tools/ctestfw/CMakeLists.txt     |   61 +
+ source/tools/escapesrc/CMakeLists.txt   |   35 +
+ source/tools/genbrk/CMakeLists.txt      |   30 +
+ source/tools/genccode/CMakeLists.txt    |   30 +
+ source/tools/gencfu/CMakeLists.txt      |   31 +
+ source/tools/gencmn/CMakeLists.txt      |   30 +
+ source/tools/gencnval/CMakeLists.txt    |   30 +
+ source/tools/gendict/CMakeLists.txt     |   30 +
+ source/tools/gennorm2/CMakeLists.txt    |   31 +
+ source/tools/genrb/CMakeLists.txt       |   65 +
+ source/tools/gensprep/CMakeLists.txt    |   31 +
+ source/tools/gentest/CMakeLists.txt     |   38 +
+ source/tools/icuinfo/CMakeLists.txt     |   53 +
+ source/tools/icupkg/CMakeLists.txt      |   30 +
+ source/tools/makeconv/CMakeLists.txt    |   31 +
+ source/tools/pkgdata/CMakeLists.txt     |   35 +
+ source/tools/toolutil/CMakeLists.txt    |   59 +
+ 51 files changed, 20144 insertions(+)
+ create mode 100644 LICENSE_CMakeLists
+ create mode 100644 README_CMakeLists.txt
  create mode 100644 source/CMakeLists.txt
  create mode 100644 source/cmake/Config.in.cmake
  create mode 100644 source/common/CMakeLists.txt
@@ -111,24 +109,11 @@ Modified version of the LibCMaker ICU files.
  create mode 100644 source/tools/pkgdata/CMakeLists.txt
  create mode 100644 source/tools/toolutil/CMakeLists.txt
 
-diff --git a/icu4c/CMakeLists.txt b/icu4c/CMakeLists.txt
-new file mode 100644
-index 0000000000..86d84498df
---- /dev/null
-+++ b/icu4c/CMakeLists.txt
-@@ -0,0 +1,7 @@
-+# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
-+#
-+## ICU build file for CMake build tools
-+
-+#cmake_minimum_required(VERSION 3.4)  # All settings are in source/CMakeLists.txt
-+project(icu_root_project NONE)
-+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/source)
-diff --git a/icu4c/LICENSE_CMakeLists b/icu4c/LICENSE_CMakeLists
+diff --git a/LICENSE_CMakeLists b/LICENSE_CMakeLists
 new file mode 100644
 index 0000000000..f23753eab1
 --- /dev/null
-+++ b/icu4c/LICENSE_CMakeLists
++++ b/LICENSE_CMakeLists
 @@ -0,0 +1,60 @@
 +Copyright (c) 2018, NikitaFeodonit
 +All rights reserved.
@@ -190,11 +175,11 @@ index 0000000000..f23753eab1
 +CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 +OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 +OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-diff --git a/icu4c/README_CMakeLists.txt b/icu4c/README_CMakeLists.txt
+diff --git a/README_CMakeLists.txt b/README_CMakeLists.txt
 new file mode 100644
 index 0000000000..356e81fa50
 --- /dev/null
-+++ b/icu4c/README_CMakeLists.txt
++++ b/README_CMakeLists.txt
 @@ -0,0 +1,146 @@
 +### ICU build files for CMake build tools
 +
@@ -344,107 +329,100 @@ index 0000000000..356e81fa50
 +See file 'LICENSE_CMakeLists' for license information.
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
 new file mode 100644
-index 0000000000..cf7e3f36da
+index 0000000000..8139279923
 --- /dev/null
 +++ b/source/CMakeLists.txt
-@@ -0,0 +1,202 @@
+@@ -0,0 +1,175 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +# Copyright (c) 2014, 2018, Ruslan Baratov. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+## ICU build files for CMake build tools are based on the original ICU files:
-+# 'configure.ac', '*/*.m4', '*/Makefile.in', 'icudefs.mk.in', 'config/mh-*',
-+# 'data/pkgdataMakefile.in', 'data/makedata.mak', 'allinone/allinone.sln',
-+# 'allinone/Build.Windows*.ProjectConfiguration.props', '*/*.vcxproj'
++# ICU build files for CMake build tools are based on the original ICU files: 'configure.ac', '*/*.m4',
++# '*/Makefile.in', 'icudefs.mk.in', 'config/mh-*', 'data/pkgdataMakefile.in', 'data/makedata.mak',
++# 'allinone/allinone.sln', 'allinone/Build.Windows*.ProjectConfiguration.props', '*/*.vcxproj'
 +
++# TODO: MSVC: lib suffix == ${VERSION_MAJOR} (61), for .dll files. TODO: check work ICU_CONDITIONAL()
 +
-+# TODO: MSVC: lib suffix == ${VERSION_MAJOR} (61), for .dll files.
-+# TODO: check work ICU_CONDITIONAL()
++# TODO: take additional compiler and link flags and link libs from mh-* TODO: THREADSC*FLAGS defined in
++# mh-* TODO: take compiler flags and rules for Android from:
++# https://android.googlesource.com/platform/external/icu/ git clone
++# https://android.googlesource.com/platform/external/icu
 +
-+# TODO: take additional compiler and link flags and link libs from mh-*
-+# TODO: THREADSC*FLAGS defined in mh-*
-+# TODO: take compiler flags and rules for Android from:
-+# https://android.googlesource.com/platform/external/icu/
-+# git clone https://android.googlesource.com/platform/external/icu
++# TODO: Using the file "uconfig.h.prepend", see configure_2nd.cmake Flags from uconfig.h.prepend are used
++# by INTERFACE_COMPILE_DEFINITIONS.
 +
-+# TODO: Using the file "uconfig.h.prepend", see configure_2nd.cmake
-+# Flags from uconfig.h.prepend are used by INTERFACE_COMPILE_DEFINITIONS.
-+
-+
-+#############################################################################
++# #######################################################################################################
 +# Configure CMake itself
-+#############################################################################
-+
++# #######################################################################################################
 +
 +if(CMAKE_GENERATOR MATCHES "Visual Studio.*")
-+  message(STATUS "CMake 3.11+ is required for Visual Studio generator.")
-+  cmake_minimum_required(VERSION 3.11)
++    message(STATUS "CMake 3.11+ is required for Visual Studio generator.")
++    cmake_minimum_required(VERSION 3.11)
 +elseif(CMAKE_GENERATOR MATCHES "Xcode")
-+  message(STATUS "CMake 3.12+ is required for Xcode generator.")
-+  cmake_minimum_required(VERSION 3.12)
++    message(STATUS "CMake 3.12+ is required for Xcode generator.")
++    cmake_minimum_required(VERSION 3.12)
 +else()
-+  cmake_minimum_required(VERSION 3.4)
++    cmake_minimum_required(VERSION 3.4)
 +endif()
 +
 +if(POLICY CMP0067)
-+  # Honor language standard in try_compile() source-file signature.
-+  # Introduced in CMake 3.8.
-+  cmake_policy(SET CMP0067 NEW)
++    # Honor language standard in try_compile() source-file signature. Introduced in CMake 3.8.
++    cmake_policy(SET CMP0067 NEW)
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Configure initialization
-+#############################################################################
++# #######################################################################################################
 +
-+set(ICUPREFIX "icu")  # before configure_1st.cmake
-+include(${CMAKE_CURRENT_LIST_DIR}/configure_1st.cmake)  # before project()
++set(ICUPREFIX "icu") # before configure_1st.cmake
++include(${CMAKE_CURRENT_LIST_DIR}/configure_1st.cmake) # before project()
 +string(TOUPPER ${PACKAGE} PACKAGE_UPPER)
 +
-+project(${PACKAGE_UPPER} VERSION ${VERSION} LANGUAGES C CXX ASM)
++project(
++    ${PACKAGE_UPPER}
++    VERSION ${VERSION}
++    LANGUAGES C CXX ASM
++)
 +
 +# Before configure_2nd.cmake
 +set(TARGETS_NAMESPACE "${PROJECT_NAME}::")
 +set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 +
-+include(${CMAKE_CURRENT_LIST_DIR}/configure_2nd.cmake)  # after project()
-+include(${CMAKE_CURRENT_LIST_DIR}/icudefs.cmake)  # after configure_2nd.cmake
++include(${CMAKE_CURRENT_LIST_DIR}/configure_2nd.cmake) # after project()
++include(${CMAKE_CURRENT_LIST_DIR}/icudefs.cmake) # after configure_2nd.cmake
 +include(${CMAKE_CURRENT_LIST_DIR}/icufunctions.cmake)
 +
 +# After icudefs.cmake
 +list(INSERT CPPFLAGS 0 ${DEFS})
 +
 +if(NOT BUILD_SHARED_LIBS)
-+  list(APPEND CPPFLAGS U_STATIC_IMPLEMENTATION)
++    list(APPEND CPPFLAGS U_STATIC_IMPLEMENTATION)
 +endif()
 +
-+# Location of the libraries before "make install" is used
-+# See also stubdata target properties.
++# Location of the libraries before "make install" is used See also stubdata target properties.
 +set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBDIR})
 +set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBDIR})
 +
-+# Location of the executables before "make install" is used
-+# See also stubdata target properties.
++# Location of the executables before "make install" is used See also stubdata target properties.
 +set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BINDIR})
 +
-+# RPATH settings
-+# https://cmake.org/Wiki/CMake_RPATH_handling
++# RPATH settings https://cmake.org/Wiki/CMake_RPATH_handling
 +# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
 +if(ICU_ENABLE_RPATH)
-+  if(IOS)
-+    # TODO: iOS dynamic framework
-+  elseif(ANDROID)
-+    # *.so libraries loaded by Java code, RPATH will not be used
-+  elseif(UNIX)
-+    if(APPLE)
-+      # https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/dyld.1.html
-+      set(CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
-+    else()
-+      # https://linux.die.net/man/8/ld-linux
-+      set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
++    if(IOS)
++        # TODO: iOS dynamic framework
++    elseif(ANDROID)
++        # *.so libraries loaded by Java code, RPATH will not be used
++    elseif(UNIX)
++        if(APPLE)
++            # https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/dyld.1.html
++            set(CMAKE_INSTALL_RPATH "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
++        else()
++            # https://linux.die.net/man/8/ld-linux
++            set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
++        endif()
 +    endif()
-+  endif()
 +endif()
 +
 +# Variables for CMake package configurations
@@ -452,216 +430,191 @@ index 0000000000..cf7e3f36da
 +set(config_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake")
 +set(config_INSTALL_DIR "${libdir}/cmake/${PROJECT_NAME}")
 +set(config_PACKAGE "${config_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
-+set(config_PACKAGE_VERSION
-+  "${config_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-+)
++set(config_PACKAGE_VERSION "${config_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Subdirectories
-+#############################################################################
++# #######################################################################################################
 +
 +# Subdirectories ordered by SUBDIRS in Makefile.in
 +
-+include(${CMAKE_CURRENT_LIST_DIR}/stubdata/CMakeLists.txt)    # icudata (stubdata)
-+include(${CMAKE_CURRENT_LIST_DIR}/common/CMakeLists.txt)      # icuuc
-+include(${CMAKE_CURRENT_LIST_DIR}/i18n/CMakeLists.txt)        # icui18n
++include(${CMAKE_CURRENT_LIST_DIR}/stubdata/CMakeLists.txt) # icudata (stubdata)
++include(${CMAKE_CURRENT_LIST_DIR}/common/CMakeLists.txt) # icuuc
++include(${CMAKE_CURRENT_LIST_DIR}/i18n/CMakeLists.txt) # icui18n
 +if(ICU_ENABLE_LAYOUTEX)
-+  include(${CMAKE_CURRENT_LIST_DIR}/layoutex/CMakeLists.txt)  # iculx
++    include(${CMAKE_CURRENT_LIST_DIR}/layoutex/CMakeLists.txt) # iculx
 +endif()
 +if(ICU_ENABLE_ICUIO)
-+  include(${CMAKE_CURRENT_LIST_DIR}/io/CMakeLists.txt)        # icuio
++    include(${CMAKE_CURRENT_LIST_DIR}/io/CMakeLists.txt) # icuio
 +endif()
 +if(ICU_ENABLE_TOOLS)
-+  include(${CMAKE_CURRENT_LIST_DIR}/tools/CMakeLists.txt)
++    include(${CMAKE_CURRENT_LIST_DIR}/tools/CMakeLists.txt)
 +endif()
-+include(${CMAKE_CURRENT_LIST_DIR}/data/CMakeLists.txt)        # icudata (real data)
++include(${CMAKE_CURRENT_LIST_DIR}/data/CMakeLists.txt) # icudata (real data)
 +if(ICU_ENABLE_EXTRAS)
-+  #include(${CMAKE_CURRENT_LIST_DIR}/extra/CMakeLists.txt)     # uconv, ...
-+  error_message(
-+    "TODO: Building the EXTRAS is not yet supported. Please set ICU_ENABLE_EXTRAS=OFF"
-+  )
++    # include(${CMAKE_CURRENT_LIST_DIR}/extra/CMakeLists.txt)     # uconv, ...
++    error_message("TODO: Building the EXTRAS is not yet supported. Please set ICU_ENABLE_EXTRAS=OFF")
 +endif()
 +if(ICU_ENABLE_SAMPLES)
-+  #include(${CMAKE_CURRENT_LIST_DIR}/samples/CMakeLists.txt)
-+  error_message(
-+    "TODO: Building the SAMPLES is not yet supported. Please set ICU_ENABLE_SAMPLES=OFF"
-+  )
++    # include(${CMAKE_CURRENT_LIST_DIR}/samples/CMakeLists.txt)
++    error_message("TODO: Building the SAMPLES is not yet supported. Please set ICU_ENABLE_SAMPLES=OFF")
 +endif()
 +if(ICU_ENABLE_TESTS)
-+  add_subdirectory(test)
-+  #include(${CMAKE_CURRENT_LIST_DIR}/test/CMakeLists.txt)
-+  #error_message(
-+  #  "TODO: Building the TESTS is not yet supported. Please set ICU_ENABLE_TESTS=OFF"
-+  #)
++    add_subdirectory(test)
++    # include(${CMAKE_CURRENT_LIST_DIR}/test/CMakeLists.txt) error_message( "TODO: Building the TESTS is
++    # not yet supported. Please set ICU_ENABLE_TESTS=OFF" )
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Install CMake package configurations
-+#############################################################################
++# #######################################################################################################
 +
 +include(CMakePackageConfigHelpers)
 +
-+# Use:
-+# * PROJECT_VERSION
-+write_basic_package_version_file(
-+  "${config_PACKAGE_VERSION}"
-+  COMPATIBILITY SameMajorVersion
-+)
++# Use: * PROJECT_VERSION
++write_basic_package_version_file("${config_PACKAGE_VERSION}" COMPATIBILITY SameMajorVersion)
 +
-+# Use:
-+# * TARGETS_EXPORT_NAME
-+# * PROJECT_NAME
++# Use: * TARGETS_EXPORT_NAME * PROJECT_NAME
 +configure_package_config_file(
-+  "${config_PACKAGE_TEMPLATE}"
-+  "${config_PACKAGE}"
-+  PATH_VARS ICUPKGDATA_DIR
-+  INSTALL_DESTINATION "${config_INSTALL_DIR}"
++    "${config_PACKAGE_TEMPLATE}" "${config_PACKAGE}"
++    PATH_VARS ICUPKGDATA_DIR
++    INSTALL_DESTINATION "${config_INSTALL_DIR}"
 +)
++
++install(FILES "${config_PACKAGE}" "${config_PACKAGE_VERSION}" DESTINATION "${config_INSTALL_DIR}")
 +
 +install(
-+  FILES "${config_PACKAGE}" "${config_PACKAGE_VERSION}"
-+  DESTINATION "${config_INSTALL_DIR}"
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    NAMESPACE "${TARGETS_NAMESPACE}"
++    DESTINATION "${config_INSTALL_DIR}"
 +)
 +
-+install(
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  NAMESPACE "${TARGETS_NAMESPACE}"
-+  DESTINATION "${config_INSTALL_DIR}"
-+)
-+
-+
-+#############################################################################
++# #######################################################################################################
 +# For cross compilation
-+#############################################################################
++# #######################################################################################################
 +
 +# config/icucross.cmake:
 +set(CROSS_BUILD_FILE ${PROJECT_BINARY_DIR}/config/icucross.cmake)
 +set(CROSS_BUILD_TEXT
-+  "
++    "
 +set(CROSS_ICU_VERSION ${VERSION})
 +set(TOOLBINDIR \${ICU_CROSS_BUILDROOT}/bin${CONFIG_DIR_NAME})
 +set(TOOLLIBDIR \${ICU_CROSS_BUILDROOT}/lib${CONFIG_DIR_NAME})
 +  "
 +)
 +file(
-+  GENERATE OUTPUT ${CROSS_BUILD_FILE}
-+  CONTENT ${CROSS_BUILD_TEXT}
-+  CONDITION $<CONFIG:Release>
++    GENERATE
++    OUTPUT ${CROSS_BUILD_FILE}
++    CONTENT ${CROSS_BUILD_TEXT}
++    CONDITION $<CONFIG:Release>
 +)
 diff --git a/source/cmake/Config.in.cmake b/source/cmake/Config.in.cmake
 new file mode 100644
-index 0000000000..a95b284915
+index 0000000000..d865445a8c
 --- /dev/null
 +++ b/source/cmake/Config.in.cmake
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,127 @@
 +@PACKAGE_INIT@
 +
-+# set_and_check() generated by configure_package_config_file().
-+# check_required_components() generated by configure_package_config_file().
++# set_and_check() generated by configure_package_config_file(). check_required_components() generated by
++# configure_package_config_file().
 +
 +function(__icu_set_pkgdata_path)
-+  if(EXISTS "${ICU_PKGDATA_EXECUTABLE}")
-+    return()
-+  endif()
++    if(EXISTS "${ICU_PKGDATA_EXECUTABLE}")
++        return()
++    endif()
 +
-+  if(NOT TARGET @PROJECT_NAME@::pkgdata)
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    if(NOT TARGET @PROJECT_NAME@::pkgdata)
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  get_target_property(configurations @PROJECT_NAME@::pkgdata IMPORTED_CONFIGURATIONS)
-+  if(NOT configurations)
-+    message(FATAL_ERROR "Internal error")
-+  endif()
-+  list(LENGTH configurations len)
-+  if(len EQUAL "0")
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    get_target_property(configurations @PROJECT_NAME@::pkgdata IMPORTED_CONFIGURATIONS)
++    if(NOT configurations)
++        message(FATAL_ERROR "Internal error")
++    endif()
++    list(LENGTH configurations len)
++    if(len EQUAL "0")
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  list(FIND configurations "RELEASE" release_index)
-+  if(release_index EQUAL "-1")
-+    list(GET configurations 0 use_config)
-+  else()
-+    set(use_config RELEASE)
-+  endif()
++    list(FIND configurations "RELEASE" release_index)
++    if(release_index EQUAL "-1")
++        list(GET configurations 0 use_config)
++    else()
++        set(use_config RELEASE)
++    endif()
 +
-+  get_target_property(
-+      ICU_PKGDATA_EXECUTABLE @PROJECT_NAME@::pkgdata IMPORTED_LOCATION_${use_config}
-+  )
++    get_target_property(ICU_PKGDATA_EXECUTABLE @PROJECT_NAME@::pkgdata IMPORTED_LOCATION_${use_config})
 +
-+  if(NOT EXISTS "${ICU_PKGDATA_EXECUTABLE}")
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    if(NOT EXISTS "${ICU_PKGDATA_EXECUTABLE}")
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  set(ICU_PKGDATA_EXECUTABLE "${ICU_PKGDATA_EXECUTABLE}" PARENT_SCOPE)
++    set(ICU_PKGDATA_EXECUTABLE
++        "${ICU_PKGDATA_EXECUTABLE}"
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +function(__icu_set_icupkg_path)
-+  if(EXISTS "${ICU_ICUPKG_EXECUTABLE}")
-+    return()
-+  endif()
++    if(EXISTS "${ICU_ICUPKG_EXECUTABLE}")
++        return()
++    endif()
 +
-+  if(NOT TARGET @PROJECT_NAME@::icupkg)
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    if(NOT TARGET @PROJECT_NAME@::icupkg)
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  get_target_property(configurations @PROJECT_NAME@::icupkg IMPORTED_CONFIGURATIONS)
-+  if(NOT configurations)
-+    message(FATAL_ERROR "Internal error")
-+  endif()
-+  list(LENGTH configurations len)
-+  if(len EQUAL "0")
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    get_target_property(configurations @PROJECT_NAME@::icupkg IMPORTED_CONFIGURATIONS)
++    if(NOT configurations)
++        message(FATAL_ERROR "Internal error")
++    endif()
++    list(LENGTH configurations len)
++    if(len EQUAL "0")
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  list(FIND configurations "RELEASE" release_index)
-+  if(release_index EQUAL "-1")
-+    list(GET configurations 0 use_config)
-+  else()
-+    set(use_config RELEASE)
-+  endif()
++    list(FIND configurations "RELEASE" release_index)
++    if(release_index EQUAL "-1")
++        list(GET configurations 0 use_config)
++    else()
++        set(use_config RELEASE)
++    endif()
 +
-+  get_target_property(
-+      ICU_ICUPKG_EXECUTABLE @PROJECT_NAME@::icupkg IMPORTED_LOCATION_${use_config}
-+  )
++    get_target_property(ICU_ICUPKG_EXECUTABLE @PROJECT_NAME@::icupkg IMPORTED_LOCATION_${use_config})
 +
-+  if(NOT EXISTS "${ICU_ICUPKG_EXECUTABLE}")
-+    message(FATAL_ERROR "Internal error")
-+  endif()
++    if(NOT EXISTS "${ICU_ICUPKG_EXECUTABLE}")
++        message(FATAL_ERROR "Internal error")
++    endif()
 +
-+  set(ICU_ICUPKG_EXECUTABLE "${ICU_ICUPKG_EXECUTABLE}" PARENT_SCOPE)
++    set(ICU_ICUPKG_EXECUTABLE
++        "${ICU_ICUPKG_EXECUTABLE}"
++        PARENT_SCOPE
++    )
 +endfunction()
-+
 +
 +# Find the required libraries
 +if(@HAVE_THREADS@ AND NOT TARGET Threads::Threads)
-+  message(FATAL_ERROR
-+    "Target 'Threads::Threads' is NOT defined, use find_package(Threads) to define it."
-+  )
-+#  find_package(Threads REQUIRED)
++    message(
++        FATAL_ERROR "Target 'Threads::Threads' is NOT defined, use find_package(Threads) to define it."
++    )
++    # find_package(Threads REQUIRED)
 +endif()
 +if(@HAVE_LIB_M@)
-+  find_library(LIB_M_LOCATION NAMES m)
-+  if(NOT LIB_M_LOCATION)
-+    message(FATAL_ERROR "'m' library is not found.")
-+  endif()
-+#  set(LIB_M_TARGET @LIB_M_TARGET@)
-+#  add_library(${LIB_M_TARGET} SHARED IMPORTED)
-+#  set_target_properties(${LIB_M_TARGET} PROPERTIES
-+#    IMPORTED_LOCATION "${LIB_M_LOCATION}"
-+#  )
++    find_library(LIB_M_LOCATION NAMES m)
++    if(NOT LIB_M_LOCATION)
++        message(FATAL_ERROR "'m' library is not found.")
++    endif()
++    # set(LIB_M_TARGET @LIB_M_TARGET@) add_library(${LIB_M_TARGET} SHARED IMPORTED)
++    # set_target_properties(${LIB_M_TARGET} PROPERTIES IMPORTED_LOCATION "${LIB_M_LOCATION}" )
 +endif()
 +if(@HAVE_LIB_DL@)
-+  find_library(LIB_DL_LOCATION NAMES ${CMAKE_DL_LIBS})
-+  if(NOT LIB_DL_LOCATION)
-+    message(FATAL_ERROR "'${CMAKE_DL_LIBS}' library is not found.")
-+  endif()
-+#  set(LIB_DL_TARGET @LIB_DL_TARGET@)
-+#  add_library(${LIB_DL_TARGET} SHARED IMPORTED)
-+#  set_target_properties(${LIB_DL_TARGET} PROPERTIES
-+#    IMPORTED_LOCATION "${LIB_DL_LOCATION}"
-+#  )
++    find_library(LIB_DL_LOCATION NAMES ${CMAKE_DL_LIBS})
++    if(NOT LIB_DL_LOCATION)
++        message(FATAL_ERROR "'${CMAKE_DL_LIBS}' library is not found.")
++    endif()
++    # set(LIB_DL_TARGET @LIB_DL_TARGET@) add_library(${LIB_DL_TARGET} SHARED IMPORTED)
++    # set_target_properties(${LIB_DL_TARGET} PROPERTIES IMPORTED_LOCATION "${LIB_DL_LOCATION}" )
 +endif()
 +
 +# Include all libraries targets
@@ -671,448 +624,502 @@ index 0000000000..a95b284915
 +check_required_components("@PROJECT_NAME@")
 +
 +if(@ICU_ENABLE_TOOLS@)
-+  __icu_set_pkgdata_path()
-+  __icu_set_icupkg_path()
++    __icu_set_pkgdata_path()
++    __icu_set_icupkg_path()
 +endif()
 +
 +if(@PKGDATA_MODE@ STREQUAL "common")
-+  get_filename_component(
-+      ICU_DATA_FILE
-+      "@PACKAGE_ICUPKGDATA_DIR@/@ICUDATA_SOURCE_ARCHIVE_FILE_NAME@"
-+      ABSOLUTE
-+  )
++    get_filename_component(
++        ICU_DATA_FILE "@PACKAGE_ICUPKGDATA_DIR@/@ICUDATA_SOURCE_ARCHIVE_FILE_NAME@" ABSOLUTE
++    )
 +
-+  if(NOT EXISTS ${ICU_DATA_FILE})
-+    message(FATAL_ERROR "File not exists: ${ICU_DATA_FILE}")
-+  endif()
++    if(NOT EXISTS ${ICU_DATA_FILE})
++        message(FATAL_ERROR "File not exists: ${ICU_DATA_FILE}")
++    endif()
 +
-+  if(IS_DIRECTORY ${ICU_DATA_FILE})
-+    message(FATAL_ERROR "Is directory: ${ICU_DATA_FILE}")
-+  endif()
++    if(IS_DIRECTORY ${ICU_DATA_FILE})
++        message(FATAL_ERROR "Is directory: ${ICU_DATA_FILE}")
++    endif()
 +endif()
 diff --git a/source/common/CMakeLists.txt b/source/common/CMakeLists.txt
 new file mode 100644
-index 0000000000..58e156a9c4
+index 0000000000..7fe27d04b3
 --- /dev/null
 +++ b/source/common/CMakeLists.txt
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,98 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_UC})
 +set(lib_NAME_SUFFIX ${COMMON_STUBNAME})
 +
 +set(private_src_DIR "${CMAKE_CURRENT_LIST_DIR}")
 +set(interface_src_DIR "${includedir}")
-+set(build_src_DIR
-+  "$<BUILD_INTERFACE:${private_src_DIR}>"
-+)
-+set(install_src_DIR
-+  "$<INSTALL_INTERFACE:${interface_src_DIR}>"
-+)
++set(build_src_DIR "$<BUILD_INTERFACE:${private_src_DIR}>")
++set(install_src_DIR "$<INSTALL_INTERFACE:${interface_src_DIR}>")
 +set(public_src_DIR "${build_src_DIR}${install_src_DIR}")
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGSICUUC}
-+    U_COMMON_IMPLEMENTATION
-+    # for plugin configuration
-+    DEFAULT_ICU_PLUGINS=\"${libdir}/icu\"
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGSICUUC} U_COMMON_IMPLEMENTATION
++             # for plugin configuration
++             DEFAULT_ICU_PLUGINS=\"${libdir}/icu\"
 +)
 +if(PKGDATA_MODE STREQUAL "common")
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS
-+      # for icu data location
-+      U_ICU_DATA_DEFAULT_DIR=\"${ICUDATA_DIR}\"
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS
++                 # for icu data location
++                 U_ICU_DATA_DEFAULT_DIR=\"${ICUDATA_DIR}\"
++    )
 +endif()
 +if(MSVC)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    # Added in ICU 61.1.
-+    COMPILE_DEFINITIONS U_PLATFORM_USES_ONLY_WIN32_API=1
-+  )
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS $<$<CONFIG:Debug>:RBBI_DEBUG>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY # Added in ICU 61.1.
++                 COMPILE_DEFINITIONS U_PLATFORM_USES_ONLY_WIN32_API=1
++    )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:RBBI_DEBUG>
++    )
 +endif()
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICUUC}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICUUC}
 +)
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${private_src_DIR}
-+)
++# Include directories PRIVATE
++target_include_directories(${lib_NAME} PRIVATE ${private_src_DIR})
 +
-+### Link libraries
-+# PUBLIC
++# Link libraries PUBLIC
 +if(PKGDATA_MODE STREQUAL "common")
-+  target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_STUBDT})
++    target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_STUBDT})
 +else()
-+  # INSTALL_INTERFACE introduced to avoid cyclic dependency:
-+  # * icupkg -> icuuc -> icudata -> icupkg (generated by)
-+  # Build:
-+  # * icudata -> icupkg -> icuuc -> icustubdata
-+  # Usage:
-+  # * icuuc -> icudata
-+  target_link_libraries(${lib_NAME} PUBLIC
-+    $<BUILD_INTERFACE:${ICULIBS_STUBDT}>
-+    $<INSTALL_INTERFACE:${ICULIBS_DT}>
-+  )
++    # INSTALL_INTERFACE introduced to avoid cyclic dependency: * icupkg -> icuuc -> icudata -> icupkg
++    # (generated by) Build: * icudata -> icupkg -> icuuc -> icustubdata Usage: * icuuc -> icudata
++    target_link_libraries(
++        ${lib_NAME} PUBLIC $<BUILD_INTERFACE:${ICULIBS_STUBDT}> $<INSTALL_INTERFACE:${ICULIBS_DT}>
++    )
 +endif()
 +# After ICULIBS_DT or ICULIBS_STUBDT
 +target_link_libraries(${lib_NAME} PUBLIC ${DEFAULT_LIBS})
 +
-+setup_icu_lib_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}")
-+
-+install(
-+  FILES ${${lib_NAME}_PUBLIC_HEADERS}
-+  DESTINATION "${includedir}/unicode"
++setup_icu_lib_target(
++    "${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}"
 +)
-+#include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
++
++install(FILES ${${lib_NAME}_PUBLIC_HEADERS} DESTINATION "${includedir}/unicode")
++# include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
 +#
-+#install(
-+#  DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode
-+#  DESTINATION "${includedir}"
-+#  FILES_MATCHING
-+#  PATTERN "*.h"
-+#)
++# install( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode DESTINATION "${includedir}" FILES_MATCHING PATTERN
++# "*.h" )
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/common_icu_lib_flags.cmake b/source/common_icu_lib_flags.cmake
 new file mode 100644
-index 0000000000..c4e989ee0f
+index 0000000000..7ee5968fa3
 --- /dev/null
 +++ b/source/common_icu_lib_flags.cmake
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,127 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+### Common libraries flags
++# Common libraries flags
 +
 +# INTERFACE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  INTERFACE_COMPILE_DEFINITIONS ${UCONFIG_CPPFLAGS}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY INTERFACE_COMPILE_DEFINITIONS ${UCONFIG_CPPFLAGS}
 +)
 +
 +# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGS}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGS}
 +)
 +if(CPPFLAGS_DEBUG)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${CPPFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${CPPFLAGS_DEBUG}>
++    )
 +endif()
 +if(CPPFLAGS_RELEASE)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS $<$<CONFIG:Release>:${CPPFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Release>:${CPPFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${CFLAGS}>
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${CFLAGS}>
 +)
 +if(CFLAGS_DEBUG)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Debug>>:${CFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Debug>>:${CFLAGS_DEBUG}>
++    )
 +endif()
 +if(CFLAGS_RELEASE)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Release>>:${CFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Release>>:${CFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${CXXFLAGS}>
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${CXXFLAGS}>
 +)
 +if(CXXFLAGS_DEBUG)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${CXXFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${CXXFLAGS_DEBUG}>
++    )
 +endif()
 +if(CXXFLAGS_RELEASE)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${CXXFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${CXXFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGS}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGS}
 +)
 +if(LDFLAGS_DEBUG)
-+  set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+    LINK_FLAGS_DEBUG ${LDFLAGS_DEBUG}
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND_STRING
++        PROPERTY LINK_FLAGS_DEBUG ${LDFLAGS_DEBUG}
++    )
 +endif()
 +if(LDFLAGS_RELEASE)
-+  set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+    LINK_FLAGS_RELEASE ${LDFLAGS_RELEASE}
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND_STRING
++        PROPERTY LINK_FLAGS_RELEASE ${LDFLAGS_RELEASE}
++    )
 +endif()
 +
 +if(BUILD_SHARED_LIBS)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS ${SHAREDLIBCPPFLAGS}
-+  )
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${SHAREDLIBCFLAGS}>
-+  )
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${SHAREDLIBCXXFLAGS}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS ${SHAREDLIBCPPFLAGS}
++    )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${SHAREDLIBCFLAGS}>
++    )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${SHAREDLIBCXXFLAGS}>
++    )
 +endif()
 +
 +if(NOT lib_NAME STREQUAL ICULIBS_DT)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS ${LIBCPPFLAGS}
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS ${LIBCPPFLAGS}
++    )
 +endif()
 +
 +if(NOT lib_NAME STREQUAL ICULIBS_DT OR NOT lib_NAME STREQUAL ICULIBS_STUBDT)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${LIBCXXFLAGS}>
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${LIBCXXFLAGS}>
++    )
 +endif()
 diff --git a/source/common_icu_lib_includes.cmake b/source/common_icu_lib_includes.cmake
 new file mode 100644
-index 0000000000..835ddd5f9e
+index 0000000000..cd21b75233
 --- /dev/null
 +++ b/source/common_icu_lib_includes.cmake
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,8 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+### Common libraries include directories
++# Common libraries include directories
 +
 +# PUBLIC
-+target_include_directories(${lib_NAME} PUBLIC
-+  $<INSTALL_INTERFACE:${includedir}>
-+)
++target_include_directories(${lib_NAME} PUBLIC $<INSTALL_INTERFACE:${includedir}>)
 diff --git a/source/common_tools_exe_flags.cmake b/source/common_tools_exe_flags.cmake
 new file mode 100644
-index 0000000000..012694226a
+index 0000000000..017a5a4383
 --- /dev/null
 +++ b/source/common_tools_exe_flags.cmake
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,86 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+### Common executables flags
++# Common executables flags
 +
 +# PRIVATE flags
-+set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGS}
++set_property(
++    TARGET ${exe_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGS}
 +)
 +if(CPPFLAGS_DEBUG)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${CPPFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:${CPPFLAGS_DEBUG}>
++    )
 +endif()
 +if(CPPFLAGS_RELEASE)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS $<$<CONFIG:Release>:${CPPFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Release>:${CPPFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+  COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${CFLAGS}>
++set_property(
++    TARGET ${exe_NAME}
++    APPEND
++    PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:C>:${CFLAGS}>
 +)
 +if(CFLAGS_DEBUG)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Debug>>:${CFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Debug>>:${CFLAGS_DEBUG}>
++    )
 +endif()
 +if(CFLAGS_RELEASE)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Release>>:${CFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:Release>>:${CFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+  COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${CXXFLAGS}>
++set_property(
++    TARGET ${exe_NAME}
++    APPEND
++    PROPERTY COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:${CXXFLAGS}>
 +)
 +if(CXXFLAGS_DEBUG)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${CXXFLAGS_DEBUG}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${CXXFLAGS_DEBUG}>
++    )
 +endif()
 +if(CXXFLAGS_RELEASE)
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${CXXFLAGS_RELEASE}>
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_OPTIONS $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${CXXFLAGS_RELEASE}>
++    )
 +endif()
 +
-+set_property(TARGET ${exe_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGS}
++set_property(
++    TARGET ${exe_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGS}
 +)
 +if(LDFLAGS_DEBUG)
-+  set_property(TARGET ${exe_NAME} APPEND_STRING PROPERTY
-+    LINK_FLAGS_DEBUG ${LDFLAGS_DEBUG}
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND_STRING
++        PROPERTY LINK_FLAGS_DEBUG ${LDFLAGS_DEBUG}
++    )
 +endif()
 +if(LDFLAGS_RELEASE)
-+  set_property(TARGET ${exe_NAME} APPEND_STRING PROPERTY
-+    LINK_FLAGS_RELEASE ${LDFLAGS_RELEASE}
-+  )
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND_STRING
++        PROPERTY LINK_FLAGS_RELEASE ${LDFLAGS_RELEASE}
++    )
 +endif()
 diff --git a/source/common_tools_exe_libs.cmake b/source/common_tools_exe_libs.cmake
 new file mode 100644
-index 0000000000..5af1df1286
+index 0000000000..1ea471803a
 --- /dev/null
 +++ b/source/common_tools_exe_libs.cmake
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,8 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+### Common executables libraries
++# Common executables libraries
 +
-+# PRIVATE
-+# LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS) $(LIB_M)
++# PRIVATE LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS) $(LIB_M)
 +target_link_libraries(${exe_NAME} PRIVATE ${ICULIBS_TOOLUTIL} ${LIB_M})
 diff --git a/source/configure_1st.cmake b/source/configure_1st.cmake
 new file mode 100644
-index 0000000000..32bb6650b3
+index 0000000000..dd22f884c3
 --- /dev/null
 +++ b/source/configure_1st.cmake
 @@ -0,0 +1,137 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +# In this configure file are set only this vars:
 +#
-+# PACKAGE
-+# VERSION VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_TWEAK
-+# LIB_VERSION LIB_VERSION_MAJOR
++# PACKAGE VERSION VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_TWEAK LIB_VERSION LIB_VERSION_MAJOR
 +# UNICODE_VERSION
 +
-+
 +function(status_message msg)
-+  message(STATUS "${msg}")
++    message(STATUS "${msg}")
 +endfunction()
 +
 +function(error_message msg)
-+  if(ANDROID)
-+    # Duplicate a message to build with Gradle and CMake in server mode.
-+    message(STATUS "ERROR: ${msg}")
-+  endif()
-+  message(FATAL_ERROR "${msg}")
++    if(ANDROID)
++        # Duplicate a message to build with Gradle and CMake in server mode.
++        message(STATUS "ERROR: ${msg}")
++    endif()
++    message(FATAL_ERROR "${msg}")
 +endfunction()
 +
 +function(check_message msg var)
-+  if(var)
-+    set(res "yes")
-+  else()
-+    set(res "no")
-+  endif()
-+  message(STATUS "Checking ${msg}  ${res}")
++    if(var)
++        set(res "yes")
++    else()
++        set(res "no")
++    endif()
++    message(STATUS "Checking ${msg}  ${res}")
 +endfunction()
 +
 +function(get_version_parts version out_MAJOR out_MINOR out_PATCH out_TWEAK)
-+  set(version_REGEX "^[0-9]+(\\.[0-9]+)?(\\.[0-9]+)?(\\.[0-9]+)?$")
-+  set(version_REGEX_1 "^[0-9]+$")
-+  set(version_REGEX_2 "^[0-9]+\\.[0-9]+$")
-+  set(version_REGEX_3 "^[0-9]+\\.[0-9]+\\.[0-9]+$")
-+  set(version_REGEX_4 "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$")
++    set(version_REGEX "^[0-9]+(\\.[0-9]+)?(\\.[0-9]+)?(\\.[0-9]+)?$")
++    set(version_REGEX_1 "^[0-9]+$")
++    set(version_REGEX_2 "^[0-9]+\\.[0-9]+$")
++    set(version_REGEX_3 "^[0-9]+\\.[0-9]+\\.[0-9]+$")
++    set(version_REGEX_4 "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$")
 +
-+  if(NOT version MATCHES ${version_REGEX})
-+    error_message("Problem parsing version string.")
-+  endif()
++    if(NOT version MATCHES ${version_REGEX})
++        error_message("Problem parsing version string.")
++    endif()
 +
-+  if(version MATCHES ${version_REGEX_1})
-+    set(count 1)
-+  elseif(version MATCHES ${version_REGEX_2})
-+    set(count 2)
-+  elseif(version MATCHES ${version_REGEX_3})
-+    set(count 3)
-+  elseif(version MATCHES ${version_REGEX_4})
-+    set(count 4)
-+  endif()
++    if(version MATCHES ${version_REGEX_1})
++        set(count 1)
++    elseif(version MATCHES ${version_REGEX_2})
++        set(count 2)
++    elseif(version MATCHES ${version_REGEX_3})
++        set(count 3)
++    elseif(version MATCHES ${version_REGEX_4})
++        set(count 4)
++    endif()
 +
-+  string(REGEX REPLACE "^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(\\.[0-9]+)?"
-+      "\\1" major "${version}")
++    string(REGEX REPLACE "^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(\\.[0-9]+)?" "\\1" major "${version}")
 +
-+  if(NOT count LESS 2)
-+    string(REGEX REPLACE "^[0-9]+\\.([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?"
-+        "\\1" minor "${version}")
-+  else()
-+    set(minor "0")
-+  endif()
++    if(NOT count LESS 2)
++        string(REGEX REPLACE "^[0-9]+\\.([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?" "\\1" minor "${version}")
++    else()
++        set(minor "0")
++    endif()
 +
-+  if(NOT count LESS 3)
-+    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)(\\.[0-9]+)?"
-+        "\\1" patch "${version}")
-+  else()
-+    set(patch "0")
-+  endif()
++    if(NOT count LESS 3)
++        string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)(\\.[0-9]+)?" "\\1" patch "${version}")
++    else()
++        set(patch "0")
++    endif()
 +
-+  if(NOT count LESS 4)
-+    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+)"
-+        "\\1" tweak "${version}")
-+  else()
-+    set(tweak "0")
-+  endif()
++    if(NOT count LESS 4)
++        string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" tweak "${version}")
++    else()
++        set(tweak "0")
++    endif()
 +
-+  set(${out_MAJOR} "${major}" PARENT_SCOPE)
-+  set(${out_MINOR} "${minor}" PARENT_SCOPE)
-+  set(${out_PATCH} "${patch}" PARENT_SCOPE)
-+  set(${out_TWEAK} "${tweak}" PARENT_SCOPE)
++    set(${out_MAJOR}
++        "${major}"
++        PARENT_SCOPE
++    )
++    set(${out_MINOR}
++        "${minor}"
++        PARENT_SCOPE
++    )
++    set(${out_PATCH}
++        "${patch}"
++        PARENT_SCOPE
++    )
++    set(${out_TWEAK}
++        "${tweak}"
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +function(get_icu_version out_VERSION)
-+  set(src_FILE ${CMAKE_CURRENT_SOURCE_DIR}/common/unicode/uvernum.h)
-+  file(READ ${src_FILE} src_FILE_CONTENTS)
-+  string(
-+    REGEX MATCH "[ \t]*#[ \t]*define[ \t]+U_ICU_VERSION[ \t]+\"([^\"]*)\""
-+    version_str ${src_FILE_CONTENTS}
-+  )
-+  if(CMAKE_MATCH_COUNT EQUAL 1)
-+    set(${out_VERSION} ${CMAKE_MATCH_1} PARENT_SCOPE)
-+  endif()
++    set(src_FILE ${CMAKE_CURRENT_SOURCE_DIR}/common/unicode/uvernum.h)
++    file(READ ${src_FILE} src_FILE_CONTENTS)
++    string(REGEX MATCH "[ \t]*#[ \t]*define[ \t]+U_ICU_VERSION[ \t]+\"([^\"]*)\"" version_str
++                 ${src_FILE_CONTENTS}
++    )
++    if(CMAKE_MATCH_COUNT EQUAL 1)
++        set(${out_VERSION}
++            ${CMAKE_MATCH_1}
++            PARENT_SCOPE
++        )
++    endif()
 +endfunction()
 +
 +function(get_unicode_version out_VERSION)
-+  set(src_FILE ${CMAKE_CURRENT_SOURCE_DIR}/common/unicode/uchar.h)
-+  file(READ ${src_FILE} src_FILE_CONTENTS)
-+  string(
-+    REGEX MATCH "[ \t]*#[ \t]*define[ \t]+U_UNICODE_VERSION[ \t]+\"([^\"]*)\""
-+    version_str ${src_FILE_CONTENTS}
-+  )
-+  if(CMAKE_MATCH_COUNT EQUAL 1)
-+    set(${out_VERSION} ${CMAKE_MATCH_1} PARENT_SCOPE)
-+  endif()
++    set(src_FILE ${CMAKE_CURRENT_SOURCE_DIR}/common/unicode/uchar.h)
++    file(READ ${src_FILE} src_FILE_CONTENTS)
++    string(REGEX MATCH "[ \t]*#[ \t]*define[ \t]+U_UNICODE_VERSION[ \t]+\"([^\"]*)\"" version_str
++                 ${src_FILE_CONTENTS}
++    )
++    if(CMAKE_MATCH_COUNT EQUAL 1)
++        set(${out_VERSION}
++            ${CMAKE_MATCH_1}
++            PARENT_SCOPE
++        )
++    endif()
 +endfunction()
-+
 +
 +set(PACKAGE "icu")
 +
@@ -1120,37 +1127,29 @@ index 0000000000..32bb6650b3
 +
 +get_icu_version(VERSION)
 +if(NOT VERSION)
-+  error_message(
-+    "Cannot determine ICU version number from uvernum.h header file"
-+  )
++    error_message("Cannot determine ICU version number from uvernum.h header file")
 +endif()
 +
 +get_unicode_version(UNICODE_VERSION)
 +if(NOT UNICODE_VERSION)
-+  error_message(
-+    "Cannot determine Unicode version number from uchar.h header file"
-+  )
++    error_message("Cannot determine Unicode version number from uchar.h header file")
 +endif()
 +
-+get_version_parts(${VERSION}
-+  VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_TWEAK
-+)
++get_version_parts(${VERSION} VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_TWEAK)
 +
 +set(LIB_VERSION ${VERSION})
 +set(LIB_VERSION_MAJOR ${VERSION_MAJOR})
 +
-+status_message(
-+  "release ${VERSION}, library ${LIB_VERSION}, unicode version ${UNICODE_VERSION}"
-+)
++status_message("release ${VERSION}, library ${LIB_VERSION}, unicode version ${UNICODE_VERSION}")
 diff --git a/source/configure_2nd.cmake b/source/configure_2nd.cmake
 new file mode 100644
-index 0000000000..710875729f
+index 0000000000..be373fbc3c
 --- /dev/null
 +++ b/source/configure_2nd.cmake
-@@ -0,0 +1,1193 @@
+@@ -0,0 +1,1208 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +include(CheckIncludeFile)
 +include(CheckIncludeFileCXX)
@@ -1159,85 +1158,93 @@ index 0000000000..710875729f
 +include(TestBigEndian)
 +
 +macro(icu_conditional name condition)
-+  if(${condition})
-+    set(${name}_TRUE "")
-+    set(U_HAVE_${name} 1)
-+  else()
-+    set(${name}_TRUE "#")
-+    set(U_HAVE_${name} 0)
-+  endif()
++    if(${condition})
++        set(${name}_TRUE "")
++        set(U_HAVE_${name} 1)
++    else()
++        set(${name}_TRUE "#")
++        set(U_HAVE_${name} 0)
++    endif()
 +endmacro()
 +
-+function(try_compile_src src_file_name src_file_ext
-+    header_text main_text definitions libraries out_var)
-+  set(file_name "try_compile_${src_file_name}")
-+  set(src_file
-+    "${CMAKE_CURRENT_BINARY_DIR}/try_compile/${file_name}.${src_file_ext}"
-+  )
-+  set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/try_compile/${file_name}")
++function(
++    try_compile_src
++    src_file_name
++    src_file_ext
++    header_text
++    main_text
++    definitions
++    libraries
++    out_var
++)
++    set(file_name "try_compile_${src_file_name}")
++    set(src_file "${CMAKE_CURRENT_BINARY_DIR}/try_compile/${file_name}.${src_file_ext}")
++    set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/try_compile/${file_name}")
 +
-+  file(WRITE ${src_file}
-+  "
++    file(
++        WRITE ${src_file}
++        "
 +      ${header_text}
 +      int main()
 +      {
 +        ${main_text}
 +        return 0;
 +      }
-+  ")
-+
-+  if(NOT definitions)
-+    set(definitions "-DTEMP_TRY_STUB_DEF")
-+  endif()
-+
-+  if(libraries)
-+    try_compile(_${out_var} ${bin_dir}
-+      SOURCES ${src_file}
-+      COMPILE_DEFINITIONS ${definitions}
-+      LINK_LIBRARIES ${libraries}
-+      OUTPUT_VARIABLE build_OUT
++  "
 +    )
-+  else()
-+    try_compile(_${out_var} ${bin_dir}
-+      SOURCES ${src_file}
-+      COMPILE_DEFINITIONS ${definitions}
-+      OUTPUT_VARIABLE build_OUT
-+    )
-+  endif()
 +
++    if(NOT definitions)
++        set(definitions "-DTEMP_TRY_STUB_DEF")
++    endif()
 +
-+  if(_${out_var})
-+    set(${out_var} 1 PARENT_SCOPE)
-+    message(STATUS "Looking for ${out_var} - set to 1 - TRUE")
-+#    message(STATUS ${build_OUT})  # For debug
-+  else()
-+    set(${out_var} 0 PARENT_SCOPE)
-+    message(STATUS "Looking for ${out_var} - set to 0 - FALSE")
-+#    message(STATUS ${build_OUT})  # For debug
-+  endif()
++    if(libraries)
++        try_compile(
++            _${out_var} ${bin_dir}
++            SOURCES ${src_file}
++            COMPILE_DEFINITIONS ${definitions}
++            LINK_LIBRARIES ${libraries}
++            OUTPUT_VARIABLE build_OUT
++        )
++    else()
++        try_compile(
++            _${out_var} ${bin_dir}
++            SOURCES ${src_file}
++            COMPILE_DEFINITIONS ${definitions}
++            OUTPUT_VARIABLE build_OUT
++        )
++    endif()
++
++    if(_${out_var})
++        set(${out_var}
++            1
++            PARENT_SCOPE
++        )
++        message(STATUS "Looking for ${out_var} - set to 1 - TRUE")
++        # message(STATUS ${build_OUT})  # For debug
++    else()
++        set(${out_var}
++            0
++            PARENT_SCOPE
++        )
++        message(STATUS "Looking for ${out_var} - set to 0 - FALSE")
++        # message(STATUS ${build_OUT})  # For debug
++    endif()
 +endfunction()
-+
 +
 +# Accumulate #defines
 +
-+# CONFIG_CPPFLAGS: These are defines that are set for ICU Build time only.
-+# They are only needed for building ICU itself. Example: platform stuff
-+# NOTE: only -D flags.
-+# NOTE: to CPPFLAGS
++# CONFIG_CPPFLAGS: These are defines that are set for ICU Build time only. They are only needed for
++# building ICU itself. Example: platform stuff NOTE: only -D flags. NOTE: to CPPFLAGS
 +set(CONFIG_CPPFLAGS "")
 +
-+# UCONFIG_CPPFLAGS: These are defines which are set for ICU build time,
-+# and also a notice is output that they need to be set
-+# for end-users of ICU also. uconfig.h.prepend is generated
-+# with, for example, "#define U_DISABLE_RENAMING 1"
-+# Example: ICU configuration stuff
-+# NOTE: only -D flags.
-+# NOTE: to CPPFLAGS and to 'uconfig.h.prepend' file.
++# UCONFIG_CPPFLAGS: These are defines which are set for ICU build time, and also a notice is output that
++# they need to be set for end-users of ICU also. uconfig.h.prepend is generated with, for example,
++# "#define U_DISABLE_RENAMING 1" Example: ICU configuration stuff NOTE: only -D flags. NOTE: to CPPFLAGS
++# and to 'uconfig.h.prepend' file.
 +set(UCONFIG_CPPFLAGS "")
 +
-+# UCONFIG_CFLAGS: contains a copy of anything that needs to be set by end users
-+# such as -std
-+# NOTE: not used, in orig configure.ac are NOT -D flags.
++# UCONFIG_CFLAGS: contains a copy of anything that needs to be set by end users such as -std NOTE: not
++# used, in orig configure.ac are NOT -D flags.
 +set(UCONFIG_CFLAGS "")
 +
 +set(CFLAGS "")
@@ -1257,175 +1264,167 @@ index 0000000000..710875729f
 +set(SHAREDLIBCPPFLAGS "")
 +
 +set(LIBS "")
-+set(LDFLAGS " ")  # Property 'LINK_FLAGS' is appendable string, not list.
++set(LDFLAGS " ") # Property 'LINK_FLAGS' is appendable string, not list.
 +
 +set(CMAKE_C_STANDARD 99)
 +set(CMAKE_C_STANDARD_REQUIRED ON)
 +set(CMAKE_CXX_STANDARD 11)
 +set(CMAKE_CXX_STANDARD_REQUIRED ON)
 +
-+# Check whether to build debug libraries
-+#check_message("whether to build debug libraries" ${ENABLE_DEBUG})
++# Check whether to build debug libraries check_message("whether to build debug libraries"
++# ${ENABLE_DEBUG})
 +list(APPEND CPPFLAGS_DEBUG U_DEBUG=1)
 +
-+# Check whether to build release libraries
-+#check_message("whether to build release libraries" ${ENABLE_RELEASE})
++# Check whether to build release libraries check_message("whether to build release libraries"
++# ${ENABLE_RELEASE})
 +
-+# TODO: see:
-+# http://userguide.icu-project.org/layoutengine/paragraph
-+# https://github.com/harfbuzz/icu-le-hb
-+# TODO: find_package(icu-le-hb), not pkg-config.
-+# pkg-config is needed for harfbuzz support
-+#PKG_CHECK_MODULES(ICULEHB, icu-le-hb, have_icu_le_hb=true, :)
++# TODO: see: http://userguide.icu-project.org/layoutengine/paragraph
++# https://github.com/harfbuzz/icu-le-hb TODO: find_package(icu-le-hb), not pkg-config. pkg-config is
++# needed for harfbuzz support PKG_CHECK_MODULES(ICULEHB, icu-le-hb, have_icu_le_hb=true, :)
 +set(HAVE_ICU_LE_HB false)
 +
-+# TODO: Is it needed with CMake?
-+# Ensure that if CXXFLAGS/CFLAGS were not set when calling configure,
-+# set it correctly based on (enable/disable) debug or release option.
-+# The release mode use is the default one for autoconf
-+#if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+#  if(CFLAGS STREQUAL "")
-+#    if(ENABLE_DEBUG)
-+#      set(CFLAGS -g)
-+#    endif()
-+#    if(ENABLE_RELEASE)
-+#      list(APPEND CFLAGS -O2)
-+#    endif()
-+#  endif()
-+#endif()
-+#if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-+#  if(CXXFLAGS STREQUAL "")
-+#    if(ENABLE_DEBUG)
-+#      set(CXXFLAGS -g)
-+#    endif()
-+#    if(ENABLE_RELEASE)
-+#      list(APPEND CXXFLAGS -O2)
-+#    endif()
-+#  endif()
-+#endif()
++# TODO: Is it needed with CMake? Ensure that if CXXFLAGS/CFLAGS were not set when calling configure, set
++# it correctly based on (enable/disable) debug or release option. The release mode use is the default one
++# for autoconf if(CMAKE_C_COMPILER_ID STREQUAL "GNU") if(CFLAGS STREQUAL "") if(ENABLE_DEBUG) set(CFLAGS
++# -g) endif() if(ENABLE_RELEASE) list(APPEND CFLAGS -O2) endif() endif() endif() if(CMAKE_CXX_COMPILER_ID
++# STREQUAL "GNU") if(CXXFLAGS STREQUAL "") if(ENABLE_DEBUG) set(CXXFLAGS -g) endif() if(ENABLE_RELEASE)
++# list(APPEND CXXFLAGS -O2) endif() endif() endif()
 +
 +option(ICU_CROSS_COMPILING "Enable cross compiling" OFF)
-+set(ICU_CROSS_BUILDROOT "" CACHE PATH
-+  "Specify an absolute path to the build directory of an ICU built for the current platform"
++set(ICU_CROSS_BUILDROOT
++    ""
++    CACHE PATH
++          "Specify an absolute path to the build directory of an ICU built for the current platform"
 +)
 +if(NOT ICU_CROSS_BUILDROOT)
-+  if(ICU_CROSS_COMPILING)
-+    error_message(
-+      "Error! Cross compiling but no ICU_CROSS_BUILDROOT option specified - please supply the path to an executable ICU's build root"
-+    )
-+  endif()
++    if(ICU_CROSS_COMPILING)
++        error_message(
++            "Error! Cross compiling but no ICU_CROSS_BUILDROOT option specified - please supply the path to an executable ICU's build root"
++        )
++    endif()
 +elseif(EXISTS ${ICU_CROSS_BUILDROOT}/config/icucross.cmake)
-+  status_message("Using cross buildroot: ${ICU_CROSS_BUILDROOT}")
++    status_message("Using cross buildroot: ${ICU_CROSS_BUILDROOT}")
 +elseif(EXISTS ${ICU_CROSS_BUILDROOT})
-+  error_message(
-+    "${crossICU_CROSS_BUILDROOT}/config/icucross.cmake not found. Please build ICU in ${ICU_CROSS_BUILDROOT} first."
-+  )
++    error_message(
++        "${crossICU_CROSS_BUILDROOT}/config/icucross.cmake not found. Please build ICU in ${ICU_CROSS_BUILDROOT} first."
++    )
 +else()
-+  error_message(
-+    "No such directory ${ICU_CROSS_BUILDROOT} supplied as the argument to ICU_CROSS_BUILDROOT. Use an absolute path."
-+  )
++    error_message(
++        "No such directory ${ICU_CROSS_BUILDROOT} supplied as the argument to ICU_CROSS_BUILDROOT. Use an absolute path."
++    )
 +endif()
 +
 +# Determine how strict we want to be when compiling
 +option(ICU_ENABLE_STRICT "Compile with strict compiler options" ON)
 +if(ICU_ENABLE_STRICT)
-+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+    list(APPEND CFLAGS
-+      -Wall -pedantic -Wshadow -Wpointer-arith
-+      -Wmissing-prototypes -Wwrite-strings
-+    )
-+  elseif(MSVC)
-+    list(APPEND CFLAGS /W4)
-+  endif()
-+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-+    list(APPEND CXXFLAGS
-+      -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long
-+    )
-+  elseif(MSVC)
-+    list(APPEND CXXFLAGS /W4)
-+  endif()
++    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
++        list(
++            APPEND
++            CFLAGS
++            -Wall
++            -pedantic
++            -Wshadow
++            -Wpointer-arith
++            -Wmissing-prototypes
++            -Wwrite-strings
++        )
++    elseif(MSVC)
++        list(APPEND CFLAGS /W4)
++    endif()
++    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++        list(
++            APPEND
++            CXXFLAGS
++            -W
++            -Wall
++            -pedantic
++            -Wpointer-arith
++            -Wwrite-strings
++            -Wno-long-long
++        )
++    elseif(MSVC)
++        list(APPEND CXXFLAGS /W4)
++    endif()
 +endif()
 +check_message("whether strict compiling is on" ${ICU_ENABLE_STRICT})
 +
-+# Checks for libraries and other host specific stuff.
-+# TODO: On HP/UX, don't link to -lm from a shared lib
++# Checks for libraries and other host specific stuff. TODO: On HP/UX, don't link to -lm from a shared lib
 +# because it isn't PIC (at least on 10.2).
 +option(ICU_USE_LIB_M "Compile with 'm' library." ON)
 +if(ICU_USE_LIB_M)
-+  find_library(LIB_M_LOCATION NAMES "m")
-+  set(HAVE_LIB_M OFF)
-+  if(LIB_M_LOCATION)
-+    try_compile_src("for_lib_m" "c"
-+      "#include <math.h>"
-+      "double d = floor(2.0);"
-+      ""
-+      "${LIB_M_LOCATION}"
-+      _HAVE_LIB_M
-+    )
-+    if(_HAVE_LIB_M)
-+      set(HAVE_LIB_M ON)
-+#      set(LIB_M_TARGET "${TARGETS_NAMESPACE}m")
-+#      add_library(${LIB_M_TARGET} SHARED IMPORTED)
-+#      set_target_properties(${LIB_M_TARGET} PROPERTIES
-+#        IMPORTED_LOCATION "${LIB_M_LOCATION}"
-+#      )
-+#      list(INSERT LIBS 0 ${LIB_M_TARGET})
-+      list(INSERT LIBS 0 "m")
++    find_library(LIB_M_LOCATION NAMES "m")
++    set(HAVE_LIB_M OFF)
++    if(LIB_M_LOCATION)
++        try_compile_src(
++            "for_lib_m"
++            "c"
++            "#include <math.h>"
++            "double d = floor(2.0);"
++            ""
++            "${LIB_M_LOCATION}"
++            _HAVE_LIB_M
++        )
++        if(_HAVE_LIB_M)
++            set(HAVE_LIB_M ON)
++            # set(LIB_M_TARGET "${TARGETS_NAMESPACE}m") add_library(${LIB_M_TARGET} SHARED IMPORTED)
++            # set_target_properties(${LIB_M_TARGET} PROPERTIES IMPORTED_LOCATION "${LIB_M_LOCATION}" )
++            # list(INSERT LIBS 0 ${LIB_M_TARGET})
++            list(INSERT LIBS 0 "m")
++        endif()
 +    endif()
-+  endif()
 +endif()
 +
 +if(BUILD_SHARED_LIBS)
-+  set(ICU_ENABLE_SHARED ON)
-+  set(ICU_ENABLE_STATIC OFF)
++    set(ICU_ENABLE_SHARED ON)
++    set(ICU_ENABLE_STATIC OFF)
 +else()
-+  set(ICU_ENABLE_SHARED OFF)
-+  set(ICU_ENABLE_STATIC ON)
++    set(ICU_ENABLE_SHARED OFF)
++    set(ICU_ENABLE_STATIC ON)
 +endif()
 +
-+# Check whether to build shared libraries
-+#option(ICU_ENABLE_SHARED "Build shared libraries" ON)
++# Check whether to build shared libraries option(ICU_ENABLE_SHARED "Build shared libraries" ON)
 +check_message("whether to build shared libraries" ${ICU_ENABLE_SHARED})
 +
-+# Check whether to build static libraries
-+#option(ICU_ENABLE_STATIC "Build static libraries" OFF)
++# Check whether to build static libraries option(ICU_ENABLE_STATIC "Build static libraries" OFF)
 +check_message("whether to build static libraries" ${ICU_ENABLE_STATIC})
 +
 +# When building release static library, there might be some optimization flags we can use
 +if(ICU_ENABLE_STATIC AND NOT ICU_ENABLE_SHARED)
-+  set(_HAVE_STATIC_OPTIMIZATION no)
-+  if(UNIX AND NOT APPLE AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+    list(APPEND ST_OPT_CPPFLAGS -ffunction-sections -fdata-sections)
-+    list(APPEND ST_OPT_LDFLAGS  "-Wl,--gc-sections")
-+    list(APPEND CHECK_CPPFLAGS ${CPPFLAGS} ${ST_OPT_CPPFLAGS})
-+    try_compile_src("static_library_optimization" "c"
-+      ""
-+      ""
-+      "${CHECK_CPPFLAGS}"
-+      "${ST_OPT_LDFLAGS}"
-+      _HAVE_STATIC_OPTIMIZATION
++    set(_HAVE_STATIC_OPTIMIZATION no)
++    if(UNIX
++       AND NOT APPLE
++       AND CMAKE_C_COMPILER_ID STREQUAL "GNU"
 +    )
-+    if(_HAVE_STATIC_OPTIMIZATION)
-+      #list(APPEND CPPFLAGS ${ST_OPT_CPPFLAGS})
-+      list(APPEND CFLAGS_RELEASE ${ST_OPT_CPPFLAGS})
-+      set(LDFLAGS_RELEASE "${LDFLAGS} ${ST_OPT_LDFLAGS}")
++        list(APPEND ST_OPT_CPPFLAGS -ffunction-sections -fdata-sections)
++        list(APPEND ST_OPT_LDFLAGS "-Wl,--gc-sections")
++        list(APPEND CHECK_CPPFLAGS ${CPPFLAGS} ${ST_OPT_CPPFLAGS})
++        try_compile_src(
++            "static_library_optimization"
++            "c"
++            ""
++            ""
++            "${CHECK_CPPFLAGS}"
++            "${ST_OPT_LDFLAGS}"
++            _HAVE_STATIC_OPTIMIZATION
++        )
++        if(_HAVE_STATIC_OPTIMIZATION)
++            # list(APPEND CPPFLAGS ${ST_OPT_CPPFLAGS})
++            list(APPEND CFLAGS_RELEASE ${ST_OPT_CPPFLAGS})
++            set(LDFLAGS_RELEASE "${LDFLAGS} ${ST_OPT_LDFLAGS}")
++        endif()
 +    endif()
-+  endif()
-+  check_message("whether we can use static library optimization option"
-+    ${_HAVE_STATIC_OPTIMIZATION}
-+  )
++    check_message("whether we can use static library optimization option" ${_HAVE_STATIC_OPTIMIZATION})
 +endif()
 +
 +if(MSVC)
-+  # ICU does not use exceptions in library code.
-+  list(APPEND CONFIG_CPPFLAGS _HAS_EXCEPTIONS=0)
++    # ICU does not use exceptions in library code.
++    list(APPEND CONFIG_CPPFLAGS _HAS_EXCEPTIONS=0)
 +
-+  # Disable MSBuild warning about Linker OutputFile.
-+  # Ex: MSBuild complains that the common project creates "icuuc62.dll"
-+  # rather than "common.dll". However, this is intentional.
-+  set(CMAKE_VS_GLOBALS  # CMake 3.13+
-+    "MSBuildWarningsAsMessages=MSB8012"
-+  )
++    # Disable MSBuild warning about Linker OutputFile. Ex: MSBuild complains that the common project
++    # creates "icuuc62.dll" rather than "common.dll". However, this is intentional.
++    set(CMAKE_VS_GLOBALS # CMake 3.13+
++        "MSBuildWarningsAsMessages=MSB8012"
++    )
 +endif()
 +
 +# Check whether to enable auto cleanup of libraries
@@ -1433,161 +1432,156 @@ index 0000000000..710875729f
 +set(UCLN_NO_AUTO_CLEANUP 1)
 +set(MSVC_RELEASE_FLAG "")
 +if(ICU_ENABLE_AUTO_CLEANUP)
-+  list(APPEND CONFIG_CPPFLAGS UCLN_NO_AUTO_CLEANUP=0)
-+  set(UCLN_NO_AUTO_CLEANUP 0)
++    list(APPEND CONFIG_CPPFLAGS UCLN_NO_AUTO_CLEANUP=0)
++    set(UCLN_NO_AUTO_CLEANUP 0)
 +
-+  # MSVC floating-point option
-+  if(MSVC)
-+    if(MSVC_VERSION LESS 1400)
-+      set(MSVC_RELEASE_FLAG /Op)
-+    else()
-+      set(MSVC_RELEASE_FLAG /fp:precise)
++    # MSVC floating-point option
++    if(MSVC)
++        if(MSVC_VERSION LESS 1400)
++            set(MSVC_RELEASE_FLAG /Op)
++        else()
++            set(MSVC_RELEASE_FLAG /fp:precise)
++        endif()
++        list(APPEND CFLAGS ${MSVC_RELEASE_FLAG})
++        list(APPEND CXXFLAGS ${MSVC_RELEASE_FLAG})
 +    endif()
-+    list(APPEND CFLAGS ${MSVC_RELEASE_FLAG})
-+    list(APPEND CXXFLAGS ${MSVC_RELEASE_FLAG})
-+  endif()
 +endif()
-+check_message(
-+  "whether to enable auto cleanup of libraries" ${ICU_ENABLE_AUTO_CLEANUP}
-+)
++check_message("whether to enable auto cleanup of libraries" ${ICU_ENABLE_AUTO_CLEANUP})
 +
 +# Check whether to enabled draft APIs
 +option(ICU_ENABLE_DRAFT "Enable draft APIs (and internal APIs)" ON)
 +set(U_DEFAULT_SHOW_DRAFT 1)
 +if(NOT ICU_ENABLE_DRAFT)
-+  set(U_DEFAULT_SHOW_DRAFT 0)
-+  list(APPEND CONFIG_CPPFLAGS U_DEFAULT_SHOW_DRAFT=0)
++    set(U_DEFAULT_SHOW_DRAFT 0)
++    list(APPEND CONFIG_CPPFLAGS U_DEFAULT_SHOW_DRAFT=0)
 +endif()
 +check_message("whether to enable draft APIs" ${ICU_ENABLE_DRAFT})
 +# Make sure that we can use draft API in ICU.
 +if(NOT U_DEFAULT_SHOW_DRAFT)
-+  list(APPEND CONFIG_CPPFLAGS U_SHOW_DRAFT_API U_SHOW_INTERNAL_API)
++    list(APPEND CONFIG_CPPFLAGS U_SHOW_DRAFT_API U_SHOW_INTERNAL_API)
 +endif()
 +
 +option(ICU_ENABLE_RENAMING "Add a version suffix to symbols" ON)
 +set(U_DISABLE_RENAMING 0)
 +if(NOT ICU_ENABLE_RENAMING)
-+  set(U_DISABLE_RENAMING 1)
-+  list(APPEND UCONFIG_CPPFLAGS U_DISABLE_RENAMING=1)
++    set(U_DISABLE_RENAMING 1)
++    list(APPEND UCONFIG_CPPFLAGS U_DISABLE_RENAMING=1)
 +endif()
 +check_message("whether to enable renaming of symbols" ${ICU_ENABLE_RENAMING})
 +
 +option(ICU_ENABLE_TRACING "Enable function and data tracing" OFF)
 +set(U_ENABLE_TRACING 0)
 +if(ICU_ENABLE_TRACING)
-+  set(U_ENABLE_TRACING 1)
-+  list(APPEND CONFIG_CPPFLAGS U_ENABLE_TRACING=1)
++    set(U_ENABLE_TRACING 1)
++    list(APPEND CONFIG_CPPFLAGS U_ENABLE_TRACING=1)
 +endif()
-+check_message(
-+  "whether to enable function and data tracing" ${ICU_ENABLE_TRACING}
-+)
++check_message("whether to enable function and data tracing" ${ICU_ENABLE_TRACING})
 +
 +# check if elf.h is present.
 +check_include_file("elf.h" _HAVE_ELF_H)
 +if(_HAVE_ELF_H)
-+  set(HAVE_ELF_H 1)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_ELF_H=1)
++    set(HAVE_ELF_H 1)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_ELF_H=1)
 +else()
-+  set(HAVE_ELF_H 0)
++    set(HAVE_ELF_H 0)
 +endif()
 +
 +# Enable/disable plugins
 +option(ICU_ENABLE_PLUGINS "Enable plugins" OFF)
 +icu_conditional(PLUGINS ICU_ENABLE_PLUGINS)
 +if(ICU_ENABLE_PLUGINS)
-+  list(APPEND UCONFIG_CPPFLAGS UCONFIG_ENABLE_PLUGINS=1)
++    list(APPEND UCONFIG_CPPFLAGS UCONFIG_ENABLE_PLUGINS=1)
 +endif()
 +
 +option(ICU_DISABLE_DYLOAD "Disable dynamic loading" OFF)
 +set(U_ENABLE_DYLOAD 1)
 +if(ICU_DISABLE_DYLOAD)
-+  set(U_ENABLE_DYLOAD 0)
-+  list(APPEND CONFIG_CPPFLAGS U_ENABLE_DYLOAD=0)
++    set(U_ENABLE_DYLOAD 0)
++    list(APPEND CONFIG_CPPFLAGS U_ENABLE_DYLOAD=0)
 +endif()
 +check_message(
-+  "whether to enable dynamic loading of plugins. Ignored if plugins disabled."
-+  ${U_ENABLE_DYLOAD}
++    "whether to enable dynamic loading of plugins. Ignored if plugins disabled." ${U_ENABLE_DYLOAD}
 +)
 +set(HAVE_LIB_DL OFF)
 +if(U_ENABLE_DYLOAD)
-+  check_include_file("dlfcn.h" _HAVE_DLFCN_H)
-+  if(_HAVE_DLFCN_H)
-+    set(HAVE_DLFCN_H 1)
++    check_include_file("dlfcn.h" _HAVE_DLFCN_H)
++    if(_HAVE_DLFCN_H)
++        set(HAVE_DLFCN_H 1)
 +
-+    check_symbol_exists("dlopen" "dlfcn.h" _HAVE_DLOPEN)
-+    if(_HAVE_DLOPEN)
-+      set(HAVE_DLOPEN 1)
-+    elseif(CMAKE_DL_LIBS)
-+      find_library(LIB_DL_LOCATION NAMES ${CMAKE_DL_LIBS})
-+      if(LIB_DL_LOCATION)
-+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
-+        check_symbol_exists("dlopen" "dlfcn.h" _HAVE_DLOPEN_DL)
-+        if(_HAVE_DLOPEN_DL)
-+          set(HAVE_DLOPEN 1)
-+          set(HAVE_LIB_DL ON)
-+#          set(LIB_DL_TARGET "${TARGETS_NAMESPACE}dl")
-+#          add_library(${LIB_DL_TARGET} SHARED IMPORTED)
-+#          set_target_properties(${LIB_DL_TARGET} PROPERTIES
-+#            IMPORTED_LOCATION "${LIB_DL_LOCATION}"
-+#          )
-+#          list(INSERT LIBS 0 ${LIB_DL_TARGET})
-+          list(INSERT LIBS 0 ${CMAKE_DL_LIBS})
-+        else()
-+          set(HAVE_DLOPEN 0)
++        check_symbol_exists("dlopen" "dlfcn.h" _HAVE_DLOPEN)
++        if(_HAVE_DLOPEN)
++            set(HAVE_DLOPEN 1)
++        elseif(CMAKE_DL_LIBS)
++            find_library(LIB_DL_LOCATION NAMES ${CMAKE_DL_LIBS})
++            if(LIB_DL_LOCATION)
++                set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
++                check_symbol_exists("dlopen" "dlfcn.h" _HAVE_DLOPEN_DL)
++                if(_HAVE_DLOPEN_DL)
++                    set(HAVE_DLOPEN 1)
++                    set(HAVE_LIB_DL ON)
++                    # set(LIB_DL_TARGET "${TARGETS_NAMESPACE}dl") add_library(${LIB_DL_TARGET} SHARED
++                    # IMPORTED) set_target_properties(${LIB_DL_TARGET} PROPERTIES IMPORTED_LOCATION
++                    # "${LIB_DL_LOCATION}" ) list(INSERT LIBS 0 ${LIB_DL_TARGET})
++                    list(INSERT LIBS 0 ${CMAKE_DL_LIBS})
++                else()
++                    set(HAVE_DLOPEN 0)
++                endif()
++            endif()
 +        endif()
-+      endif()
++    else()
++        set(HAVE_DLFCN_H 0)
 +    endif()
-+  else()
-+    set(HAVE_DLFCN_H 0)
-+  endif()
 +
-+  if(NOT HAVE_DLFCN_H OR NOT HAVE_DLOPEN)
-+    list(APPEND CONFIG_CPPFLAGS HAVE_DLOPEN=0)
-+  endif()
++    if(NOT HAVE_DLFCN_H OR NOT HAVE_DLOPEN)
++        list(APPEND CONFIG_CPPFLAGS HAVE_DLOPEN=0)
++    endif()
 +endif()
 +
-+# Check for miscellanous functions.
-+# So, use for putil / tools only.
-+# Note that this will generate HAVE_GETTIMEOFDAY, not U_HAVE_GETTIMEOFDAY
++# Check for miscellanous functions. So, use for putil / tools only. Note that this will generate
++# HAVE_GETTIMEOFDAY, not U_HAVE_GETTIMEOFDAY
 +check_symbol_exists("gettimeofday" "sys/time.h" _HAVE_GETTIMEOFDAY)
 +if(_HAVE_GETTIMEOFDAY)
-+  set(HAVE_GETTIMEOFDAY 1)
++    set(HAVE_GETTIMEOFDAY 1)
 +else()
-+  set(HAVE_GETTIMEOFDAY 0)
++    set(HAVE_GETTIMEOFDAY 0)
 +endif()
 +
 +# Check whether to use the evil rpath or not
 +option(ICU_ENABLE_RPATH "Use rpath when linking" OFF)
 +
 +if(CMAKE_CXX_STANDARD LESS 11)
-+  try_compile_src("if_include_string_works" "cpp"
-+    "#include <string>"
-+    ""
-+    ""
-+    ""
-+    _HEADER_STDSTRING
-+  )
-+  if(_HEADER_STDSTRING)
-+    set(U_HAVE_STD_STRING 1)
-+  else()
-+    set(U_HAVE_STD_STRING 0)
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_STD_STRING=0)
-+  endif()
-+  check_message("if #include <string> works" ${_HEADER_STDSTRING})
++    try_compile_src(
++        "if_include_string_works"
++        "cpp"
++        "#include <string>"
++        ""
++        ""
++        ""
++        _HEADER_STDSTRING
++    )
++    if(_HEADER_STDSTRING)
++        set(U_HAVE_STD_STRING 1)
++    else()
++        set(U_HAVE_STD_STRING 0)
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_STD_STRING=0)
++    endif()
++    check_message("if #include <string> works" ${_HEADER_STDSTRING})
 +endif()
 +
 +# NOTE: this check is removed in ICU 63.1, C++11 has <atomic>.
-+try_compile_src("if_include_atomic_works" "cpp"
-+  "#include <atomic>"
-+  ""
-+  ""
-+  ""
-+  _HEADER_ATOMIC
++try_compile_src(
++    "if_include_atomic_works"
++    "cpp"
++    "#include <atomic>"
++    ""
++    ""
++    ""
++    _HEADER_ATOMIC
 +)
 +if(_HEADER_ATOMIC)
-+  set(U_HAVE_ATOMIC 1)
++    set(U_HAVE_ATOMIC 1)
 +else()
-+  set(U_HAVE_ATOMIC 0)
++    set(U_HAVE_ATOMIC 0)
 +endif()
 +# Make this available via CPPFLAGS
 +list(APPEND CONFIG_CPPFLAGS U_HAVE_ATOMIC=${U_HAVE_ATOMIC})
@@ -1596,57 +1590,61 @@ index 0000000000..710875729f
 +# Always build ICU with multi-threading support.
 +find_package(Threads REQUIRED)
 +if(NOT TARGET Threads::Threads)
-+  error_message("Threads library is not found.")
++    error_message("Threads library is not found.")
 +endif()
 +set(HAVE_THREADS ON)
 +list(INSERT LIBS 0 Threads::Threads)
-+# TODO: need THREADSC*FLAGS ?
-+# TODO: THREADSC*FLAGS defined in mh-*
++# TODO: need THREADSC*FLAGS ? TODO: THREADSC*FLAGS defined in mh-*
 +set(THREADSCPPFLAGS "")
 +set(THREADSCFLAGS "")
 +set(THREADSCXXFLAGS "")
 +
 +# Check for mmap()
 +set(HAVE_MMAP 0)
-+try_compile_src("if_include_atomic_works" "cpp"
-+  "
++try_compile_src(
++    "if_include_atomic_works"
++    "cpp"
++    "
 +    #include <unistd.h>
 +    #include <sys/mman.h>
 +    #include <sys/stat.h>
 +    #include <fcntl.h>
 +  "
-+  "mmap((void *)0, 0, PROT_READ, 0, 0, 0);"
-+  ""
-+  ""
-+  _HAVE_MMAP
++    "mmap((void *)0, 0, PROT_READ, 0, 0, 0);"
++    ""
++    ""
++    _HAVE_MMAP
 +)
 +if(_HAVE_MMAP)
-+  set(HAVE_MMAP 1)
++    set(HAVE_MMAP 1)
 +else()
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_MMAP=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_MMAP=0)
 +endif()
 +check_message("for mmap" ${HAVE_MMAP})
 +
 +# Check to see if genccode can generate simple assembly.
 +set(GENCCODE_ASSEMBLY "")
 +if(MINGW)
-+  if( CMAKE_SIZEOF_VOID_P EQUAL 8)
-+    set(GENCCODE_ASSEMBLY "-a gcc-mingw64")  # 64 bits
-+  else()
-+    set(GENCCODE_ASSEMBLY "-a gcc-cygwin")   # 32 bits
-+  endif()
++    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
++        set(GENCCODE_ASSEMBLY "-a gcc-mingw64") # 64 bits
++    else()
++        set(GENCCODE_ASSEMBLY "-a gcc-cygwin") # 32 bits
++    endif()
 +elseif(APPLE)
-+  set(GENCCODE_ASSEMBLY "-a gcc-darwin")
-+elseif(UNIX)  # for GCC and clang
-+  set(GENCCODE_ASSEMBLY "-a gcc")
++    set(GENCCODE_ASSEMBLY "-a gcc-darwin")
++elseif(UNIX) # for GCC and clang
++    set(GENCCODE_ASSEMBLY "-a gcc")
 +endif()
-+if(IOS OR ANDROID OR WINDOWS_STORE)
-+  # Support only archive mode for these platforms.
-+  set(GENCCODE_ASSEMBLY "")
++if(IOS
++   OR ANDROID
++   OR WINDOWS_STORE
++)
++    # Support only archive mode for these platforms.
++    set(GENCCODE_ASSEMBLY "")
 +endif()
 +set(_GENCCODE_ASSEMBLY ${GENCCODE_ASSEMBLY})
 +if(NOT _GENCCODE_ASSEMBLY)
-+  set(_GENCCODE_ASSEMBLY OFF)
++    set(_GENCCODE_ASSEMBLY OFF)
 +endif()
 +check_message("for genccode assembly" ${_GENCCODE_ASSEMBLY})
 +
@@ -1654,32 +1652,32 @@ index 0000000000..710875729f
 +
 +check_include_file("inttypes.h" _HAVE_INTTYPES_H)
 +if(_HAVE_INTTYPES_H)
-+  set(HAVE_INTTYPES_H 1)
-+  set(U_HAVE_INTTYPES_H 1)
++    set(HAVE_INTTYPES_H 1)
++    set(U_HAVE_INTTYPES_H 1)
 +else()
-+  set(HAVE_INTTYPES_H 0)
-+  set(U_HAVE_INTTYPES_H 0)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_INTTYPES_H=0)
++    set(HAVE_INTTYPES_H 0)
++    set(U_HAVE_INTTYPES_H 0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_INTTYPES_H=0)
 +endif()
 +
 +check_include_file("dirent.h" _HAVE_DIRENT_H)
 +if(_HAVE_DIRENT_H)
-+  set(HAVE_DIRENT_H 1)
-+  set(U_HAVE_DIRENT_H 1)
++    set(HAVE_DIRENT_H 1)
++    set(U_HAVE_DIRENT_H 1)
 +else()
-+  set(HAVE_DIRENT_H 0)
-+  set(U_HAVE_DIRENT_H 0)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_DIRENT_H=0)
++    set(HAVE_DIRENT_H 0)
++    set(U_HAVE_DIRENT_H 0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_DIRENT_H=0)
 +endif()
 +
 +# Check for endianness
 +test_big_endian(_U_IS_BIG_ENDIAN)
 +if(_U_IS_BIG_ENDIAN)
-+  set(U_IS_BIG_ENDIAN 1)
-+  set(U_ENDIAN_CHAR "b")
++    set(U_IS_BIG_ENDIAN 1)
++    set(U_ENDIAN_CHAR "b")
 +else()
-+  set(U_IS_BIG_ENDIAN 0)
-+  set(U_ENDIAN_CHAR "l")
++    set(U_IS_BIG_ENDIAN 0)
++    set(U_ENDIAN_CHAR "l")
 +endif()
 +
 +# Do various POSIX related checks
@@ -1687,63 +1685,69 @@ index 0000000000..710875729f
 +set(U_NL_LANGINFO_CODESET -1)
 +check_symbol_exists("nl_langinfo" "langinfo.h" _HAVE_NL_LANGINFO)
 +if(_HAVE_NL_LANGINFO)
-+  set(HAVE_NL_LANGINFO 1)
-+  set(U_HAVE_NL_LANGINFO 1)
++    set(HAVE_NL_LANGINFO 1)
++    set(U_HAVE_NL_LANGINFO 1)
 +
-+  set(NL_LANGINFO_CODESET "unknown")
-+  foreach(nl_item CODESET _NL_CTYPE_CODESET_NAME)
-+    try_compile_src("check_nl_langinfo_item" "c"
-+      "#include <langinfo.h>"
-+      "nl_langinfo(${nl_item});"
-+      ""
-+      ""
-+      _NL_LANGINFO_CODESET
-+    )
++    set(NL_LANGINFO_CODESET "unknown")
++    foreach(nl_item CODESET _NL_CTYPE_CODESET_NAME)
++        try_compile_src(
++            "check_nl_langinfo_item"
++            "c"
++            "#include <langinfo.h>"
++            "nl_langinfo(${nl_item});"
++            ""
++            ""
++            _NL_LANGINFO_CODESET
++        )
++        if(_NL_LANGINFO_CODESET)
++            set(NL_LANGINFO_CODESET ${nl_item})
++            break()
++        endif()
++    endforeach()
++
 +    if(_NL_LANGINFO_CODESET)
-+      set(NL_LANGINFO_CODESET ${nl_item})
-+      break()
++        set(U_HAVE_NL_LANGINFO_CODESET 1)
++        set(U_NL_LANGINFO_CODESET ${NL_LANGINFO_CODESET})
++        if(NOT NL_LANGINFO_CODESET STREQUAL "xCODESET")
++            list(APPEND CONFIG_CPPFLAGS NL_LANGINFO_CODESET=${NL_LANGINFO_CODESET})
++        endif()
++    else()
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_NL_LANGINFO_CODESET=0)
 +    endif()
-+  endforeach()
-+
-+  if(_NL_LANGINFO_CODESET)
-+    set(U_HAVE_NL_LANGINFO_CODESET 1)
-+    set(U_NL_LANGINFO_CODESET ${NL_LANGINFO_CODESET})
-+    if(NOT NL_LANGINFO_CODESET STREQUAL "xCODESET")
-+      list(APPEND CONFIG_CPPFLAGS NL_LANGINFO_CODESET=${NL_LANGINFO_CODESET})
-+    endif()
-+  else()
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_NL_LANGINFO_CODESET=0)
-+  endif()
 +
 +else()
-+  set(HAVE_NL_LANGINFO 0)
-+  set(U_HAVE_NL_LANGINFO 0)
-+  if(MINGW AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_NL_LANGINFO_CODESET=0)
-+  endif()
++    set(HAVE_NL_LANGINFO 0)
++    set(U_HAVE_NL_LANGINFO 0)
++    if(MINGW AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_NL_LANGINFO_CODESET=0)
++    endif()
 +endif()
 +
 +# Namespace support checks
-+try_compile_src("check_namespace_support" "cpp"
-+  "
++try_compile_src(
++    "check_namespace_support"
++    "cpp"
++    "
 +    namespace x_version {void f(){}}
 +    namespace x = x_version;
 +    using namespace x_version;
 +  "
-+  "f();"
-+  ""
-+  ""
-+  _NAMESPACE_OK
++    "f();"
++    ""
++    ""
++    _NAMESPACE_OK
 +)
 +check_message("for namespace support" ${_NAMESPACE_OK})
 +if(NOT _NAMESPACE_OK)
-+  error_message("Namespace support is required to build ICU.")
++    error_message("Namespace support is required to build ICU.")
 +endif()
 +
 +set(U_OVERRIDE_CXX_ALLOCATION 0)
 +set(U_HAVE_PLACEMENT_NEW 0)
-+try_compile_src("overriding_new_and_delete" "cpp"
-+  "
++try_compile_src(
++    "overriding_new_and_delete"
++    "cpp"
++    "
 +    #include <stdlib.h>
 +    class UMemory {
 +    public:
@@ -1753,19 +1757,19 @@ index 0000000000..710875729f
 +    void operator delete[](void *p) {free(p);}
 +    };
 +  "
-+  ""
-+  ""
-+  ""
-+  _OVERRIDE_CXX_ALLOCATION_OK
++    ""
++    ""
++    ""
++    _OVERRIDE_CXX_ALLOCATION_OK
 +)
-+check_message(
-+  "for properly overriding new and delete" ${_OVERRIDE_CXX_ALLOCATION_OK}
-+)
++check_message("for properly overriding new and delete" ${_OVERRIDE_CXX_ALLOCATION_OK})
 +if(_OVERRIDE_CXX_ALLOCATION_OK)
-+  set(U_OVERRIDE_CXX_ALLOCATION 1)
++    set(U_OVERRIDE_CXX_ALLOCATION 1)
 +
-+  try_compile_src("placement_new_and_delete" "cpp"
-+    "
++    try_compile_src(
++        "placement_new_and_delete"
++        "cpp"
++        "
 +      #include <stdlib.h>
 +      class UMemory {
 +      public:
@@ -1777,53 +1781,55 @@ index 0000000000..710875729f
 +      void operator delete(void *, void *) {}
 +      };
 +    "
-+    ""
-+    ""
-+    ""
-+    _OVERRIDE_PLACEMENT_NEW_OK
-+  )
-+  if(_OVERRIDE_PLACEMENT_NEW_OK)
-+    set(U_HAVE_PLACEMENT_NEW 1)
-+  else()
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_PLACEMENT_NEW=0)
-+  endif()
-+  check_message("for placement new and delete" ${_OVERRIDE_PLACEMENT_NEW_OK})
++        ""
++        ""
++        ""
++        _OVERRIDE_PLACEMENT_NEW_OK
++    )
++    if(_OVERRIDE_PLACEMENT_NEW_OK)
++        set(U_HAVE_PLACEMENT_NEW 1)
++    else()
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_PLACEMENT_NEW=0)
++    endif()
++    check_message("for placement new and delete" ${_OVERRIDE_PLACEMENT_NEW_OK})
 +else()
-+  list(APPEND CONFIG_CPPFLAGS U_OVERRIDE_CXX_ALLOCATION=0)
++    list(APPEND CONFIG_CPPFLAGS U_OVERRIDE_CXX_ALLOCATION=0)
 +endif()
 +
 +check_symbol_exists("popen" "stdio.h" _HAVE_POPEN)
 +if(_HAVE_POPEN)
-+  set(HAVE_POPEN 1)
-+  set(U_HAVE_POPEN 1)
++    set(HAVE_POPEN 1)
++    set(U_HAVE_POPEN 1)
 +else()
-+  set(HAVE_POPEN 0)
-+  set(U_HAVE_POPEN 0)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_POPEN=0)
++    set(HAVE_POPEN 0)
++    set(U_HAVE_POPEN 0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_POPEN=0)
 +endif()
 +
 +check_symbol_exists("tzset" "time.h" _HAVE_TZSET)
 +set(U_HAVE_TZSET 0)
 +if(_HAVE_TZSET)
-+  set(HAVE_TZSET 1)
-+  set(U_TZSET tzset)
-+  set(U_HAVE_TZSET 1)
-+else()
-+  set(HAVE_TZSET 0)
-+  check_symbol_exists("_tzset" "time.h" _HAVE__TZSET)
-+  if(_HAVE__TZSET)
-+    set(HAVE__TZSET 1)
-+    set(U_TZSET _tzset)
++    set(HAVE_TZSET 1)
++    set(U_TZSET tzset)
 +    set(U_HAVE_TZSET 1)
-+  else()
-+    set(HAVE__TZSET 0)
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_TZSET=0)
-+  endif()
++else()
++    set(HAVE_TZSET 0)
++    check_symbol_exists("_tzset" "time.h" _HAVE__TZSET)
++    if(_HAVE__TZSET)
++        set(HAVE__TZSET 1)
++        set(U_TZSET _tzset)
++        set(U_HAVE_TZSET 1)
++    else()
++        set(HAVE__TZSET 0)
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_TZSET=0)
++    endif()
 +endif()
 +
 +set(U_HAVE_TZNAME 0)
-+try_compile_src("for_tzname" "c"
-+  "
++try_compile_src(
++    "for_tzname"
++    "c"
++    "
 +    #ifndef _XOPEN_SOURCE
 +    #define _XOPEN_SOURCE
 +    #endif
@@ -1833,322 +1839,349 @@ index 0000000000..710875729f
 +    extern char *tzname[]; /* RS6000 and others reject char **tzname.  */
 +    #endif
 +  "
-+  "atoi(*tzname);"
-+  ""
-+  ""
-+  _TZNAME
++    "atoi(*tzname);"
++    ""
++    ""
++    _TZNAME
 +)
 +if(_TZNAME)
-+  set(U_TZNAME tzname)
-+  set(U_HAVE_TZNAME 1)
++    set(U_TZNAME tzname)
++    set(U_HAVE_TZNAME 1)
 +else()
-+  try_compile_src("for__tzname" "c"
-+    "
++    try_compile_src(
++        "for__tzname"
++        "c"
++        "
 +      #include <stdlib.h>
 +      #include <time.h>
 +      extern char *_tzname[];
 +    "
-+    "atoi(*_tzname);"
-+    ""
-+    ""
-+    __TZNAME
-+  )
-+  if(__TZNAME)
-+    set(U_TZNAME _tzname)
-+    set(U_HAVE_TZNAME 1)
-+    list(APPEND CONFIG_CPPFLAGS U_TZNAME=${U_TZNAME})
-+  else()
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_TZNAME=0)
-+  endif()
++        "atoi(*_tzname);"
++        ""
++        ""
++        __TZNAME
++    )
++    if(__TZNAME)
++        set(U_TZNAME _tzname)
++        set(U_HAVE_TZNAME 1)
++        list(APPEND CONFIG_CPPFLAGS U_TZNAME=${U_TZNAME})
++    else()
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_TZNAME=0)
++    endif()
 +endif()
 +
-+try_compile_src("for_timezone" "c"
-+  "
++try_compile_src(
++    "for_timezone"
++    "c"
++    "
 +    #ifndef _XOPEN_SOURCE
 +    #define _XOPEN_SOURCE
 +    #endif
 +    #include <time.h>
 +  "
-+  "timezone = 1;"
-+  ""
-+  ""
-+  _TIMEZONE
++    "timezone = 1;"
++    ""
++    ""
++    _TIMEZONE
 +)
 +set(U_HAVE_TIMEZONE 0)
 +if(_TIMEZONE)
-+  set(U_TIMEZONE timezone)
-+  set(U_HAVE_TIMEZONE 1)
-+else()
-+  try_compile_src("for___timezone" "c"
-+    "#include <time.h>"
-+    "__timezone = 1;"
-+    ""
-+    ""
-+    ___TIMEZONE
-+  )
-+  if(___TIMEZONE)
-+    set(U_TIMEZONE __timezone)
++    set(U_TIMEZONE timezone)
 +    set(U_HAVE_TIMEZONE 1)
-+  else()
-+    try_compile_src("for__timezone" "c"
-+      "#include <time.h>"
-+      "_timezone = 1;"
-+      ""
-+      ""
-+      __TIMEZONE
++else()
++    try_compile_src(
++        "for___timezone"
++        "c"
++        "#include <time.h>"
++        "__timezone = 1;"
++        ""
++        ""
++        ___TIMEZONE
 +    )
-+    if(__TIMEZONE)
-+      set(U_TIMEZONE _timezone)
-+      set(U_HAVE_TIMEZONE 1)
++    if(___TIMEZONE)
++        set(U_TIMEZONE __timezone)
++        set(U_HAVE_TIMEZONE 1)
 +    else()
-+      list(APPEND CONFIG_CPPFLAGS U_HAVE_TIMEZONE=0)
++        try_compile_src(
++            "for__timezone"
++            "c"
++            "#include <time.h>"
++            "_timezone = 1;"
++            ""
++            ""
++            __TIMEZONE
++        )
++        if(__TIMEZONE)
++            set(U_TIMEZONE _timezone)
++            set(U_HAVE_TIMEZONE 1)
++        else()
++            list(APPEND CONFIG_CPPFLAGS U_HAVE_TIMEZONE=0)
++        endif()
 +    endif()
-+  endif()
 +endif()
 +
 +check_symbol_exists("strtod_l" "stdlib.h" _HAVE_STRTOD_L)
 +if(_HAVE_STRTOD_L)
-+  set(HAVE_STRTOD_L 1)
-+  set(U_HAVE_STRTOD_L 1)
-+  if(NOT ANDROID)
-+    # Symbols "freelocale" and "LC_ALL_MASK" are not defined
-+    # in Android with "xlocale.h".
-+    check_include_file("xlocale.h" _HAVE_XLOCALE_H)
-+  endif()
-+  if(_HAVE_XLOCALE_H)
-+    set(HAVE_XLOCALE_H 1)
-+    set(U_HAVE_XLOCALE_H 1)
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=1 U_HAVE_XLOCALE_H=1)
-+  else()
-+    set(HAVE_XLOCALE_H 0)
-+    set(U_HAVE_XLOCALE_H 0)
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=1 U_HAVE_XLOCALE_H=0)
-+  endif()
++    set(HAVE_STRTOD_L 1)
++    set(U_HAVE_STRTOD_L 1)
++    if(NOT ANDROID)
++        # Symbols "freelocale" and "LC_ALL_MASK" are not defined in Android with "xlocale.h".
++        check_include_file("xlocale.h" _HAVE_XLOCALE_H)
++    endif()
++    if(_HAVE_XLOCALE_H)
++        set(HAVE_XLOCALE_H 1)
++        set(U_HAVE_XLOCALE_H 1)
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=1 U_HAVE_XLOCALE_H=1)
++    else()
++        set(HAVE_XLOCALE_H 0)
++        set(U_HAVE_XLOCALE_H 0)
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=1 U_HAVE_XLOCALE_H=0)
++    endif()
 +else()
-+  set(HAVE_STRTOD_L 0)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=0)
-+  set(U_HAVE_STRTOD_L 0)
++    set(HAVE_STRTOD_L 0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_STRTOD_L=0)
++    set(U_HAVE_STRTOD_L 0)
 +endif()
 +
 +# Checks for typedefs
-+check_type_size("int8_t"   TYPE_int8_t   LANGUAGE CXX)
-+check_type_size("uint8_t"  TYPE_uint8_t  LANGUAGE CXX)
-+check_type_size("int16_t"  TYPE_int16_t  LANGUAGE CXX)
++check_type_size("int8_t" TYPE_int8_t LANGUAGE CXX)
++check_type_size("uint8_t" TYPE_uint8_t LANGUAGE CXX)
++check_type_size("int16_t" TYPE_int16_t LANGUAGE CXX)
 +check_type_size("uint16_t" TYPE_uint16_t LANGUAGE CXX)
-+check_type_size("int32_t"  TYPE_int32_t  LANGUAGE CXX)
++check_type_size("int32_t" TYPE_int32_t LANGUAGE CXX)
 +check_type_size("uint32_t" TYPE_uint32_t LANGUAGE CXX)
-+check_type_size("int64_t"  TYPE_int64_t  LANGUAGE CXX)
++check_type_size("int64_t" TYPE_int64_t LANGUAGE CXX)
 +check_type_size("uint64_t" TYPE_uint64_t LANGUAGE CXX)
 +
 +if(NOT HAVE_TYPE_int8_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_INT8_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_INT8_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_uint8_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT8_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT8_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_int16_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_INT16_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_INT16_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_uint16_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT16_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT16_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_int32_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_INT32_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_INT32_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_uint32_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT32_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT32_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_int64_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_INT64_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_INT64_T=0)
 +endif()
 +
 +if(NOT HAVE_TYPE_uint64_t)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT64_T=0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_UINT64_T=0)
 +endif()
 +
 +# Do various wchar_t related checks
 +option(ICU_USE_WCS_OR_W_LIB "Compile with 'wxs' or 'w' libraries." ON)
 +check_include_file("wchar.h" _HAVE_WCHAR_H)
 +if(_HAVE_WCHAR_H)
-+  set(HAVE_WCHAR_H 1)
-+  set(U_HAVE_WCHAR_H 1)
-+  set(wcs_w_lib "")
-+  if(ICU_USE_WCS_OR_W_LIB)
-+    set(wcs_w_lib "" wcs w)
-+  endif()
-+  foreach(lib ${wcs_w_lib})
-+    if(lib)
-+      find_library(HAVE_LIB_${lib} NAMES ${lib})
-+      if(NOT HAVE_LIB_${lib})
-+        continue()
-+      endif()
-+    else()
-+      set(HAVE_LIB_${lib} "")
++    set(HAVE_WCHAR_H 1)
++    set(U_HAVE_WCHAR_H 1)
++    set(wcs_w_lib "")
++    if(ICU_USE_WCS_OR_W_LIB)
++        set(wcs_w_lib "" wcs w)
 +    endif()
-+    try_compile_src("for_timezone" "c"
-+      "
++    foreach(lib ${wcs_w_lib})
++        if(lib)
++            find_library(HAVE_LIB_${lib} NAMES ${lib})
++            if(NOT HAVE_LIB_${lib})
++                continue()
++            endif()
++        else()
++            set(HAVE_LIB_${lib} "")
++        endif()
++        try_compile_src(
++            "for_timezone"
++            "c"
++            "
 +        #define HAVE_WCHAR_H 1
 +        #include <wchar.h>
 +      "
-+      "
++            "
 +        wchar_t *src = (void*) 0;
 +        wchar_t *dst = (void*) 0;
 +        wcscpy(dst, src);
 +      "
-+      ""
-+      "${HAVE_LIB_${lib}}"
-+      _HAVE_WCSCPY
-+    )
++            ""
++            "${HAVE_LIB_${lib}}"
++            _HAVE_WCSCPY
++        )
++        if(_HAVE_WCSCPY)
++            if(${HAVE_LIB_${lib}})
++                list(INSERT LIBS 0 ${HAVE_LIB_${lib}})
++            endif()
++            break()
++        endif()
++    endforeach()
 +    if(_HAVE_WCSCPY)
-+      if(${HAVE_LIB_${lib}})
-+        list(INSERT LIBS 0 ${HAVE_LIB_${lib}})
-+      endif()
-+      break()
++        set(HAVE_WCSCPY 1)
++        set(U_HAVE_WCSCPY 1)
++    else()
++        set(HAVE_WCSCPY 0)
++        set(U_HAVE_WCSCPY 0)
++        list(APPEND CONFIG_CPPFLAGS U_HAVE_WCSCPY=0)
 +    endif()
-+  endforeach()
-+  if(_HAVE_WCSCPY)
-+    set(HAVE_WCSCPY 1)
-+    set(U_HAVE_WCSCPY 1)
-+  else()
-+    set(HAVE_WCSCPY 0)
-+    set(U_HAVE_WCSCPY 0)
-+    list(APPEND CONFIG_CPPFLAGS U_HAVE_WCSCPY=0)
-+  endif()
 +else()
-+  set(HAVE_WCHAR_H 0)
-+  set(HAVE_WCSCPY 0)
-+  set(U_HAVE_WCHAR_H 0)
-+  set(U_HAVE_WCSCPY 0)
-+  list(APPEND CONFIG_CPPFLAGS U_HAVE_WCHAR_H=0 U_HAVE_WCSCPY=0)
++    set(HAVE_WCHAR_H 0)
++    set(HAVE_WCSCPY 0)
++    set(U_HAVE_WCHAR_H 0)
++    set(U_HAVE_WCSCPY 0)
++    list(APPEND CONFIG_CPPFLAGS U_HAVE_WCHAR_H=0 U_HAVE_WCSCPY=0)
 +endif()
 +
-+get_property(DIR_DEFS DIRECTORY PROPERTY COMPILE_DEFINITIONS)
++get_property(
++    DIR_DEFS
++    DIRECTORY
++    PROPERTY COMPILE_DEFINITIONS
++)
 +foreach(def ${DIR_DEFS})
-+  if(def MATCHES "STDC_HEADERS=1")
-+    set(HAVE_STDC_HEADERS 1)
-+    break()
-+  endif()
++    if(def MATCHES "STDC_HEADERS=1")
++        set(HAVE_STDC_HEADERS 1)
++        break()
++    endif()
 +endforeach()
-+set(CMAKE_EXTRA_INCLUDE_FILES)  # var is to check_type_size()
++set(CMAKE_EXTRA_INCLUDE_FILES) # var is to check_type_size()
 +if(HAVE_STDC_HEADERS)
-+  list(APPEND CMAKE_EXTRA_INCLUDE_FILES stddef.h)
++    list(APPEND CMAKE_EXTRA_INCLUDE_FILES stddef.h)
 +endif()
 +if(HAVE_WCHAR_H)
-+  list(APPEND CMAKE_EXTRA_INCLUDE_FILES string.h wchar.h)
++    list(APPEND CMAKE_EXTRA_INCLUDE_FILES string.h wchar.h)
 +endif()
 +check_type_size("wchar_t" WCHAR_T_SIZE LANGUAGE CXX)
 +# We do this check to verify that everything is okay.
 +if(WCHAR_T_SIZE STREQUAL "" AND U_HAVE_WCHAR_H)
-+  error_message("There is wchar.h but the size of wchar_t is empty")
++    error_message("There is wchar.h but the size of wchar_t is empty")
 +endif()
 +if(WCHAR_T_SIZE EQUAL 0)
-+  # TODO: set(U_SIZEOF_WCHAR_T ${WCHAR_T_SIZE}-${KEY}), see CMake docs for CheckTypeSize.
-+  error_message(
-+    "TODO: WCHAR_T_SIZE == 0 with CMAKE_OSX_ARCHITECTURES, see CMake docs for CheckTypeSize."
-+  )
++    # TODO: set(U_SIZEOF_WCHAR_T ${WCHAR_T_SIZE}-${KEY}), see CMake docs for CheckTypeSize.
++    error_message(
++        "TODO: WCHAR_T_SIZE == 0 with CMAKE_OSX_ARCHITECTURES, see CMake docs for CheckTypeSize."
++    )
 +endif()
 +set(U_SIZEOF_WCHAR_T ${WCHAR_T_SIZE})
 +
 +set(U_CHECK_UTF16_STRING 1)
 +set(CHECK_UTF16_STRING_RESULT "unknown")
 +if(CMAKE_C_STANDARD EQUAL 99 OR CMAKE_C_STANDARD GREATER 10)
-+  set(U_CHECK_UTF16_STRING 1)
-+  set(CHECK_UTF16_STRING_RESULT "C only")
++    set(U_CHECK_UTF16_STRING 1)
++    set(CHECK_UTF16_STRING_RESULT "C only")
 +else()
-+  set(U_CHECK_UTF16_STRING 0)
++    set(U_CHECK_UTF16_STRING 0)
 +endif()
 +if(NOT CMAKE_CXX_STANDARD EQUAL 98 AND CMAKE_CXX_STANDARD GREATER 10)
-+  set(U_CHECK_UTF16_STRING 1)
-+  if(CHECK_UTF16_STRING_RESULT STREQUAL "C only")
-+    set(CHECK_UTF16_STRING_RESULT "available")
-+  else()
-+    set(CHECK_UTF16_STRING_RESULT "C++ only")
-+  endif()
++    set(U_CHECK_UTF16_STRING 1)
++    if(CHECK_UTF16_STRING_RESULT STREQUAL "C only")
++        set(CHECK_UTF16_STRING_RESULT "available")
++    else()
++        set(CHECK_UTF16_STRING_RESULT "C++ only")
++    endif()
 +else()
-+  set(U_CHECK_UTF16_STRING 0)
++    set(U_CHECK_UTF16_STRING 0)
 +endif()
 +status_message("for UTF-16 string literal support  ${CHECK_UTF16_STRING_RESULT}")
 +
 +# Enable/disable extras
 +option(ICU_ENABLE_EXTRAS "Build ICU extras" ON)
-+ICU_CONDITIONAL(EXTRAS ICU_ENABLE_EXTRAS)
++icu_conditional(EXTRAS ICU_ENABLE_EXTRAS)
 +
 +option(ICU_ENABLE_ICUIO "Build ICU's icuio library" ON)
-+ICU_CONDITIONAL(ICUIO ICU_ENABLE_ICUIO)
++icu_conditional(ICUIO ICU_ENABLE_ICUIO)
 +
 +# Enable/disable layoutex
-+option(ICU_ENABLE_LAYOUTEX
-+  "Build ICU's Paragraph Layout library. icu-le-hb must be available via find_package(icu-le-hb). See http://harfbuzz.org"
-+  ${HAVE_ICU_LE_HB}
++option(
++    ICU_ENABLE_LAYOUTEX
++    "Build ICU's Paragraph Layout library. icu-le-hb must be available via find_package(icu-le-hb). See http://harfbuzz.org"
++    ${HAVE_ICU_LE_HB}
 +)
 +# TODO: remove it when find_package(icu-le-hb).
 +if(ICU_ENABLE_LAYOUTEX)
-+  error_message("TODO: find_package(icu-le-hb), see: http://userguide.icu-project.org/layoutengine/paragraph. Now please set ICU_ENABLE_LAYOUTEX=OFF")
++    error_message(
++        "TODO: find_package(icu-le-hb), see: http://userguide.icu-project.org/layoutengine/paragraph. Now please set ICU_ENABLE_LAYOUTEX=OFF"
++    )
 +endif()
-+ICU_CONDITIONAL(LAYOUTEX ICU_ENABLE_LAYOUTEX)
++icu_conditional(LAYOUTEX ICU_ENABLE_LAYOUTEX)
 +
 +# Enable/disable layout
 +option(ICU_ENABLE_LAYOUT "..." OFF)
 +if(ICU_ENABLE_LAYOUT)
-+  error_message("The ICU Layout Engine has been removed. Please set ICU_ENABLE_LAYOUT=OFF")
++    error_message("The ICU Layout Engine has been removed. Please set ICU_ENABLE_LAYOUT=OFF")
 +endif()
 +
 +# Enable/disable tools
 +option(ICU_ENABLE_TOOLS "Build ICU's tools" ON)
-+if(IOS OR ANDROID OR WINDOWS_STORE)
-+  set(ICU_CROSS_BUILDROOT OFF CACHE BOOL "Build ICU's tools" FORCE)
-+endif()
-+ICU_CONDITIONAL(TOOLS ICU_ENABLE_TOOLS)
-+
-+#ICU_DATA_PACKAGING     specify how to package ICU data. Possible values:
-+#  files    raw files (.res, etc)
-+#  archive  build a single icudtXX.dat file
-+#  library  shared library (.dll/.so/etc.)
-+#  static   static library (.a/.lib/etc.)
-+#  auto     build shared if possible (default)
-+#     See http://userguide.icu-project.org/icudata for more info.
-+set(ICU_DATA_PACKAGING "auto" CACHE STRING
-+  "Specify how to package ICU data. Possible values: files, archive, library, static, auto. See http://userguide.icu-project.org/icudata for more info"
++if(IOS
++   OR ANDROID
++   OR WINDOWS_STORE
 +)
-+if(IOS OR ANDROID OR WINDOWS_STORE)
-+  # Support only archive mode for these platforms.
-+  set(ICU_DATA_PACKAGING "archive" CACHE STRING
-+    "Specify how to package ICU data. Possible values: files, archive, library, static, auto. See http://userguide.icu-project.org/icudata for more info"
-+    FORCE
-+  )
++    set(ICU_CROSS_BUILDROOT
++        OFF
++        CACHE BOOL "Build ICU's tools" FORCE
++    )
++endif()
++icu_conditional(TOOLS ICU_ENABLE_TOOLS)
++
++# ICU_DATA_PACKAGING     specify how to package ICU data. Possible values: files    raw files (.res, etc)
++# archive  build a single icudtXX.dat file library  shared library (.dll/.so/etc.) static   static
++# library (.a/.lib/etc.) auto     build shared if possible (default) See
++# http://userguide.icu-project.org/icudata for more info.
++set(ICU_DATA_PACKAGING
++    "auto"
++    CACHE
++        STRING
++        "Specify how to package ICU data. Possible values: files, archive, library, static, auto. See http://userguide.icu-project.org/icudata for more info"
++)
++if(IOS
++   OR ANDROID
++   OR WINDOWS_STORE
++)
++    # Support only archive mode for these platforms.
++    set(ICU_DATA_PACKAGING
++        "archive"
++        CACHE
++            STRING
++            "Specify how to package ICU data. Possible values: files, archive, library, static, auto. See http://userguide.icu-project.org/icudata for more info"
++            FORCE
++    )
 +endif()
 +
 +if(ICU_DATA_PACKAGING STREQUAL "files"
-+    OR ICU_DATA_PACKAGING STREQUAL "archive"
-+    OR ICU_DATA_PACKAGING STREQUAL "library"
-+    OR ICU_DATA_PACKAGING STREQUAL "static"
-+    OR ICU_DATA_PACKAGING STREQUAL "auto")
-+  set(datapackaging ${ICU_DATA_PACKAGING})
++   OR ICU_DATA_PACKAGING STREQUAL "archive"
++   OR ICU_DATA_PACKAGING STREQUAL "library"
++   OR ICU_DATA_PACKAGING STREQUAL "static"
++   OR ICU_DATA_PACKAGING STREQUAL "auto"
++)
++    set(datapackaging ${ICU_DATA_PACKAGING})
 +elseif(ICU_DATA_PACKAGING STREQUAL "common")
-+  set(datapackaging "archive")
++    set(datapackaging "archive")
 +elseif(ICU_DATA_PACKAGING STREQUAL "dll")
-+  set(datapackaging "library")
++    set(datapackaging "library")
 +else()
-+  error_message("Bad value ${ICU_DATA_PACKAGING} for ICU_DATA_PACKAGING")
++    error_message("Bad value ${ICU_DATA_PACKAGING} for ICU_DATA_PACKAGING")
 +endif()
 +
-+# TODO:
-+# Always put raw data files in share/icu/{version}, etc.
-+# Never use lib/icu/{version} for data files..
-+# Actual shared libraries will go in {libdir}.
++# TODO: Always put raw data files in share/icu/{version}, etc. Never use lib/icu/{version} for data
++# files.. Actual shared libraries will go in {libdir}.
 +
 +if(datapackaging STREQUAL "auto")
-+  # default to library
-+  set(datapackaging "library")
-+  if(ICU_ENABLE_STATIC AND NOT ICU_ENABLE_SHARED)
-+    set(datapackaging "static")
-+  endif()
++    # default to library
++    set(datapackaging "library")
++    if(ICU_ENABLE_STATIC AND NOT ICU_ENABLE_SHARED)
++        set(datapackaging "static")
++    endif()
 +endif()
 +
 +# TODO: datapackaging_dir=`eval echo $thedatadir`"/icu/${VERSION}"
@@ -2157,119 +2190,108 @@ index 0000000000..710875729f
 +set(datapackaging_msg "(No explanation for mode ${datapackaging}.)")
 +
 +set(datapackaging_msg_path
-+  "ICU will look in ${datapackaging_dir} which is the installation location. Call u_setDataDirectory() or use the ICU_DATA environment variable to override."
++    "ICU will look in ${datapackaging_dir} which is the installation location. Call u_setDataDirectory() or use the ICU_DATA environment variable to override."
 +)
 +set(datapackaging_msg_set
-+  "ICU will use the linked data library. If linked with the stub library located in stubdata/, the application can use udata_setCommonData() or set a data path to override."
++    "ICU will use the linked data library. If linked with the stub library located in stubdata/, the application can use udata_setCommonData() or set a data path to override."
 +)
 +set(datapackaging_howfound "(unknown)")
 +
 +if(datapackaging STREQUAL "files")
-+  set(DATA_PACKAGING_MODE "files")
-+  set(datapackaging_msg "ICU data will be stored in individual files.")
-+  set(datapackaging_howfound "${datapackaging_msg_path}")
++    set(DATA_PACKAGING_MODE "files")
++    set(datapackaging_msg "ICU data will be stored in individual files.")
++    set(datapackaging_howfound "${datapackaging_msg_path}")
 +elseif(datapackaging STREQUAL "archive")
-+  set(DATA_PACKAGING_MODE "common")
-+  set(datapackaging_msg "ICU data will be stored in a single .dat file.")
-+  set(datapackaging_howfound "${datapackaging_msg_path}")
++    set(DATA_PACKAGING_MODE "common")
++    set(datapackaging_msg "ICU data will be stored in a single .dat file.")
++    set(datapackaging_howfound "${datapackaging_msg_path}")
 +elseif(datapackaging STREQUAL "library")
 +    set(DATA_PACKAGING_MODE "dll")
 +    set(datapackaging_msg "ICU data will be linked with ICU.")
 +    if(ICU_ENABLE_STATIC)
-+      set(datapackaging_msg "${datapackaging_msg} A static data library will be built. ")
++        set(datapackaging_msg "${datapackaging_msg} A static data library will be built. ")
 +    endif()
 +    if(ICU_ENABLE_SHARED)
-+      set(datapackaging_msg "${datapackaging_msg} A shared data library will be built. ")
++        set(datapackaging_msg "${datapackaging_msg} A shared data library will be built. ")
 +    endif()
 +    set(datapackaging_howfound "${datapackaging_msg_set}")
 +elseif(datapackaging STREQUAL "static")
-+  set(DATA_PACKAGING_MODE "static")
-+  set(datapackaging_msg "ICU data will be stored in a static library.")
-+  set(datapackaging_howfound "${datapackaging_msg_set}")
++    set(DATA_PACKAGING_MODE "static")
++    set(datapackaging_msg "ICU data will be stored in a static library.")
++    set(datapackaging_howfound "${datapackaging_msg_set}")
 +endif()
 +
 +# Sets a library suffix
-+set(ICU_LIBRARY_SUFFIX "" CACHE STRING "Tag a suffix to the library names")
++set(ICU_LIBRARY_SUFFIX
++    ""
++    CACHE STRING "Tag a suffix to the library names"
++)
 +set(ICULIBSUFFIX ${ICU_LIBRARY_SUFFIX})
 +if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-+  set(ICULIBSUFFIX "${ICULIBSUFFIX}$<$<CONFIG:Debug>:d>")
++    set(ICULIBSUFFIX "${ICULIBSUFFIX}$<$<CONFIG:Debug>:d>")
 +endif()
 +set(msg ${ICULIBSUFFIX})
 +if(NOT msg)
-+  set(msg "none")
++    set(msg "none")
 +endif()
 +status_message("for a library suffix to use  ${msg}")
 +if(ICULIBSUFFIX)
-+  if(NOT ICULIBSUFFIX MATCHES "[A-Za-z0-9_]+")
-+    error_message("Suffix must contain only [A-Za-z0-9_] symbols.")
-+  endif()
-+  set(U_HAVE_LIB_SUFFIX 1)
-+  #set(ICULIBSUFFIXCNAME=`echo _$ICULIBSUFFIX | sed 's/[^A-Za-z0-9_]/_/g'`)
-+  set(ICULIBSUFFIXCNAME _${ICULIBSUFFIX})
-+  list(APPEND UCONFIG_CPPFLAGS
-+    U_HAVE_LIB_SUFFIX=1 U_LIB_SUFFIX_C_NAME=\"${ICULIBSUFFIXCNAME}\"
-+  )
++    if(NOT ICULIBSUFFIX MATCHES "[A-Za-z0-9_]+")
++        error_message("Suffix must contain only [A-Za-z0-9_] symbols.")
++    endif()
++    set(U_HAVE_LIB_SUFFIX 1)
++    # set(ICULIBSUFFIXCNAME=`echo _$ICULIBSUFFIX | sed 's/[^A-Za-z0-9_]/_/g'`)
++    set(ICULIBSUFFIXCNAME _${ICULIBSUFFIX})
++    list(APPEND UCONFIG_CPPFLAGS U_HAVE_LIB_SUFFIX=1 U_LIB_SUFFIX_C_NAME=\"${ICULIBSUFFIXCNAME}\")
 +else()
-+  set(U_HAVE_LIB_SUFFIX 0)
-+  set(ICULIBSUFFIXCNAME "")
++    set(U_HAVE_LIB_SUFFIX 0)
++    set(ICULIBSUFFIXCNAME "")
 +endif()
 +
 +# Enable/disable tests
 +option(ICU_ENABLE_TESTS "Build ICU tests" ON)
-+ICU_CONDITIONAL(TESTS ICU_ENABLE_TESTS)
++icu_conditional(TESTS ICU_ENABLE_TESTS)
 +
-+# Enable/disable samples
-+# Additionally, the variable FORCE_LIBS may be set before calling configure.
-+# If set, it will REPLACE any automatic list of libraries.
++# Enable/disable samples Additionally, the variable FORCE_LIBS may be set before calling configure. If
++# set, it will REPLACE any automatic list of libraries.
 +option(ICU_ENABLE_SAMPLES "Build ICU samples" ON)
-+ICU_CONDITIONAL(SAMPLES ICU_ENABLE_SAMPLES)
++icu_conditional(SAMPLES ICU_ENABLE_SAMPLES)
 +
 +set(ICUDATA_CHAR ${U_ENDIAN_CHAR})
-+#if(WIN32)  # From source/data/makedata.mak  # TODO: need it?
-+#  set(ICUDATA_CHAR "l")
-+#endif()
++# if(WIN32)  # From source/data/makedata.mak  # TODO: need it? set(ICUDATA_CHAR "l") endif()
 +
-+# TODO:
-+# Platform-specific Makefile setup
-+# set ICUDATA_CHAR to 'e' for any EBCDIC (which should be big endian) platform.
-+#if(<platform> EQUAL <...> AND NOT ICU_ENABLE_ASCII_STRINGS STREQUAL "1")
-+#  set(ICUDATA_CHAR "e")
-+#endif()
++# TODO: Platform-specific Makefile setup set ICUDATA_CHAR to 'e' for any EBCDIC (which should be big
++# endian) platform. if(<platform> EQUAL <...> AND NOT ICU_ENABLE_ASCII_STRINGS STREQUAL "1")
++# set(ICUDATA_CHAR "e") endif()
 +
 +if(FORCE_LIBS)
-+  status_message(
-+    " *** Overriding automatically chosen [LIBS=${LIBS}], using instead [FORCE_LIBS=${FORCE_LIBS}]"
-+  )
-+  set(LIBS ${FORCE_LIBS})
++    status_message(
++        " *** Overriding automatically chosen [LIBS=${LIBS}], using instead [FORCE_LIBS=${FORCE_LIBS}]"
++    )
++    set(LIBS ${FORCE_LIBS})
 +endif()
 +
 +# Now that we're done using CPPFLAGS etc. for tests, we can change it for build.
 +if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-+  list(APPEND CLANGCFLAGS -Qunused-arguments -Wno-parentheses-equality)
++    list(APPEND CLANGCFLAGS -Qunused-arguments -Wno-parentheses-equality)
 +else()
-+  set(CLANGCFLAGS "")
++    set(CLANGCFLAGS "")
 +endif()
 +if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-+  list(APPEND CLANGCXXFLAGS -Qunused-arguments -Wno-parentheses-equality)
++    list(APPEND CLANGCXXFLAGS -Qunused-arguments -Wno-parentheses-equality)
 +else()
-+  set(CLANGCXXFLAGS "")
++    set(CLANGCXXFLAGS "")
 +endif()
 +
 +list(APPEND CPPFLAGS ${THREADSCPPFLAGS})
-+list(APPEND CFLAGS   ${THREADSCFLAGS}   ${CLANGCFLAGS})
++list(APPEND CFLAGS ${THREADSCFLAGS} ${CLANGCFLAGS})
 +list(APPEND CXXFLAGS ${THREADSCXXFLAGS} ${CLANGCXXFLAGS})
 +
 +# append all config cppflags
 +list(APPEND CPPFLAGS ${CONFIG_CPPFLAGS} ${UCONFIG_CPPFLAGS})
 +
-+
-+
-+# icucommon
-+#  "-DDEFAULT_ICU_PLUGINS=\"/usr/local/lib/icu\" "
-+#list(APPEND CPPFLAGS _REENTRANT PIC)
-+#set(LDFLAGS "${LDFLAGS} -Wl,-Bsymbolic")
-+
-+
++# icucommon "-DDEFAULT_ICU_PLUGINS=\"/usr/local/lib/icu\" " list(APPEND CPPFLAGS _REENTRANT PIC)
++# set(LDFLAGS "${LDFLAGS} -Wl,-Bsymbolic")
 +
 +status_message("CPPFLAGS=${CPPFLAGS}")
 +status_message("CFLAGS=${CFLAGS}")
@@ -2286,10 +2308,10 @@ index 0000000000..710875729f
 +status_message(" To locate data: ${datapackaging_howfound}")
 +
 +if(UCONFIG_CPPFLAGS)
-+  set(HDRFILE_NAME "uconfig.h.prepend")
-+  set(HDRFILE "${PROJECT_BINARY_DIR}/config/uconfig.h.prepend")
-+  status_message(
-+    "
++    set(HDRFILE_NAME "uconfig.h.prepend")
++    set(HDRFILE "${PROJECT_BINARY_DIR}/config/uconfig.h.prepend")
++    status_message(
++        "
 +*** WARNING: You must set the following flags before code compiled against this ICU will function properly:
 +
 +   ${UCONFIG_CPPFLAGS}
@@ -2299,61 +2321,53 @@ index 0000000000..710875729f
 +
 +---------------   ${HDRFILE_NAME}
 +    "
-+  )
++    )
 +
-+  set(HDRFILE_TEXT
-+    "/* ICU customizations: put these lines at the top of uconfig.h */\n\n"
-+  )
-+  foreach(flag ${UCONFIG_CPPFLAGS})
-+    set(HDRFILE_TEXT "${HDRFILE_TEXT}/* $flag */")
-+    if(flag MATCHES ".*=.*")
-+      string(REGEX REPLACE "([^=]*)=(.*)" "#define \\1 \\2" _flag ${flag})
-+      set(HDRFILE_TEXT "${HDRFILE_TEXT}${_flag}\n")
-+    elseif(flag MATCHES ".*")
-+      string(REGEX REPLACE "([^=]*)(.*)" "#define \\1 \\2" _flag ${flag})
-+      set(HDRFILE_TEXT "${HDRFILE_TEXT}${_flag}\n")
-+#    elseif(flag MATCHES ".*")
-+#      set(HDRFILE_TEXT "${HDRFILE_TEXT} /*  Not sure how to handle this argument: ${flag} */\n")
-+    endif()
-+  endforeach()
-+  status_message(${HDRFILE_TEXT})
-+  set(HDRFILE_TEXT "${HDRFILE_TEXT}\n/* End of ${HDRFILE_NAME}*/\n")
-+  file(WRITE ${HDRFILE} ${HDRFILE_TEXT})
-+  status_message("--------------- end ${HDRFILE_NAME}")
++    set(HDRFILE_TEXT "/* ICU customizations: put these lines at the top of uconfig.h */\n\n")
++    foreach(flag ${UCONFIG_CPPFLAGS})
++        set(HDRFILE_TEXT "${HDRFILE_TEXT}/* $flag */")
++        if(flag MATCHES ".*=.*")
++            string(REGEX REPLACE "([^=]*)=(.*)" "#define \\1 \\2" _flag ${flag})
++            set(HDRFILE_TEXT "${HDRFILE_TEXT}${_flag}\n")
++        elseif(flag MATCHES ".*")
++            string(REGEX REPLACE "([^=]*)(.*)" "#define \\1 \\2" _flag ${flag})
++            set(HDRFILE_TEXT "${HDRFILE_TEXT}${_flag}\n")
++            # elseif(flag MATCHES ".*") set(HDRFILE_TEXT "${HDRFILE_TEXT} /*  Not sure how to handle this
++            # argument: ${flag} */\n")
++        endif()
++    endforeach()
++    status_message(${HDRFILE_TEXT})
++    set(HDRFILE_TEXT "${HDRFILE_TEXT}\n/* End of ${HDRFILE_NAME}*/\n")
++    file(WRITE ${HDRFILE} ${HDRFILE_TEXT})
++    status_message("--------------- end ${HDRFILE_NAME}")
 +endif()
 +
 +if(UCONFIG_CFLAGS)
-+  status_message(
-+    "C   apps may want to build with CFLAGS   = ${UCONFIG_CFLAGS}"
-+  )
++    status_message("C   apps may want to build with CFLAGS   = ${UCONFIG_CFLAGS}")
 +endif()
 +if(UCONFIG_CXXFLAGS)
-+  status_message(
-+    "C++ apps may want to build with CXXFLAGS = ${UCONFIG_CXXFLAGS}"
-+  )
++    status_message("C++ apps may want to build with CXXFLAGS = ${UCONFIG_CXXFLAGS}")
 +endif()
 +
 +if(NOT ICU_ENABLE_TOOLS)
-+  status_message(
-+    "## Note: you have disabled ICU's tools. This ICU cannot build its own data or tests."
-+  )
-+  status_message(
-+    "## Expect build failures in the 'data', 'test', and other directories."
-+  )
++    status_message(
++        "## Note: you have disabled ICU's tools. This ICU cannot build its own data or tests."
++    )
++    status_message("## Expect build failures in the 'data', 'test', and other directories.")
 +endif()
 diff --git a/source/data/CMakeLists.txt b/source/data/CMakeLists.txt
 new file mode 100644
-index 0000000000..210db80d64
+index 0000000000..5a1c4665b2
 --- /dev/null
 +++ b/source/data/CMakeLists.txt
-@@ -0,0 +1,358 @@
+@@ -0,0 +1,340 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
-+#############################################################################
++# #######################################################################################################
 +# Variables
-+#############################################################################
++# #######################################################################################################
 +
 +set(SRCDATADIR ${PROJECT_SOURCE_DIR}/data)
 +set(OUTDIR ${PROJECT_BINARY_DIR}/data/out)
@@ -2389,7 +2403,7 @@ index 0000000000..210db80d64
 +set(UCMBLDDIR ${BUILDDIR}/mappings)
 +set(SPREPSRCDIR ${SRCDATADIR}/sprep)
 +set(COMINCDIR ${PROJECT_SOURCE_DIR}/common/unicode)
-+#set(SRCLISTDEPS Makefile ${srcdir}/Makefile.in)
++# set(SRCLISTDEPS Makefile ${srcdir}/Makefile.in)
 +
 +set(OUT_DIR ${BUILDDIR})
 +set(TMP_DIR ${OUTTMPDIR})
@@ -2397,313 +2411,295 @@ index 0000000000..210db80d64
 +set(INDEX_NAME res_index)
 +
 +set(BUILD_DIRS
-+  ${OUTDIR} ${MAINBUILDDIR} ${BUILDDIR} ${CURRBLDDIR} ${LANGBLDDIR}
-+  ${REGIONBLDDIR} ${ZONEBLDDIR} ${UNITBLDDIR} ${BRKBLDDIR} ${COLBLDDIR}
-+  ${RBNFBLDDIR} ${TRANSLITBLDDIR} ${UCMBLDDIR}
-+  ${OUTTMPDIR} ${OUTTMPDIR_390STUB}
-+  ${OUTTMPDIR}/${CURR_TREE} ${OUTTMPDIR}/${LANG_TREE}
-+  ${OUTTMPDIR}/${REGION_TREE} ${OUTTMPDIR}/${ZONE_TREE}
-+  ${OUTTMPDIR}/${UNIT_TREE} ${OUTTMPDIR}/${COLLATION_TREE}
-+  ${OUTTMPDIR}/${RBNF_TREE} ${OUTTMPDIR}/${TRANSLIT_TREE}
-+  ${OUTTMPDIR}/${BREAK_TREE}
++    ${OUTDIR}
++    ${MAINBUILDDIR}
++    ${BUILDDIR}
++    ${CURRBLDDIR}
++    ${LANGBLDDIR}
++    ${REGIONBLDDIR}
++    ${ZONEBLDDIR}
++    ${UNITBLDDIR}
++    ${BRKBLDDIR}
++    ${COLBLDDIR}
++    ${RBNFBLDDIR}
++    ${TRANSLITBLDDIR}
++    ${UCMBLDDIR}
++    ${OUTTMPDIR}
++    ${OUTTMPDIR_390STUB}
++    ${OUTTMPDIR}/${CURR_TREE}
++    ${OUTTMPDIR}/${LANG_TREE}
++    ${OUTTMPDIR}/${REGION_TREE}
++    ${OUTTMPDIR}/${ZONE_TREE}
++    ${OUTTMPDIR}/${UNIT_TREE}
++    ${OUTTMPDIR}/${COLLATION_TREE}
++    ${OUTTMPDIR}/${RBNF_TREE}
++    ${OUTTMPDIR}/${TRANSLIT_TREE}
++    ${OUTTMPDIR}/${BREAK_TREE}
 +)
 +
 +# relative lib links from pkgdata are the same as for tmp
 +set(TOOLDIR ${PROJECT_BINARY_DIR}/tools)
 +
-+## MISC files
++# MISC files
 +set(PKGDATA_LIST ${OUTTMPDIR}/icudata.lst)
 +set(ICUPKG_INC ${PROJECT_BINARY_DIR}/data/icupkg.inc)
 +
 +# Allow Windows to override these options
 +if(MSVC)
-+  set(PKGDATA_OPTS
-+    -f  # --force-prefix
-+    -v  # --verbose
-+  )
-+
-+  if(WINDOWS_STORE)
-+    list(APPEND PKGDATA_OPTS
-+      -u  # --windows-uwp-build
++    set(PKGDATA_OPTS -f # --force-prefix
++                     -v # --verbose
 +    )
-+#    # TODO: for UWP ARM, see source/data/makedata.mak
-+#    if("$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug")
-+#      list(APPEND PKGDATA_OPTS
-+#        -a  # --windows-uwp-arm-build
-+#      )
-+#    endif()
-+  endif()
++
++    if(WINDOWS_STORE)
++        list(APPEND PKGDATA_OPTS -u # --windows-uwp-build
++        )
++        # # TODO: for UWP ARM, see source/data/makedata.mak if("$(CFG)" == "ARM\Release" || "$(CFG)" ==
++        # "ARM\Debug") list(APPEND PKGDATA_OPTS -a  # --windows-uwp-arm-build ) endif()
++    endif()
 +
 +else()
-+  set(PKGDATA_OPTS
-+    -O ${ICUPKG_INC}  # --bldopt
-+    -q  # --quiet
-+  )
++    set(PKGDATA_OPTS -O ${ICUPKG_INC} # --bldopt
++                     -q # --quiet
++    )
 +endif()
 +if(MSVC)
-+  set(PKGDATA_VERSIONING "")
++    set(PKGDATA_VERSIONING "")
 +else()
-+  set(PKGDATA_VERSIONING
-+    -r ${SO_TARGET_VERSION}  # --revision
-+  )
++    set(PKGDATA_VERSIONING -r ${SO_TARGET_VERSION} # --revision
++    )
 +endif()
 +
-+# This allows all the data to be in one directory
-+#if(PKGDATA_MODE STREQUAL "dll")
-+#  set(ICUPKGDATA_OUTDIR ${libdir})
-+#elseif(PKGDATA_MODE STREQUAL "static")
-+#  set(ICUPKGDATA_OUTDIR ${libdir})
-+#else()
-+#  set(ICUPKGDATA_OUTDIR ${OUTDIR})
-+#endif()
-+# We only interested in generated assembler file.
++# This allows all the data to be in one directory if(PKGDATA_MODE STREQUAL "dll") set(ICUPKGDATA_OUTDIR
++# ${libdir}) elseif(PKGDATA_MODE STREQUAL "static") set(ICUPKGDATA_OUTDIR ${libdir}) else()
++# set(ICUPKGDATA_OUTDIR ${OUTDIR}) endif() We only interested in generated assembler file.
 +set(ICUPKGDATA_OUTDIR ${OUTDIR})
 +
 +set(PKGDATA
-+  ${TOOLBINDIR}/pkgdata
-+  ${PKGDATA_OPTS}
-+  -c  # --copyright
-+  -s ${PROJECT_BINARY_DIR}/data/out/build/${ICUDATA_PLATFORM_NAME}  # --sourcedir
-+  -d ${ICUPKGDATA_OUTDIR}  # --destdir
++    ${TOOLBINDIR}/pkgdata
++    ${PKGDATA_OPTS}
++    -c # --copyright
++    -s
++    ${PROJECT_BINARY_DIR}/data/out/build/${ICUDATA_PLATFORM_NAME} # --sourcedir
++    -d
++    ${ICUPKGDATA_OUTDIR} # --destdir
 +)
 +
 +if(MSVC)
-+  set(ICUDATA_ASM_FILE ${OUTTMPDIR}/${ICUDATA_PLATFORM_NAME}_dat.obj)
++    set(ICUDATA_ASM_FILE ${OUTTMPDIR}/${ICUDATA_PLATFORM_NAME}_dat.obj)
 +else()
-+  set(ICUDATA_ASM_FILE ${OUTTMPDIR}/${ICUDATA_PLATFORM_NAME}_dat.S)
++    set(ICUDATA_ASM_FILE ${OUTTMPDIR}/${ICUDATA_PLATFORM_NAME}_dat.S)
 +endif()
 +
 +set(deps_icupkg "")
 +set(deps_pkgdata "")
 +if(NOT ICU_CROSS_COMPILING)
-+  set(deps_icupkg icupkg)
-+  set(deps_pkgdata pkgdata)
++    set(deps_icupkg icupkg)
++    set(deps_pkgdata pkgdata)
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# BUILD RULES
-+#############################################################################
++# #######################################################################################################
 +
-+#############################################################################
++# #######################################################################################################
 +# Make the build directories
-+#############################################################################
++# #######################################################################################################
 +
 +# build-dir:
 +file(MAKE_DIRECTORY ${BUILD_DIRS})
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Configure the options for pkgdata
-+#############################################################################
++# #######################################################################################################
 +
-+# We only interested in generated assembler file.
-+# Variables like compiler/ranlib/linker/... set to dummy echo commands
++# We only interested in generated assembler file. Variables like compiler/ranlib/linker/... set to dummy
++# echo commands
 +
-+# icupkg.inc: pkgdataMakefile
-+# See source/data/pkgdataMakefile.in
++# icupkg.inc: pkgdataMakefile See source/data/pkgdataMakefile.in
 +if(PKGDATA_MODE STREQUAL "dll" OR PKGDATA_MODE STREQUAL "static")
-+  configure_file(${CMAKE_CURRENT_LIST_DIR}/icupkg.inc.cmake ${ICUPKG_INC} @ONLY)
++    configure_file(${CMAKE_CURRENT_LIST_DIR}/icupkg.inc.cmake ${ICUPKG_INC} @ONLY)
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Find the data archive and convert it if need
-+#############################################################################
++# #######################################################################################################
 +
-+# Find out if we have a source archive.
-+# If we have that, then use that instead of building everything from scratch.
-+# Set in root CMakeLists.txt
++# Find out if we have a source archive. If we have that, then use that instead of building everything
++# from scratch. Set in root CMakeLists.txt
 +set(ICUDATA_SOURCE_ARCHIVE_FILE_NAME ${ICUDATA_PLATFORM_NAME}.dat)
-+set(ICUDATA_SOURCE_ARCHIVE
-+  ${CMAKE_CURRENT_LIST_DIR}/in/${ICUDATA_SOURCE_ARCHIVE_FILE_NAME}
-+)
++set(ICUDATA_SOURCE_ARCHIVE ${CMAKE_CURRENT_LIST_DIR}/in/${ICUDATA_SOURCE_ARCHIVE_FILE_NAME})
 +if(NOT EXISTS ${ICUDATA_SOURCE_ARCHIVE})
-+  set(ICUDATA_SOURCE_ARCHIVE "")
++    set(ICUDATA_SOURCE_ARCHIVE "")
 +endif()
 +if(NOT ICUDATA_SOURCE_ARCHIVE)
-+  file(GLOB ICUDATA_ARCHIVE_FILES LIST_DIRECTORIES false
-+     ${CMAKE_CURRENT_LIST_DIR}/in/${ICUDATA_BASENAME_VERSION}*.dat
-+  )
-+  list(GET ICUDATA_ARCHIVE_FILES 0 ICUDATA_ARCHIVE)
-+  # We don't have the data in the current endianess or charset.
-+  # See if we can find data of any archive type,
-+  # and convert it to the current type.
-+  if(ICUDATA_ARCHIVE)
-+    set(ICUDATA_SOURCE_ARCHIVE ${OUTDIR}/${ICUDATA_SOURCE_ARCHIVE_FILE_NAME})
-+    set(icudata_source_archive_STAMP "${OUTDIR}/icudata_source_archive_stamp")
-+
-+    add_custom_command(
-+      OUTPUT ${ICUDATA_SOURCE_ARCHIVE} ${icudata_source_archive_STAMP}
-+      COMMAND ${TOOLBINDIR}/icupkg
-+        -t${ICUDATA_CHAR}  # --type
-+        ${ICUDATA_ARCHIVE} ${ICUDATA_SOURCE_ARCHIVE}
-+      COMMAND ${CMAKE_COMMAND} -E touch ${icudata_source_archive_STAMP}
-+      DEPENDS ${deps_icupkg} ${ICUDATA_ARCHIVE} # ${OUTDIR}
-+      COMMENT
-+        "Convert ${ICUDATA_ARCHIVE} to ${ICUDATA_SOURCE_ARCHIVE}"
++    file(
++        GLOB ICUDATA_ARCHIVE_FILES
++        LIST_DIRECTORIES false
++        ${CMAKE_CURRENT_LIST_DIR}/in/${ICUDATA_BASENAME_VERSION}*.dat
 +    )
-+  endif()
-+else()
-+  if(NOT ENABLE_STATIC)
-+    if(PKGDATA_MODE STREQUAL "common")
-+      # We have a source data common archive in the native endianess,
-+      # and it's what we want to build. Try to not run any of ICU's tools.
-+      set(ICUDATA_SOURCE_IS_NATIVE_TARGET YES)
++    list(GET ICUDATA_ARCHIVE_FILES 0 ICUDATA_ARCHIVE)
++    # We don't have the data in the current endianess or charset. See if we can find data of any archive
++    # type, and convert it to the current type.
++    if(ICUDATA_ARCHIVE)
++        set(ICUDATA_SOURCE_ARCHIVE ${OUTDIR}/${ICUDATA_SOURCE_ARCHIVE_FILE_NAME})
++        set(icudata_source_archive_STAMP "${OUTDIR}/icudata_source_archive_stamp")
++
++        add_custom_command(
++            OUTPUT ${ICUDATA_SOURCE_ARCHIVE} ${icudata_source_archive_STAMP}
++            COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} # --type
++                    ${ICUDATA_ARCHIVE} ${ICUDATA_SOURCE_ARCHIVE}
++            COMMAND ${CMAKE_COMMAND} -E touch ${icudata_source_archive_STAMP}
++            DEPENDS ${deps_icupkg} ${ICUDATA_ARCHIVE} # ${OUTDIR}
++            COMMENT "Convert ${ICUDATA_ARCHIVE} to ${ICUDATA_SOURCE_ARCHIVE}"
++        )
 +    endif()
-+  endif()
++else()
++    if(NOT ENABLE_STATIC)
++        if(PKGDATA_MODE STREQUAL "common")
++            # We have a source data common archive in the native endianess, and it's what we want to
++            # build. Try to not run any of ICU's tools.
++            set(ICUDATA_SOURCE_IS_NATIVE_TARGET YES)
++        endif()
++    endif()
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Unpack the data archive and generate the list of data files
-+#############################################################################
++# #######################################################################################################
 +
 +if(CMAKE_HOST_WIN32 AND NOT (CMAKE_GENERATOR STREQUAL "MSYS Makefiles"))
-+  # protection not needed
-+  set(extract_pattern *)
++    # protection not needed
++    set(extract_pattern *)
 +else()
-+  set(extract_pattern \\*)
++    set(extract_pattern \\*)
 +endif()
 +
 +if(NOT ICUDATA_SOURCE_ARCHIVE)
-+  # TODO: data building from scratch.
-+#  error_message("TODO: data building from scratch is not support now.")
-+  include(${CMAKE_CURRENT_LIST_DIR}/rules.cmake)
++    # TODO: data building from scratch.
++    # error_message("TODO: data building from scratch is not support now.")
++    include(${CMAKE_CURRENT_LIST_DIR}/rules.cmake)
 +elseif(PKGDATA_MODE STREQUAL "dll" OR PKGDATA_MODE STREQUAL "static")
-+  #build-local: build-dir $(SO_VERSION_DATA) $(PKGDATA_LIST) $(OS390LIST)
-+  #${PKGDATA_LIST}: ${SRCLISTDEPS} ${ICUDATA_SOURCE_ARCHIVE}
-+  if(NOT ICUDATA_SOURCE_IS_NATIVE_TARGET)
-+    set(pkgdata_list_STAMP "${OUTDIR}/pkgdata_list_stamp")
++    # build-local: build-dir $(SO_VERSION_DATA) $(PKGDATA_LIST) $(OS390LIST) ${PKGDATA_LIST}:
++    # ${SRCLISTDEPS} ${ICUDATA_SOURCE_ARCHIVE}
++    if(NOT ICUDATA_SOURCE_IS_NATIVE_TARGET)
++        set(pkgdata_list_STAMP "${OUTDIR}/pkgdata_list_stamp")
 +
-+    add_custom_command(
-+      OUTPUT ${PKGDATA_LIST} ${pkgdata_list_STAMP}
-+      COMMAND ${CMAKE_COMMAND} -E remove -f ${PKGDATA_LIST}
-+      COMMAND ${TOOLBINDIR}/icupkg
-+        -d ${BUILDDIR}  # --destdir
-+        --list
-+        -x ${extract_pattern}  # --extract
-+        ${ICUDATA_SOURCE_ARCHIVE}
-+        -o ${PKGDATA_LIST}  # --outlist
-+      COMMAND ${CMAKE_COMMAND} -E touch ${pkgdata_list_STAMP}
-+      DEPENDS ${deps_icupkg} ${ICUDATA_SOURCE_ARCHIVE}
-+        ${icudata_source_archive_STAMP} # ${BUILD_DIRS}
-+      COMMENT
-+        "Unpacking ${ICUDATA_SOURCE_ARCHIVE} and generating ${PKGDATA_LIST} (list of data files)"
-+    )
-+  else()
-+    #@echo "${PKGDATA_LIST}" > ${PKGDATA_LIST}
-+    file(WRITE ${PKGDATA_LIST} ${PKGDATA_LIST})
-+  endif()
++        add_custom_command(
++            OUTPUT ${PKGDATA_LIST} ${pkgdata_list_STAMP}
++            COMMAND ${CMAKE_COMMAND} -E remove -f ${PKGDATA_LIST}
++            COMMAND
++                ${TOOLBINDIR}/icupkg -d ${BUILDDIR} # --destdir
++                --list -x ${extract_pattern} # --extract
++                ${ICUDATA_SOURCE_ARCHIVE} -o ${PKGDATA_LIST} # --outlist
++            COMMAND ${CMAKE_COMMAND} -E touch ${pkgdata_list_STAMP}
++            DEPENDS ${deps_icupkg} ${ICUDATA_SOURCE_ARCHIVE}
++                    ${icudata_source_archive_STAMP} # ${BUILD_DIRS}
++            COMMENT
++                "Unpacking ${ICUDATA_SOURCE_ARCHIVE} and generating ${PKGDATA_LIST} (list of data files)"
++        )
++    else()
++        # @echo "${PKGDATA_LIST}" > ${PKGDATA_LIST}
++        file(WRITE ${PKGDATA_LIST} ${PKGDATA_LIST})
++    endif()
 +endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Generate the assembler file
-+#############################################################################
++# #######################################################################################################
 +
-+# We only interested in generated assembler file.
-+# Variables like compiler/ranlib/linker/... set to dummy echo commands
++# We only interested in generated assembler file. Variables like compiler/ranlib/linker/... set to dummy
++# echo commands
 +
-+#packagedata: icupkg.inc ${PKGDATA_LIST} build-local
++# packagedata: icupkg.inc ${PKGDATA_LIST} build-local
 +if(PKGDATA_MODE STREQUAL "dll" OR PKGDATA_MODE STREQUAL "static")
-+  if(ENABLE_STATIC)
-+    if(PKGDATA_MODE STREQUAL "dll")
-+      set(ADD_icudata_asm_target YES)
-+      set(asm_PKGDATA_MODE static)
-+      set(asm_PKGDATA_LIBNAME ${PKGDATA_LIBSTATICNAME})
++    if(ENABLE_STATIC)
++        if(PKGDATA_MODE STREQUAL "dll")
++            set(ADD_icudata_asm_target YES)
++            set(asm_PKGDATA_MODE static)
++            set(asm_PKGDATA_LIBNAME ${PKGDATA_LIBSTATICNAME})
++        endif()
 +    endif()
-+  endif()
-+  if(NOT ICUDATA_SOURCE_IS_NATIVE_TARGET)
-+    set(ADD_icudata_asm_target YES)
-+    set(asm_PKGDATA_MODE ${PKGDATA_MODE})
-+    set(asm_PKGDATA_LIBNAME ${PKGDATA_LIBNAME})
-+  endif()
++    if(NOT ICUDATA_SOURCE_IS_NATIVE_TARGET)
++        set(ADD_icudata_asm_target YES)
++        set(asm_PKGDATA_MODE ${PKGDATA_MODE})
++        set(asm_PKGDATA_LIBNAME ${PKGDATA_LIBNAME})
++    endif()
 +endif()
 +
 +if(ADD_icudata_asm_target)
-+  set(icudata_asm_file_STAMP "${OUTDIR}/icudata_asm_file_stamp")
++    set(icudata_asm_file_STAMP "${OUTDIR}/icudata_asm_file_stamp")
 +
-+  add_custom_command(
-+    OUTPUT ${ICUDATA_ASM_FILE} ${icudata_asm_file_STAMP}
-+    COMMAND ${PKGDATA}
-+      -e ${ICUDATA_ENTRY_POINT}  # --entrypoint
-+      -T ${OUTTMPDIR}            # --tempdir
-+      -p ${ICUDATA_NAME}         # --name
-+      -m ${asm_PKGDATA_MODE}     # --mode
-+      ${PKGDATA_VERSIONING}
-+      ${asm_PKGDATA_LIBNAME}
-+      ${PKGDATA_LIST}
-+    COMMAND ${CMAKE_COMMAND} -E touch ${icudata_asm_file_STAMP}
-+    DEPENDS ${deps_pkgdata} ${PKGDATA_LIST} ${pkgdata_list_STAMP} ${ICUDATA_ALL_OUTPUT_FILES} # ${ICUPKG_INC}
-+    COMMENT
-+      "Packing data to the asm file ${ICUDATA_ASM_FILE}"
-+  )
-+  add_custom_target(icudata_asm_target
-+    DEPENDS ${ICUDATA_ASM_FILE} ${icudata_asm_file_STAMP}
-+  )
++    add_custom_command(
++        OUTPUT ${ICUDATA_ASM_FILE} ${icudata_asm_file_STAMP}
++        COMMAND
++            ${PKGDATA} -e ${ICUDATA_ENTRY_POINT} # --entrypoint
++            -T ${OUTTMPDIR} # --tempdir
++            -p ${ICUDATA_NAME} # --name
++            -m ${asm_PKGDATA_MODE} # --mode
++            ${PKGDATA_VERSIONING} ${asm_PKGDATA_LIBNAME} ${PKGDATA_LIST}
++        COMMAND ${CMAKE_COMMAND} -E touch ${icudata_asm_file_STAMP}
++        DEPENDS ${deps_pkgdata} ${PKGDATA_LIST} ${pkgdata_list_STAMP}
++                ${ICUDATA_ALL_OUTPUT_FILES} # ${ICUPKG_INC}
++        COMMENT "Packing data to the asm file ${ICUDATA_ASM_FILE}"
++    )
++    add_custom_target(icudata_asm_target DEPENDS ${ICUDATA_ASM_FILE} ${icudata_asm_file_STAMP})
 +endif()
 +
-+#if(ICUDATA_SOURCE_IS_NATIVE_TARGET)
-+#  #${INSTALL_DATA} ${ICUDATA_SOURCE_ARCHIVE} ${OUTDIR}
-+#  install(FILES ${ICUDATA_SOURCE_ARCHIVE} DESTINATION ${OUTDIR})
-+#endif()
++# if(ICUDATA_SOURCE_IS_NATIVE_TARGET) #${INSTALL_DATA} ${ICUDATA_SOURCE_ARCHIVE} ${OUTDIR} install(FILES
++# ${ICUDATA_SOURCE_ARCHIVE} DESTINATION ${OUTDIR}) endif()
 +
-+
-+#############################################################################
++# #######################################################################################################
 +# Make and install the data library
-+#############################################################################
++# #######################################################################################################
 +
 +if(PKGDATA_MODE STREQUAL "dll" OR PKGDATA_MODE STREQUAL "static")
-+  set(lib_NAME ${ICULIBS_DT})
-+  set(lib_NAME_SUFFIX ${DATA_STUBNAME})
++    set(lib_NAME ${ICULIBS_DT})
++    set(lib_NAME_SUFFIX ${DATA_STUBNAME})
 +
-+  add_library(${lib_NAME} "")
++    add_library(${lib_NAME} "")
 +
-+  set_target_properties(${lib_NAME} PROPERTIES
-+    LINKER_LANGUAGE C
-+    EXPORT_NAME ${lib_NAME_SUFFIX}
-+    OUTPUT_NAME
-+      ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+    RUNTIME_OUTPUT_NAME
-+      ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
-+  )
++    set_target_properties(
++        ${lib_NAME}
++        PROPERTIES LINKER_LANGUAGE C
++                   EXPORT_NAME ${lib_NAME_SUFFIX}
++                   OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++                   RUNTIME_OUTPUT_NAME
++                   ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++    )
 +
-+  ### Common libraries options
-+  include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
-+  #include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
++    # Common libraries options
++    include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
++    # include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
 +
-+  ### Library's specific flags
-+  set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+    LINK_FLAGS ${LDFLAGSICUDT}
-+  )
++    # Library's specific flags
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND_STRING
++        PROPERTY LINK_FLAGS ${LDFLAGSICUDT}
++    )
 +
-+  ### Include directories
-+  # PRIVATE
-+  target_include_directories(${lib_NAME} PRIVATE
-+    ${PROJECT_SOURCE_DIR}/common
-+    ${PROJECT_BINARY_DIR}/common
-+  )
++    # Include directories PRIVATE
++    target_include_directories(
++        ${lib_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_BINARY_DIR}/common
++    )
 +
-+  ### Dependencies
-+  add_dependencies(${lib_NAME} icudata_asm_target)
++    # Dependencies
++    add_dependencies(${lib_NAME} icudata_asm_target)
 +
-+  target_sources(${lib_NAME}
-+    PRIVATE
-+      ${ICUDATA_ASM_FILE}
-+  )
++    target_sources(${lib_NAME} PRIVATE ${ICUDATA_ASM_FILE})
 +
-+  install(
-+    TARGETS ${lib_NAME}
-+    EXPORT "${TARGETS_EXPORT_NAME}"
-+    ARCHIVE  DESTINATION "${libdir}"
-+    LIBRARY  DESTINATION "${libdir}"
-+    RUNTIME  DESTINATION "${bindir}"
-+    INCLUDES DESTINATION "${includedir}"
-+  )
++    install(
++        TARGETS ${lib_NAME}
++        EXPORT "${TARGETS_EXPORT_NAME}"
++        ARCHIVE DESTINATION "${libdir}"
++        LIBRARY DESTINATION "${libdir}"
++        RUNTIME DESTINATION "${bindir}"
++        INCLUDES
++        DESTINATION "${includedir}"
++    )
 +
 +elseif(PKGDATA_MODE STREQUAL "common")
-+  install(FILES ${ICUDATA_SOURCE_ARCHIVE} DESTINATION ${ICUPKGDATA_DIR})
++    install(FILES ${ICUDATA_SOURCE_ARCHIVE} DESTINATION ${ICUPKGDATA_DIR})
 +endif()
 diff --git a/source/data/cmake-brkitr-index-txt-content.in b/source/data/cmake-brkitr-index-txt-content.in
 new file mode 100644
@@ -10207,321 +10203,339 @@ index 0000000000..a9ecd830c7
 +INSTALL_CMD="@CMAKE_COMMAND@" -E echo INSTALL
 diff --git a/source/data/rules.cmake b/source/data/rules.cmake
 new file mode 100644
-index 0000000000..6b3965fe26
+index 0000000000..fa273f2146
 --- /dev/null
 +++ b/source/data/rules.cmake
-@@ -0,0 +1,8509 @@
+@@ -0,0 +1,8561 @@
 +set(IN_DIR ${SRCDATADIR})
 +set(SRC_DIR ${SRCDATADIR})
 +
-+add_custom_target(data_dirs
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR} ${OUT_DIR}/brkitr
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/coll
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/curr
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/lang
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/rbnf
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/region
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/translit
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/unit
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/zone
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/brkitr
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/coll
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/curr
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/lang
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/locales
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/rbnf
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/region
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/unit
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/zone
++add_custom_target(
++    data_dirs
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR} ${OUT_DIR}/brkitr
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/coll
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/curr
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/lang
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/rbnf
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/region
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/translit
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/unit
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR}/zone
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/brkitr
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/coll
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/curr
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/lang
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/locales
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/rbnf
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/region
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/unit
++    COMMAND ${CMAKE_COMMAND} -E make_directory ${TMP_DIR}/zone
 +)
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/cnvalias.icu
-+  DEPENDS data_dirs ${IN_DIR}/mappings/convrtrs.txt ${TOOLBINDIR}/gencnval
-+  COMMAND ${TOOLBINDIR}/gencnval -s ${IN_DIR} -d ${OUT_DIR} mappings/convrtrs.txt
++    OUTPUT ${OUT_DIR}/cnvalias.icu
++    DEPENDS data_dirs ${IN_DIR}/mappings/convrtrs.txt ${TOOLBINDIR}/gencnval
++    COMMAND ${TOOLBINDIR}/gencnval -s ${IN_DIR} -d ${OUT_DIR} mappings/convrtrs.txt
 +)
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/ulayout.icu
-+  DEPENDS data_dirs ${IN_DIR}/in/ulayout.icu ${TOOLBINDIR}/icupkg
-+  COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/ulayout.icu ${OUT_DIR}/ulayout.icu
++    OUTPUT ${OUT_DIR}/ulayout.icu
++    DEPENDS data_dirs ${IN_DIR}/in/ulayout.icu ${TOOLBINDIR}/icupkg
++    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/ulayout.icu ${OUT_DIR}/ulayout.icu
 +)
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/confusables.cfu
-+  DEPENDS data_dirs ${OUT_DIR}/cnvalias.icu ${IN_DIR}/unidata/confusables.txt
-+          ${IN_DIR}/unidata/confusablesWholeScript.txt ${TOOLBINDIR}/gencfu
-+  COMMAND ${TOOLBINDIR}/gencfu -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/unidata/confusables.txt -w ${IN_DIR}/unidata/confusablesWholeScript.txt -o confusables.cfu
++    OUTPUT ${OUT_DIR}/confusables.cfu
++    DEPENDS data_dirs ${OUT_DIR}/cnvalias.icu ${IN_DIR}/unidata/confusables.txt
++            ${IN_DIR}/unidata/confusablesWholeScript.txt ${TOOLBINDIR}/gencfu
++    COMMAND ${TOOLBINDIR}/gencfu -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/unidata/confusables.txt -w
++            ${IN_DIR}/unidata/confusablesWholeScript.txt -o confusables.cfu
 +)
 +
-+### cnv
++# cnv
 +
 +function(generate_cnv FILE)
-+  file(TO_NATIVE_PATH "mappings/${FILE}.ucm" CNV_INPUT)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.cnv
-+    DEPENDS data_dirs ${IN_DIR}/mappings/${FILE}.ucm ${TOOLBINDIR}/makeconv
-+    COMMAND ${TOOLBINDIR}/makeconv -s ${IN_DIR} -d ${OUT_DIR} -c ${CNV_INPUT}
-+  )
++    file(TO_NATIVE_PATH "mappings/${FILE}.ucm" CNV_INPUT)
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.cnv
++        DEPENDS data_dirs ${IN_DIR}/mappings/${FILE}.ucm ${TOOLBINDIR}/makeconv
++        COMMAND ${TOOLBINDIR}/makeconv -s ${IN_DIR} -d ${OUT_DIR} -c ${CNV_INPUT}
++    )
 +endfunction()
 +
 +set(data_cnv_mappings
-+cns-11643-1992
-+ebcdic-xml-us
-+euc-jp-2007
-+euc-tw-2014
-+gb18030
-+gsm-03.38-2009
-+ibm-1006_P100-1995
-+ibm-1025_P100-1995
-+ibm-1026_P100-1995
-+ibm-1047_P100-1995
-+ibm-1051_P100-1995
-+ibm-1089_P100-1995
-+ibm-1097_P100-1995
-+ibm-1098_P100-1995
-+ibm-1112_P100-1995
-+ibm-1122_P100-1999
-+ibm-1123_P100-1995
-+ibm-1124_P100-1996
-+ibm-1125_P100-1997
-+ibm-1129_P100-1997
-+ibm-1130_P100-1997
-+ibm-1131_P100-1997
-+ibm-1132_P100-1998
-+ibm-1133_P100-1997
-+ibm-1137_P100-1999
-+ibm-1140_P100-1997
-+ibm-1141_P100-1997
-+ibm-1142_P100-1997
-+ibm-1143_P100-1997
-+ibm-1144_P100-1997
-+ibm-1145_P100-1997
-+ibm-1146_P100-1997
-+ibm-1147_P100-1997
-+ibm-1148_P100-1997
-+ibm-1149_P100-1997
-+ibm-1153_P100-1999
-+ibm-1154_P100-1999
-+ibm-1155_P100-1999
-+ibm-1156_P100-1999
-+ibm-1157_P100-1999
-+ibm-1158_P100-1999
-+ibm-1160_P100-1999
-+ibm-1162_P100-1999
-+ibm-1164_P100-1999
-+ibm-1168_P100-2002
-+ibm-1250_P100-1995
-+ibm-1251_P100-1995
-+ibm-1252_P100-2000
-+ibm-1253_P100-1995
-+ibm-1254_P100-1995
-+ibm-1255_P100-1995
-+ibm-1256_P110-1997
-+ibm-1257_P100-1995
-+ibm-1258_P100-1997
-+ibm-12712_P100-1998
-+ibm-1276_P100-1995
-+ibm-1363_P110-1997
-+ibm-1363_P11B-1998
-+ibm-1364_P110-2007
-+ibm-1371_P100-1999
-+ibm-1373_P100-2002
-+ibm-1375_P100-2008
-+ibm-1383_P110-1999
-+ibm-1386_P100-2001
-+ibm-1388_P103-2001
-+ibm-1390_P110-2003
-+ibm-1399_P110-2003
-+ibm-16684_P110-2003
-+ibm-16804_X110-1999
-+ibm-273_P100-1995
-+ibm-277_P100-1995
-+ibm-278_P100-1995
-+ibm-280_P100-1995
-+ibm-284_P100-1995
-+ibm-285_P100-1995
-+ibm-290_P100-1995
-+ibm-297_P100-1995
-+ibm-33722_P120-1999
-+ibm-33722_P12A_P12A-2004_U2
-+ibm-33722_P12A_P12A-2009_U2
-+ibm-37_P100-1995
-+ibm-420_X120-1999
-+ibm-424_P100-1995
-+ibm-437_P100-1995
-+ibm-4517_P100-2005
-+ibm-4899_P100-1998
-+ibm-4909_P100-1999
-+ibm-4971_P100-1999
-+ibm-500_P100-1995
-+ibm-5012_P100-1999
-+ibm-5123_P100-1999
-+ibm-5346_P100-1998
-+ibm-5347_P100-1998
-+ibm-5348_P100-1997
-+ibm-5349_P100-1998
-+ibm-5350_P100-1998
-+ibm-5351_P100-1998
-+ibm-5352_P100-1998
-+ibm-5353_P100-1998
-+ibm-5354_P100-1998
-+ibm-5471_P100-2006
-+ibm-5478_P100-1995
-+ibm-720_P100-1997
-+ibm-737_P100-1997
-+ibm-775_P100-1996
-+ibm-803_P100-1999
-+ibm-813_P100-1995
-+ibm-838_P100-1995
-+ibm-8482_P100-1999
-+ibm-850_P100-1995
-+ibm-851_P100-1995
-+ibm-852_P100-1995
-+ibm-855_P100-1995
-+ibm-856_P100-1995
-+ibm-857_P100-1995
-+ibm-858_P100-1997
-+ibm-860_P100-1995
-+ibm-861_P100-1995
-+ibm-862_P100-1995
-+ibm-863_P100-1995
-+ibm-864_X110-1999
-+ibm-865_P100-1995
-+ibm-866_P100-1995
-+ibm-867_P100-1998
-+ibm-868_P100-1995
-+ibm-869_P100-1995
-+ibm-870_P100-1995
-+ibm-871_P100-1995
-+ibm-874_P100-1995
-+ibm-875_P100-1995
-+ibm-878_P100-1996
-+ibm-9005_X110-2007
-+ibm-901_P100-1999
-+ibm-902_P100-1999
-+ibm-9067_X100-2005
-+ibm-912_P100-1995
-+ibm-913_P100-2000
-+ibm-914_P100-1995
-+ibm-915_P100-1995
-+ibm-916_P100-1995
-+ibm-918_P100-1995
-+ibm-920_P100-1995
-+ibm-921_P100-1995
-+ibm-922_P100-1999
-+ibm-923_P100-1998
-+ibm-930_P120-1999
-+ibm-933_P110-1995
-+ibm-935_P110-1999
-+ibm-937_P110-1999
-+ibm-939_P120-1999
-+ibm-942_P12A-1999
-+ibm-943_P130-1999
-+ibm-943_P15A-2003
-+ibm-9447_P100-2002
-+ibm-9448_X100-2005
-+ibm-9449_P100-2002
-+ibm-949_P110-1999
-+ibm-949_P11A-1999
-+ibm-950_P110-1999
-+ibm-954_P101-2007
-+ibm-964_P110-1999
-+ibm-970_P110_P110-2006_U2
-+ibm-971_P100-1995
-+icu-internal-25546
-+icu-internal-compound-d1
-+icu-internal-compound-d2
-+icu-internal-compound-d3
-+icu-internal-compound-d4
-+icu-internal-compound-d5
-+icu-internal-compound-d6
-+icu-internal-compound-d7
-+icu-internal-compound-s1
-+icu-internal-compound-s2
-+icu-internal-compound-s3
-+icu-internal-compound-t
-+iso-8859_10-1998
-+iso-8859_11-2001
-+iso-8859_14-1998
-+iso-ir-165
-+jisx-212
-+lmb-excp
-+macos-0_2-10.2
-+macos-29-10.2
-+macos-35-10.2
-+macos-6_2-10.4
-+macos-7_3-10.2
-+windows-874-2000
-+windows-936-2000
-+windows-949-2000
-+windows-950-2000
++    cns-11643-1992
++    ebcdic-xml-us
++    euc-jp-2007
++    euc-tw-2014
++    gb18030
++    gsm-03.38-2009
++    ibm-1006_P100-1995
++    ibm-1025_P100-1995
++    ibm-1026_P100-1995
++    ibm-1047_P100-1995
++    ibm-1051_P100-1995
++    ibm-1089_P100-1995
++    ibm-1097_P100-1995
++    ibm-1098_P100-1995
++    ibm-1112_P100-1995
++    ibm-1122_P100-1999
++    ibm-1123_P100-1995
++    ibm-1124_P100-1996
++    ibm-1125_P100-1997
++    ibm-1129_P100-1997
++    ibm-1130_P100-1997
++    ibm-1131_P100-1997
++    ibm-1132_P100-1998
++    ibm-1133_P100-1997
++    ibm-1137_P100-1999
++    ibm-1140_P100-1997
++    ibm-1141_P100-1997
++    ibm-1142_P100-1997
++    ibm-1143_P100-1997
++    ibm-1144_P100-1997
++    ibm-1145_P100-1997
++    ibm-1146_P100-1997
++    ibm-1147_P100-1997
++    ibm-1148_P100-1997
++    ibm-1149_P100-1997
++    ibm-1153_P100-1999
++    ibm-1154_P100-1999
++    ibm-1155_P100-1999
++    ibm-1156_P100-1999
++    ibm-1157_P100-1999
++    ibm-1158_P100-1999
++    ibm-1160_P100-1999
++    ibm-1162_P100-1999
++    ibm-1164_P100-1999
++    ibm-1168_P100-2002
++    ibm-1250_P100-1995
++    ibm-1251_P100-1995
++    ibm-1252_P100-2000
++    ibm-1253_P100-1995
++    ibm-1254_P100-1995
++    ibm-1255_P100-1995
++    ibm-1256_P110-1997
++    ibm-1257_P100-1995
++    ibm-1258_P100-1997
++    ibm-12712_P100-1998
++    ibm-1276_P100-1995
++    ibm-1363_P110-1997
++    ibm-1363_P11B-1998
++    ibm-1364_P110-2007
++    ibm-1371_P100-1999
++    ibm-1373_P100-2002
++    ibm-1375_P100-2008
++    ibm-1383_P110-1999
++    ibm-1386_P100-2001
++    ibm-1388_P103-2001
++    ibm-1390_P110-2003
++    ibm-1399_P110-2003
++    ibm-16684_P110-2003
++    ibm-16804_X110-1999
++    ibm-273_P100-1995
++    ibm-277_P100-1995
++    ibm-278_P100-1995
++    ibm-280_P100-1995
++    ibm-284_P100-1995
++    ibm-285_P100-1995
++    ibm-290_P100-1995
++    ibm-297_P100-1995
++    ibm-33722_P120-1999
++    ibm-33722_P12A_P12A-2004_U2
++    ibm-33722_P12A_P12A-2009_U2
++    ibm-37_P100-1995
++    ibm-420_X120-1999
++    ibm-424_P100-1995
++    ibm-437_P100-1995
++    ibm-4517_P100-2005
++    ibm-4899_P100-1998
++    ibm-4909_P100-1999
++    ibm-4971_P100-1999
++    ibm-500_P100-1995
++    ibm-5012_P100-1999
++    ibm-5123_P100-1999
++    ibm-5346_P100-1998
++    ibm-5347_P100-1998
++    ibm-5348_P100-1997
++    ibm-5349_P100-1998
++    ibm-5350_P100-1998
++    ibm-5351_P100-1998
++    ibm-5352_P100-1998
++    ibm-5353_P100-1998
++    ibm-5354_P100-1998
++    ibm-5471_P100-2006
++    ibm-5478_P100-1995
++    ibm-720_P100-1997
++    ibm-737_P100-1997
++    ibm-775_P100-1996
++    ibm-803_P100-1999
++    ibm-813_P100-1995
++    ibm-838_P100-1995
++    ibm-8482_P100-1999
++    ibm-850_P100-1995
++    ibm-851_P100-1995
++    ibm-852_P100-1995
++    ibm-855_P100-1995
++    ibm-856_P100-1995
++    ibm-857_P100-1995
++    ibm-858_P100-1997
++    ibm-860_P100-1995
++    ibm-861_P100-1995
++    ibm-862_P100-1995
++    ibm-863_P100-1995
++    ibm-864_X110-1999
++    ibm-865_P100-1995
++    ibm-866_P100-1995
++    ibm-867_P100-1998
++    ibm-868_P100-1995
++    ibm-869_P100-1995
++    ibm-870_P100-1995
++    ibm-871_P100-1995
++    ibm-874_P100-1995
++    ibm-875_P100-1995
++    ibm-878_P100-1996
++    ibm-9005_X110-2007
++    ibm-901_P100-1999
++    ibm-902_P100-1999
++    ibm-9067_X100-2005
++    ibm-912_P100-1995
++    ibm-913_P100-2000
++    ibm-914_P100-1995
++    ibm-915_P100-1995
++    ibm-916_P100-1995
++    ibm-918_P100-1995
++    ibm-920_P100-1995
++    ibm-921_P100-1995
++    ibm-922_P100-1999
++    ibm-923_P100-1998
++    ibm-930_P120-1999
++    ibm-933_P110-1995
++    ibm-935_P110-1999
++    ibm-937_P110-1999
++    ibm-939_P120-1999
++    ibm-942_P12A-1999
++    ibm-943_P130-1999
++    ibm-943_P15A-2003
++    ibm-9447_P100-2002
++    ibm-9448_X100-2005
++    ibm-9449_P100-2002
++    ibm-949_P110-1999
++    ibm-949_P11A-1999
++    ibm-950_P110-1999
++    ibm-954_P101-2007
++    ibm-964_P110-1999
++    ibm-970_P110_P110-2006_U2
++    ibm-971_P100-1995
++    icu-internal-25546
++    icu-internal-compound-d1
++    icu-internal-compound-d2
++    icu-internal-compound-d3
++    icu-internal-compound-d4
++    icu-internal-compound-d5
++    icu-internal-compound-d6
++    icu-internal-compound-d7
++    icu-internal-compound-s1
++    icu-internal-compound-s2
++    icu-internal-compound-s3
++    icu-internal-compound-t
++    iso-8859_10-1998
++    iso-8859_11-2001
++    iso-8859_14-1998
++    iso-ir-165
++    jisx-212
++    lmb-excp
++    macos-0_2-10.2
++    macos-29-10.2
++    macos-35-10.2
++    macos-6_2-10.4
++    macos-7_3-10.2
++    windows-874-2000
++    windows-936-2000
++    windows-949-2000
++    windows-950-2000
 +)
 +
 +foreach(CNV ${data_cnv_mappings})
-+  generate_cnv(${CNV})
-+  list(APPEND tmpdep ${OUT_DIR}/${CNV}.cnv)
++    generate_cnv(${CNV})
++    list(APPEND tmpdep ${OUT_DIR}/${CNV}.cnv)
 +endforeach()
 +
-+### brkitr
++# brkitr
 +
 +set(BRKITR_BRK_DEPS ${OUT_DIR}/cnvalias.icu ${OUT_DIR}/ulayout.icu)
 +
 +macro(generate_brk FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/brkitr/${FILE}.brk
-+    DEPENDS data_dirs ${BRKITR_BRK_DEPS} ${IN_DIR}/brkitr/rules/${FILE}.txt ${TOOLBINDIR}/genbrk
-+    COMMAND ${TOOLBINDIR}/genbrk -d ${OUT_DIR} -i ${OUT_DIR} -c -r ${IN_DIR}/brkitr/rules/${FILE}.txt -o brkitr/${FILE}.brk
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/brkitr/${FILE}.brk
++        DEPENDS data_dirs ${BRKITR_BRK_DEPS} ${IN_DIR}/brkitr/rules/${FILE}.txt ${TOOLBINDIR}/genbrk
++        COMMAND ${TOOLBINDIR}/genbrk -d ${OUT_DIR} -i ${OUT_DIR} -c -r
++                ${IN_DIR}/brkitr/rules/${FILE}.txt -o brkitr/${FILE}.brk
++    )
 +endmacro()
 +
 +set(data_brk_mappings
-+  char
-+  line
-+  line_cj
-+  line_loose
-+  line_loose_cj
-+  line_normal
-+  line_normal_cj
-+  sent
-+  sent_el
-+  title
-+  word
-+  word_POSIX
++    char
++    line
++    line_cj
++    line_loose
++    line_loose_cj
++    line_normal
++    line_normal_cj
++    sent
++    sent_el
++    title
++    word
++    word_POSIX
 +)
 +
 +foreach(BRK ${data_brk_mappings})
-+  generate_brk(${BRK})
-+  list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRK}.brk)
++    generate_brk(${BRK})
++    list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRK}.brk)
 +endforeach()
 +
 +# stringprep
 +
 +set(STRINGPREP_DEPS ${IN_DIR}/unidata/NormalizationCorrections.txt)
-+set(SPP_FILES rfc3491 rfc3530cs rfc3530csci rfc3530mixp rfc3722 rfc3920node rfc3920res rfc4011 rfc4013 rfc4505 rfc4518 rfc4518ci)
++set(SPP_FILES
++    rfc3491
++    rfc3530cs
++    rfc3530csci
++    rfc3530mixp
++    rfc3722
++    rfc3920node
++    rfc3920res
++    rfc4011
++    rfc4013
++    rfc4505
++    rfc4518
++    rfc4518ci
++)
 +
 +macro(generate_spp FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.spp
-+    DEPENDS data_dirs ${STRINGPREP_DEPS} ${IN_DIR}/sprep/${FILE}.txt ${TOOLBINDIR}/gensprep
-+    COMMAND ${TOOLBINDIR}/gensprep -s ${IN_DIR}/sprep -d ${OUT_DIR} -i ${OUT_DIR} -b ${SPP_FILE} -m ${IN_DIR}/unidata -u 3.2.0 ${FILE}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.spp
++        DEPENDS data_dirs ${STRINGPREP_DEPS} ${IN_DIR}/sprep/${FILE}.txt ${TOOLBINDIR}/gensprep
++        COMMAND ${TOOLBINDIR}/gensprep -s ${IN_DIR}/sprep -d ${OUT_DIR} -i ${OUT_DIR} -b ${SPP_FILE} -m
++                ${IN_DIR}/unidata -u 3.2.0 ${FILE}.txt
++    )
 +endmacro()
 +
 +foreach(SPP_FILE ${SPP_FILES})
-+  generate_spp(${SPP_FILE})
-+  list(APPEND tmpdep ${OUT_DIR}/${SPP_FILE}.spp)
++    generate_spp(${SPP_FILE})
++    list(APPEND tmpdep ${OUT_DIR}/${SPP_FILE}.spp)
 +endforeach()
 +
-+### brkitr dict
++# brkitr dict
 +
 +function(generate_brkitrdict FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/brkitr/${FILE}.dict
-+    DEPENDS data_dirs ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${TOOLBINDIR}/gendict
-+    COMMAND ${TOOLBINDIR}/gendict -i ${OUT_DIR} -c ${BRKITR_DICT_${FILE}_FLAGS} ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${OUT_DIR}/brkitr/${FILE}.dict
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/brkitr/${FILE}.dict
++        DEPENDS data_dirs ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${TOOLBINDIR}/gendict
++        COMMAND ${TOOLBINDIR}/gendict -i ${OUT_DIR} -c ${BRKITR_DICT_${FILE}_FLAGS}
++                ${IN_DIR}/brkitr/dictionaries/${FILE}.txt ${OUT_DIR}/brkitr/${FILE}.dict
++    )
 +endfunction()
 +
 +set(BRKITR_DICT_FILES burmesedict cjdict khmerdict laodict thaidict)
@@ -10532,8396 +10546,8408 @@ index 0000000000..6b3965fe26
 +set(BRKITR_DICT_thaidict_FLAGS --bytes --transform offset-0x0e00)
 +
 +foreach(BRKITR_DICT_FILE ${BRKITR_DICT_FILES})
-+  generate_brkitrdict(${BRKITR_DICT_FILE})
-+  list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRKITR_DICT_FILE}.dict)
++    generate_brkitrdict(${BRKITR_DICT_FILE})
++    list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRKITR_DICT_FILE}.dict)
 +endforeach()
 +
-+### nrm
++# nrm
 +
 +function(generate_nrm FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.nrm
-+    DEPENDS data_dirs ${IN_DIR}/in/${FILE}.nrm ${TOOLBINDIR}/icupkg
-+    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/${FILE}.nrm ${OUT_DIR}/${FILE}.nrm
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.nrm
++        DEPENDS data_dirs ${IN_DIR}/in/${FILE}.nrm ${TOOLBINDIR}/icupkg
++        COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/${FILE}.nrm ${OUT_DIR}/${FILE}.nrm
++    )
 +endfunction()
 +
 +set(IN_NRM_FILES nfkc nfkc_cf uts46)
 +foreach(IN_NRM_FILE ${IN_NRM_FILES})
-+  generate_nrm(${IN_NRM_FILE})
-+  list(APPEND tmpdep ${OUT_DIR}/${IN_NRM_FILE}.nrm)
++    generate_nrm(${IN_NRM_FILE})
++    list(APPEND tmpdep ${OUT_DIR}/${IN_NRM_FILE}.nrm)
 +endforeach()
 +
-+### coll/ucadata
++# coll/ucadata
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/coll/ucadata.icu
-+  DEPENDS data_dirs ${IN_DIR}/in/coll/ucadata-unihan.icu ${TOOLBINDIR}/icupkg
-+  COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/coll/ucadata-unihan.icu ${OUT_DIR}/coll/ucadata.icu
++    OUTPUT ${OUT_DIR}/coll/ucadata.icu
++    DEPENDS data_dirs ${IN_DIR}/in/coll/ucadata-unihan.icu ${TOOLBINDIR}/icupkg
++    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/coll/ucadata-unihan.icu
++            ${OUT_DIR}/coll/ucadata.icu
 +)
 +
-+### unames
++# unames
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/unames.icu
-+  DEPENDS data_dirs ${IN_DIR}/in/unames.icu ${TOOLBINDIR}/icupkg
-+  COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/unames.icu ${OUT_DIR}/unames.icu
++    OUTPUT ${OUT_DIR}/unames.icu
++    DEPENDS data_dirs ${IN_DIR}/in/unames.icu ${TOOLBINDIR}/icupkg
++    COMMAND ${TOOLBINDIR}/icupkg -t${ICUDATA_CHAR} ${IN_DIR}/in/unames.icu ${OUT_DIR}/unames.icu
 +)
 +
-+### misc res
++# misc res
 +
 +function(generate_misc_res FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.res
-+    DEPENDS data_dirs ${IN_DIR}/misc/${FILE}.txt ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/misc -d ${OUT_DIR} -i ${OUT_DIR} -k -q ${FILE}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.res
++        DEPENDS data_dirs ${IN_DIR}/misc/${FILE}.txt ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/misc -d ${OUT_DIR} -i ${OUT_DIR} -k -q ${FILE}.txt
++    )
 +endfunction()
 +
 +set(MISC_RES_FILES
-+  currencyNumericCodes
-+  dayPeriods
-+  genderList
-+  icustd
-+  icuver
-+  keyTypeData
-+  langInfo
-+  likelySubtags
-+  metaZones
-+  metadata
-+  numberingSystems
-+  pluralRanges
-+  plurals
-+  supplementalData
-+  timezoneTypes
-+  windowsZones
-+  zoneinfo64
++    currencyNumericCodes
++    dayPeriods
++    genderList
++    icustd
++    icuver
++    keyTypeData
++    langInfo
++    likelySubtags
++    metaZones
++    metadata
++    numberingSystems
++    pluralRanges
++    plurals
++    supplementalData
++    timezoneTypes
++    windowsZones
++    zoneinfo64
 +)
 +
 +foreach(MISC_RES_FILE ${MISC_RES_FILES})
-+  generate_misc_res(${MISC_RES_FILE})
-+  list(APPEND tmpdep ${OUT_DIR}/${MISC_RES_FILE}.res)
++    generate_misc_res(${MISC_RES_FILE})
++    list(APPEND tmpdep ${OUT_DIR}/${MISC_RES_FILE}.res)
 +endforeach()
 +
-+### curr supplementalData res FILE
++# curr supplementalData res FILE
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/curr/supplementalData.res
-+  DEPENDS data_dirs ${IN_DIR}/curr/supplementalData.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr -i ${OUT_DIR} -k -q supplementalData.txt
++    OUTPUT ${OUT_DIR}/curr/supplementalData.res
++    DEPENDS data_dirs ${IN_DIR}/curr/supplementalData.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr -i ${OUT_DIR} -k -q
++            supplementalData.txt
 +)
 +list(APPEND tmpdep ${OUT_DIR}/curr/supplementalData.res)
 +
-+### translit
-+add_prefix(TRANSLIT_RES_DEPS ${IN_DIR}
-+        translit/Any_Accents.txt
-+		translit/Any_Publishing.txt
-+		translit/Arab_Latn.txt
-+		translit/Beng_Arab.txt
-+		translit/Beng_Deva.txt
-+		translit/Beng_Gujr.txt
-+		translit/Beng_Guru.txt
-+		translit/Beng_Knda.txt
-+		translit/Beng_Latn.txt
-+		translit/Beng_Mlym.txt
-+		translit/Beng_Orya.txt
-+		translit/Beng_Taml.txt
-+		translit/Beng_Telu.txt
-+		translit/Beng_ur.txt
-+		translit/Bengali_InterIndic.txt
-+		translit/Cyrl_Latn.txt
-+		translit/Deva_Arab.txt
-+		translit/Deva_Beng.txt
-+		translit/Deva_Gujr.txt
-+		translit/Deva_Guru.txt
-+		translit/Deva_Knda.txt
-+		translit/Deva_Latn.txt
-+		translit/Deva_Mlym.txt
-+		translit/Deva_Orya.txt
-+		translit/Deva_Taml.txt
-+		translit/Deva_Telu.txt
-+		translit/Deva_ur.txt
-+		translit/Devanagari_InterIndic.txt
-+		translit/Fullwidth_Halfwidth.txt
-+		translit/Geor_Latn.txt
-+		translit/Grek_Latn.txt
-+		translit/Grek_Latn_UNGEGN.txt
-+		translit/Gujarati_InterIndic.txt
-+		translit/Gujr_Arab.txt
-+		translit/Gujr_Beng.txt
-+		translit/Gujr_Deva.txt
-+		translit/Gujr_Guru.txt
-+		translit/Gujr_Knda.txt
-+		translit/Gujr_Latn.txt
-+		translit/Gujr_Mlym.txt
-+		translit/Gujr_Orya.txt
-+		translit/Gujr_Taml.txt
-+		translit/Gujr_Telu.txt
-+		translit/Gujr_ur.txt
-+		translit/Gurmukhi_InterIndic.txt
-+		translit/Guru_Arab.txt
-+		translit/Guru_Beng.txt
-+		translit/Guru_Deva.txt
-+		translit/Guru_Gujr.txt
-+		translit/Guru_Knda.txt
-+		translit/Guru_Latn.txt
-+		translit/Guru_Mlym.txt
-+		translit/Guru_Orya.txt
-+		translit/Guru_Taml.txt
-+		translit/Guru_Telu.txt
-+		translit/Guru_ur.txt
-+		translit/Han_Latin_Names.txt
-+		translit/Han_Spacedhan.txt
-+		translit/Hang_Latn.txt
-+		translit/Hani_Latn.txt
-+		translit/Hans_Hant.txt
-+		translit/Hebr_Latn.txt
-+		translit/Hira_Kana.txt
-+		translit/Hira_Latn.txt
-+		translit/InterIndic_Arabic.txt
-+		translit/InterIndic_Bengali.txt
-+		translit/InterIndic_Devanagari.txt
-+		translit/InterIndic_Gujarati.txt
-+		translit/InterIndic_Gurmukhi.txt
-+		translit/InterIndic_Kannada.txt
-+		translit/InterIndic_Latin.txt
-+		translit/InterIndic_Malayalam.txt
-+		translit/InterIndic_Oriya.txt
-+		translit/InterIndic_Tamil.txt
-+		translit/InterIndic_Telugu.txt
-+		translit/InterIndic_ur.txt
-+		translit/Jamo_Latn.txt
-+		translit/Kannada_InterIndic.txt
-+		translit/Knda_Arab.txt
-+		translit/Knda_Beng.txt
-+		translit/Knda_Deva.txt
-+		translit/Knda_Gujr.txt
-+		translit/Knda_Guru.txt
-+		translit/Knda_Latn.txt
-+		translit/Knda_Mlym.txt
-+		translit/Knda_Orya.txt
-+		translit/Knda_Taml.txt
-+		translit/Knda_Telu.txt
-+		translit/Knda_ur.txt
-+		translit/Latin_ASCII.txt
-+		translit/Latin_ConjoiningJamo.txt
-+		translit/Latin_InterIndic.txt
-+		translit/Latin_NumericPinyin.txt
-+		translit/Latn_Armn.txt
-+		translit/Latn_Beng.txt
-+		translit/Latn_Bopo.txt
-+		translit/Latn_Cans.txt
-+		translit/Latn_Deva.txt
-+		translit/Latn_Ethi.txt
-+		translit/Latn_Gujr.txt
-+		translit/Latn_Guru.txt
-+		translit/Latn_Hang.txt
-+		translit/Latn_Jamo.txt
-+		translit/Latn_Kana.txt
-+		translit/Latn_Knda.txt
-+		translit/Latn_Mlym.txt
-+		translit/Latn_Orya.txt
-+		translit/Latn_Taml.txt
-+		translit/Latn_Telu.txt
-+		translit/Latn_Thaa.txt
-+		translit/Latn_Thai.txt
-+		translit/Malayalam_InterIndic.txt
-+		translit/Mlym_Arab.txt
-+		translit/Mlym_Beng.txt
-+		translit/Mlym_Deva.txt
-+		translit/Mlym_Gujr.txt
-+		translit/Mlym_Guru.txt
-+		translit/Mlym_Knda.txt
-+		translit/Mlym_Latn.txt
-+		translit/Mlym_Orya.txt
-+		translit/Mlym_Taml.txt
-+		translit/Mlym_Telu.txt
-+		translit/Mlym_ur.txt
-+		translit/Oriya_InterIndic.txt
-+		translit/Orya_Arab.txt
-+		translit/Orya_Beng.txt
-+		translit/Orya_Deva.txt
-+		translit/Orya_Gujr.txt
-+		translit/Orya_Guru.txt
-+		translit/Orya_Knda.txt
-+		translit/Orya_Latn.txt
-+		translit/Orya_Mlym.txt
-+		translit/Orya_Taml.txt
-+		translit/Orya_Telu.txt
-+		translit/Orya_ur.txt
-+		translit/Pinyin_NumericPinyin.txt
-+		translit/Syrc_Latn.txt
-+		translit/Tamil_InterIndic.txt
-+		translit/Taml_Arab.txt
-+		translit/Taml_Beng.txt
-+		translit/Taml_Deva.txt
-+		translit/Taml_Gujr.txt
-+		translit/Taml_Guru.txt
-+		translit/Taml_Knda.txt
-+		translit/Taml_Latn.txt
-+		translit/Taml_Mlym.txt
-+		translit/Taml_Orya.txt
-+		translit/Taml_Telu.txt
-+		translit/Taml_ur.txt
-+		translit/Telu_Arab.txt
-+		translit/Telu_Beng.txt
-+		translit/Telu_Deva.txt
-+		translit/Telu_Gujr.txt
-+		translit/Telu_Guru.txt
-+		translit/Telu_Knda.txt
-+		translit/Telu_Latn.txt
-+		translit/Telu_Mlym.txt
-+		translit/Telu_Orya.txt
-+		translit/Telu_Taml.txt
-+		translit/Telu_ur.txt
-+		translit/Telugu_InterIndic.txt
-+		translit/ThaiLogical_Latin.txt
-+		translit/Thai_Latn.txt
-+		translit/Thai_ThaiLogical.txt
-+		translit/Thai_ThaiSemi.txt
-+		translit/Zawgyi_my.txt
-+		translit/am_am_FONIPA.txt
-+		translit/am_am_Latn_BGN.txt
-+		translit/am_ar.txt
-+		translit/am_chr.txt
-+		translit/am_fa.txt
-+		translit/ar_ar_Latn_BGN.txt
-+		translit/az_Cyrl_az_BGN.txt
-+		translit/az_Lower.txt
-+		translit/az_Title.txt
-+		translit/az_Upper.txt
-+		translit/be_be_Latn_BGN.txt
-+		translit/bg_bg_Latn_BGN.txt
-+		translit/blt_blt_FONIPA.txt
-+		translit/ch_am.txt
-+		translit/ch_ar.txt
-+		translit/ch_ch_FONIPA.txt
-+		translit/ch_chr.txt
-+		translit/ch_fa.txt
-+		translit/chr_chr_FONIPA.txt
-+		translit/cs_FONIPA_ja.txt
-+		translit/cs_FONIPA_ko.txt
-+		translit/cs_am.txt
-+		translit/cs_ar.txt
-+		translit/cs_chr.txt
-+		translit/cs_cs_FONIPA.txt
-+		translit/cs_fa.txt
-+		translit/cs_ja.txt
-+		translit/cs_ko.txt
-+		translit/cy_cy_FONIPA.txt
-+		translit/de_ASCII.txt
-+		translit/dsb_dsb_FONIPA.txt
-+		translit/dv_dv_Latn_BGN.txt
-+		translit/el_Lower.txt
-+		translit/el_Title.txt
-+		translit/el_Upper.txt
-+		translit/el_el_Latn_BGN.txt
-+		translit/eo_am.txt
-+		translit/eo_ar.txt
-+		translit/eo_chr.txt
-+		translit/eo_eo_FONIPA.txt
-+		translit/eo_fa.txt
-+		translit/es_419_am.txt
-+		translit/es_419_ar.txt
-+		translit/es_419_chr.txt
-+		translit/es_419_fa.txt
-+		translit/es_419_ja.txt
-+		translit/es_419_zh.txt
-+		translit/es_FONIPA_am.txt
-+		translit/es_FONIPA_es_419_FONIPA.txt
-+		translit/es_FONIPA_ja.txt
-+		translit/es_FONIPA_zh.txt
-+		translit/es_am.txt
-+		translit/es_ar.txt
-+		translit/es_chr.txt
-+		translit/es_es_FONIPA.txt
-+		translit/es_fa.txt
-+		translit/es_ja.txt
-+		translit/es_zh.txt
-+		translit/fa_fa_FONIPA.txt
-+		translit/fa_fa_Latn_BGN.txt
-+		translit/ha_ha_NE.txt
-+		translit/he_he_Latn_BGN.txt
-+		translit/hy_AREVMDA_am.txt
-+		translit/hy_AREVMDA_ar.txt
-+		translit/hy_AREVMDA_chr.txt
-+		translit/hy_AREVMDA_fa.txt
-+		translit/hy_AREVMDA_hy_AREVMDA_FONIPA.txt
-+		translit/hy_am.txt
-+		translit/hy_ar.txt
-+		translit/hy_chr.txt
-+		translit/hy_fa.txt
-+		translit/hy_hy_FONIPA.txt
-+		translit/hy_hy_Latn_BGN.txt
-+		translit/ia_am.txt
-+		translit/ia_ar.txt
-+		translit/ia_chr.txt
-+		translit/ia_fa.txt
-+		translit/ia_ia_FONIPA.txt
-+		translit/it_am.txt
-+		translit/it_ja.txt
-+		translit/ja_Hrkt_ja_Latn_BGN.txt
-+		translit/ja_Latn_ko.txt
-+		translit/ja_Latn_ru.txt
-+		translit/ka_ka_Latn_BGN.txt
-+		translit/ka_ka_Latn_BGN_1981.txt
-+		translit/kk_am.txt
-+		translit/kk_ar.txt
-+		translit/kk_chr.txt
-+		translit/kk_fa.txt
-+		translit/kk_kk_FONIPA.txt
-+		translit/kk_kk_Latn_BGN.txt
-+		translit/ko_ko_Latn_BGN.txt
-+		translit/ky_am.txt
-+		translit/ky_ar.txt
-+		translit/ky_chr.txt
-+		translit/ky_fa.txt
-+		translit/ky_ky_FONIPA.txt
-+		translit/ky_ky_Latn_BGN.txt
-+		translit/la_la_FONIPA.txt
-+		translit/lt_Lower.txt
-+		translit/lt_Title.txt
-+		translit/lt_Upper.txt
-+		translit/mk_mk_Latn_BGN.txt
-+		translit/mn_mn_Latn_BGN.txt
-+		translit/mn_mn_Latn_MNS.txt
-+		translit/my_Zawgyi.txt
-+		translit/my_am.txt
-+		translit/my_ar.txt
-+		translit/my_chr.txt
-+		translit/my_fa.txt
-+		translit/my_my_FONIPA.txt
-+		translit/my_my_Latn.txt
-+		translit/nl_Title.txt
-+		translit/nv_nv_FONIPA.txt
-+		translit/pl_FONIPA_ja.txt
-+		translit/pl_am.txt
-+		translit/pl_ar.txt
-+		translit/pl_chr.txt
-+		translit/pl_fa.txt
-+		translit/pl_ja.txt
-+		translit/pl_pl_FONIPA.txt
-+		translit/ps_ps_Latn_BGN.txt
-+		translit/rm_SURSILV_am.txt
-+		translit/rm_SURSILV_ar.txt
-+		translit/rm_SURSILV_chr.txt
-+		translit/rm_SURSILV_fa.txt
-+		translit/rm_SURSILV_rm_FONIPA_SURSILV.txt
-+		translit/ro_FONIPA_ja.txt
-+		translit/ro_am.txt
-+		translit/ro_ar.txt
-+		translit/ro_chr.txt
-+		translit/ro_fa.txt
-+		translit/ro_ja.txt
-+		translit/ro_ro_FONIPA.txt
-+		translit/ru_Latn_ru_BGN.txt
-+		translit/ru_ja.txt
-+		translit/ru_ru_Latn_BGN.txt
-+		translit/ru_zh.txt
-+		translit/sat_Olck_sat_FONIPA.txt
-+		translit/sat_am.txt
-+		translit/sat_ar.txt
-+		translit/sat_chr.txt
-+		translit/sat_fa.txt
-+		translit/si_am.txt
-+		translit/si_ar.txt
-+		translit/si_chr.txt
-+		translit/si_fa.txt
-+		translit/si_si_FONIPA.txt
-+		translit/si_si_Latn.txt
-+		translit/sk_FONIPA_ja.txt
-+		translit/sk_am.txt
-+		translit/sk_ar.txt
-+		translit/sk_chr.txt
-+		translit/sk_fa.txt
-+		translit/sk_ja.txt
-+		translit/sk_sk_FONIPA.txt
-+		translit/sr_sr_Latn_BGN.txt
-+		translit/ta_ta_FONIPA.txt
-+		translit/tk_Cyrl_tk_BGN.txt
-+		translit/tlh_am.txt
-+		translit/tlh_ar.txt
-+		translit/tlh_chr.txt
-+		translit/tlh_fa.txt
-+		translit/tlh_tlh_FONIPA.txt
-+		translit/tr_Lower.txt
-+		translit/tr_Title.txt
-+		translit/tr_Upper.txt
-+		translit/ug_ug_FONIPA.txt
-+		translit/uk_uk_Latn_BGN.txt
-+		translit/und_FONIPA_ar.txt
-+		translit/und_FONIPA_chr.txt
-+		translit/und_FONIPA_fa.txt
-+		translit/und_FONIPA_und_FONXSAMP.txt
-+		translit/uz_Cyrl_uz_BGN.txt
-+		translit/uz_Cyrl_uz_Latn.txt
-+		translit/vec_vec_FONIPA.txt
-+		translit/xh_am.txt
-+		translit/xh_ar.txt
-+		translit/xh_chr.txt
-+		translit/xh_fa.txt
-+		translit/xh_xh_FONIPA.txt
-+		translit/yo_yo_BJ.txt
-+		translit/zh_Latn_PINYIN_ru.txt
-+		translit/zu_am.txt
-+		translit/zu_ar.txt
-+		translit/zu_chr.txt
-+		translit/zu_fa.txt
-+		translit/zu_zu_FONIPA.txt)
-+
-+add_custom_command(
-+  OUTPUT ${OUT_DIR}/translit/root.res
-+  DEPENDS data_dirs ${IN_DIR}/translit/root.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k root.txt
++# translit
++add_prefix(
++    TRANSLIT_RES_DEPS
++    ${IN_DIR}
++    translit/Any_Accents.txt
++    translit/Any_Publishing.txt
++    translit/Arab_Latn.txt
++    translit/Beng_Arab.txt
++    translit/Beng_Deva.txt
++    translit/Beng_Gujr.txt
++    translit/Beng_Guru.txt
++    translit/Beng_Knda.txt
++    translit/Beng_Latn.txt
++    translit/Beng_Mlym.txt
++    translit/Beng_Orya.txt
++    translit/Beng_Taml.txt
++    translit/Beng_Telu.txt
++    translit/Beng_ur.txt
++    translit/Bengali_InterIndic.txt
++    translit/Cyrl_Latn.txt
++    translit/Deva_Arab.txt
++    translit/Deva_Beng.txt
++    translit/Deva_Gujr.txt
++    translit/Deva_Guru.txt
++    translit/Deva_Knda.txt
++    translit/Deva_Latn.txt
++    translit/Deva_Mlym.txt
++    translit/Deva_Orya.txt
++    translit/Deva_Taml.txt
++    translit/Deva_Telu.txt
++    translit/Deva_ur.txt
++    translit/Devanagari_InterIndic.txt
++    translit/Fullwidth_Halfwidth.txt
++    translit/Geor_Latn.txt
++    translit/Grek_Latn.txt
++    translit/Grek_Latn_UNGEGN.txt
++    translit/Gujarati_InterIndic.txt
++    translit/Gujr_Arab.txt
++    translit/Gujr_Beng.txt
++    translit/Gujr_Deva.txt
++    translit/Gujr_Guru.txt
++    translit/Gujr_Knda.txt
++    translit/Gujr_Latn.txt
++    translit/Gujr_Mlym.txt
++    translit/Gujr_Orya.txt
++    translit/Gujr_Taml.txt
++    translit/Gujr_Telu.txt
++    translit/Gujr_ur.txt
++    translit/Gurmukhi_InterIndic.txt
++    translit/Guru_Arab.txt
++    translit/Guru_Beng.txt
++    translit/Guru_Deva.txt
++    translit/Guru_Gujr.txt
++    translit/Guru_Knda.txt
++    translit/Guru_Latn.txt
++    translit/Guru_Mlym.txt
++    translit/Guru_Orya.txt
++    translit/Guru_Taml.txt
++    translit/Guru_Telu.txt
++    translit/Guru_ur.txt
++    translit/Han_Latin_Names.txt
++    translit/Han_Spacedhan.txt
++    translit/Hang_Latn.txt
++    translit/Hani_Latn.txt
++    translit/Hans_Hant.txt
++    translit/Hebr_Latn.txt
++    translit/Hira_Kana.txt
++    translit/Hira_Latn.txt
++    translit/InterIndic_Arabic.txt
++    translit/InterIndic_Bengali.txt
++    translit/InterIndic_Devanagari.txt
++    translit/InterIndic_Gujarati.txt
++    translit/InterIndic_Gurmukhi.txt
++    translit/InterIndic_Kannada.txt
++    translit/InterIndic_Latin.txt
++    translit/InterIndic_Malayalam.txt
++    translit/InterIndic_Oriya.txt
++    translit/InterIndic_Tamil.txt
++    translit/InterIndic_Telugu.txt
++    translit/InterIndic_ur.txt
++    translit/Jamo_Latn.txt
++    translit/Kannada_InterIndic.txt
++    translit/Knda_Arab.txt
++    translit/Knda_Beng.txt
++    translit/Knda_Deva.txt
++    translit/Knda_Gujr.txt
++    translit/Knda_Guru.txt
++    translit/Knda_Latn.txt
++    translit/Knda_Mlym.txt
++    translit/Knda_Orya.txt
++    translit/Knda_Taml.txt
++    translit/Knda_Telu.txt
++    translit/Knda_ur.txt
++    translit/Latin_ASCII.txt
++    translit/Latin_ConjoiningJamo.txt
++    translit/Latin_InterIndic.txt
++    translit/Latin_NumericPinyin.txt
++    translit/Latn_Armn.txt
++    translit/Latn_Beng.txt
++    translit/Latn_Bopo.txt
++    translit/Latn_Cans.txt
++    translit/Latn_Deva.txt
++    translit/Latn_Ethi.txt
++    translit/Latn_Gujr.txt
++    translit/Latn_Guru.txt
++    translit/Latn_Hang.txt
++    translit/Latn_Jamo.txt
++    translit/Latn_Kana.txt
++    translit/Latn_Knda.txt
++    translit/Latn_Mlym.txt
++    translit/Latn_Orya.txt
++    translit/Latn_Taml.txt
++    translit/Latn_Telu.txt
++    translit/Latn_Thaa.txt
++    translit/Latn_Thai.txt
++    translit/Malayalam_InterIndic.txt
++    translit/Mlym_Arab.txt
++    translit/Mlym_Beng.txt
++    translit/Mlym_Deva.txt
++    translit/Mlym_Gujr.txt
++    translit/Mlym_Guru.txt
++    translit/Mlym_Knda.txt
++    translit/Mlym_Latn.txt
++    translit/Mlym_Orya.txt
++    translit/Mlym_Taml.txt
++    translit/Mlym_Telu.txt
++    translit/Mlym_ur.txt
++    translit/Oriya_InterIndic.txt
++    translit/Orya_Arab.txt
++    translit/Orya_Beng.txt
++    translit/Orya_Deva.txt
++    translit/Orya_Gujr.txt
++    translit/Orya_Guru.txt
++    translit/Orya_Knda.txt
++    translit/Orya_Latn.txt
++    translit/Orya_Mlym.txt
++    translit/Orya_Taml.txt
++    translit/Orya_Telu.txt
++    translit/Orya_ur.txt
++    translit/Pinyin_NumericPinyin.txt
++    translit/Syrc_Latn.txt
++    translit/Tamil_InterIndic.txt
++    translit/Taml_Arab.txt
++    translit/Taml_Beng.txt
++    translit/Taml_Deva.txt
++    translit/Taml_Gujr.txt
++    translit/Taml_Guru.txt
++    translit/Taml_Knda.txt
++    translit/Taml_Latn.txt
++    translit/Taml_Mlym.txt
++    translit/Taml_Orya.txt
++    translit/Taml_Telu.txt
++    translit/Taml_ur.txt
++    translit/Telu_Arab.txt
++    translit/Telu_Beng.txt
++    translit/Telu_Deva.txt
++    translit/Telu_Gujr.txt
++    translit/Telu_Guru.txt
++    translit/Telu_Knda.txt
++    translit/Telu_Latn.txt
++    translit/Telu_Mlym.txt
++    translit/Telu_Orya.txt
++    translit/Telu_Taml.txt
++    translit/Telu_ur.txt
++    translit/Telugu_InterIndic.txt
++    translit/ThaiLogical_Latin.txt
++    translit/Thai_Latn.txt
++    translit/Thai_ThaiLogical.txt
++    translit/Thai_ThaiSemi.txt
++    translit/Zawgyi_my.txt
++    translit/am_am_FONIPA.txt
++    translit/am_am_Latn_BGN.txt
++    translit/am_ar.txt
++    translit/am_chr.txt
++    translit/am_fa.txt
++    translit/ar_ar_Latn_BGN.txt
++    translit/az_Cyrl_az_BGN.txt
++    translit/az_Lower.txt
++    translit/az_Title.txt
++    translit/az_Upper.txt
++    translit/be_be_Latn_BGN.txt
++    translit/bg_bg_Latn_BGN.txt
++    translit/blt_blt_FONIPA.txt
++    translit/ch_am.txt
++    translit/ch_ar.txt
++    translit/ch_ch_FONIPA.txt
++    translit/ch_chr.txt
++    translit/ch_fa.txt
++    translit/chr_chr_FONIPA.txt
++    translit/cs_FONIPA_ja.txt
++    translit/cs_FONIPA_ko.txt
++    translit/cs_am.txt
++    translit/cs_ar.txt
++    translit/cs_chr.txt
++    translit/cs_cs_FONIPA.txt
++    translit/cs_fa.txt
++    translit/cs_ja.txt
++    translit/cs_ko.txt
++    translit/cy_cy_FONIPA.txt
++    translit/de_ASCII.txt
++    translit/dsb_dsb_FONIPA.txt
++    translit/dv_dv_Latn_BGN.txt
++    translit/el_Lower.txt
++    translit/el_Title.txt
++    translit/el_Upper.txt
++    translit/el_el_Latn_BGN.txt
++    translit/eo_am.txt
++    translit/eo_ar.txt
++    translit/eo_chr.txt
++    translit/eo_eo_FONIPA.txt
++    translit/eo_fa.txt
++    translit/es_419_am.txt
++    translit/es_419_ar.txt
++    translit/es_419_chr.txt
++    translit/es_419_fa.txt
++    translit/es_419_ja.txt
++    translit/es_419_zh.txt
++    translit/es_FONIPA_am.txt
++    translit/es_FONIPA_es_419_FONIPA.txt
++    translit/es_FONIPA_ja.txt
++    translit/es_FONIPA_zh.txt
++    translit/es_am.txt
++    translit/es_ar.txt
++    translit/es_chr.txt
++    translit/es_es_FONIPA.txt
++    translit/es_fa.txt
++    translit/es_ja.txt
++    translit/es_zh.txt
++    translit/fa_fa_FONIPA.txt
++    translit/fa_fa_Latn_BGN.txt
++    translit/ha_ha_NE.txt
++    translit/he_he_Latn_BGN.txt
++    translit/hy_AREVMDA_am.txt
++    translit/hy_AREVMDA_ar.txt
++    translit/hy_AREVMDA_chr.txt
++    translit/hy_AREVMDA_fa.txt
++    translit/hy_AREVMDA_hy_AREVMDA_FONIPA.txt
++    translit/hy_am.txt
++    translit/hy_ar.txt
++    translit/hy_chr.txt
++    translit/hy_fa.txt
++    translit/hy_hy_FONIPA.txt
++    translit/hy_hy_Latn_BGN.txt
++    translit/ia_am.txt
++    translit/ia_ar.txt
++    translit/ia_chr.txt
++    translit/ia_fa.txt
++    translit/ia_ia_FONIPA.txt
++    translit/it_am.txt
++    translit/it_ja.txt
++    translit/ja_Hrkt_ja_Latn_BGN.txt
++    translit/ja_Latn_ko.txt
++    translit/ja_Latn_ru.txt
++    translit/ka_ka_Latn_BGN.txt
++    translit/ka_ka_Latn_BGN_1981.txt
++    translit/kk_am.txt
++    translit/kk_ar.txt
++    translit/kk_chr.txt
++    translit/kk_fa.txt
++    translit/kk_kk_FONIPA.txt
++    translit/kk_kk_Latn_BGN.txt
++    translit/ko_ko_Latn_BGN.txt
++    translit/ky_am.txt
++    translit/ky_ar.txt
++    translit/ky_chr.txt
++    translit/ky_fa.txt
++    translit/ky_ky_FONIPA.txt
++    translit/ky_ky_Latn_BGN.txt
++    translit/la_la_FONIPA.txt
++    translit/lt_Lower.txt
++    translit/lt_Title.txt
++    translit/lt_Upper.txt
++    translit/mk_mk_Latn_BGN.txt
++    translit/mn_mn_Latn_BGN.txt
++    translit/mn_mn_Latn_MNS.txt
++    translit/my_Zawgyi.txt
++    translit/my_am.txt
++    translit/my_ar.txt
++    translit/my_chr.txt
++    translit/my_fa.txt
++    translit/my_my_FONIPA.txt
++    translit/my_my_Latn.txt
++    translit/nl_Title.txt
++    translit/nv_nv_FONIPA.txt
++    translit/pl_FONIPA_ja.txt
++    translit/pl_am.txt
++    translit/pl_ar.txt
++    translit/pl_chr.txt
++    translit/pl_fa.txt
++    translit/pl_ja.txt
++    translit/pl_pl_FONIPA.txt
++    translit/ps_ps_Latn_BGN.txt
++    translit/rm_SURSILV_am.txt
++    translit/rm_SURSILV_ar.txt
++    translit/rm_SURSILV_chr.txt
++    translit/rm_SURSILV_fa.txt
++    translit/rm_SURSILV_rm_FONIPA_SURSILV.txt
++    translit/ro_FONIPA_ja.txt
++    translit/ro_am.txt
++    translit/ro_ar.txt
++    translit/ro_chr.txt
++    translit/ro_fa.txt
++    translit/ro_ja.txt
++    translit/ro_ro_FONIPA.txt
++    translit/ru_Latn_ru_BGN.txt
++    translit/ru_ja.txt
++    translit/ru_ru_Latn_BGN.txt
++    translit/ru_zh.txt
++    translit/sat_Olck_sat_FONIPA.txt
++    translit/sat_am.txt
++    translit/sat_ar.txt
++    translit/sat_chr.txt
++    translit/sat_fa.txt
++    translit/si_am.txt
++    translit/si_ar.txt
++    translit/si_chr.txt
++    translit/si_fa.txt
++    translit/si_si_FONIPA.txt
++    translit/si_si_Latn.txt
++    translit/sk_FONIPA_ja.txt
++    translit/sk_am.txt
++    translit/sk_ar.txt
++    translit/sk_chr.txt
++    translit/sk_fa.txt
++    translit/sk_ja.txt
++    translit/sk_sk_FONIPA.txt
++    translit/sr_sr_Latn_BGN.txt
++    translit/ta_ta_FONIPA.txt
++    translit/tk_Cyrl_tk_BGN.txt
++    translit/tlh_am.txt
++    translit/tlh_ar.txt
++    translit/tlh_chr.txt
++    translit/tlh_fa.txt
++    translit/tlh_tlh_FONIPA.txt
++    translit/tr_Lower.txt
++    translit/tr_Title.txt
++    translit/tr_Upper.txt
++    translit/ug_ug_FONIPA.txt
++    translit/uk_uk_Latn_BGN.txt
++    translit/und_FONIPA_ar.txt
++    translit/und_FONIPA_chr.txt
++    translit/und_FONIPA_fa.txt
++    translit/und_FONIPA_und_FONXSAMP.txt
++    translit/uz_Cyrl_uz_BGN.txt
++    translit/uz_Cyrl_uz_Latn.txt
++    translit/vec_vec_FONIPA.txt
++    translit/xh_am.txt
++    translit/xh_ar.txt
++    translit/xh_chr.txt
++    translit/xh_fa.txt
++    translit/xh_xh_FONIPA.txt
++    translit/yo_yo_BJ.txt
++    translit/zh_Latn_PINYIN_ru.txt
++    translit/zu_am.txt
++    translit/zu_ar.txt
++    translit/zu_chr.txt
++    translit/zu_fa.txt
++    translit/zu_zu_FONIPA.txt
 +)
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/translit/en.res
-+  DEPENDS data_dirs ${IN_DIR}/translit/en.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k en.txt
++    OUTPUT ${OUT_DIR}/translit/root.res
++    DEPENDS data_dirs ${IN_DIR}/translit/root.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k root.txt
 +)
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/translit/el.res
-+  DEPENDS data_dirs ${IN_DIR}/translit/el.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k el.txt
++    OUTPUT ${OUT_DIR}/translit/en.res
++    DEPENDS data_dirs ${IN_DIR}/translit/en.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k en.txt
 +)
 +
-+### locales pool
++add_custom_command(
++    OUTPUT ${OUT_DIR}/translit/el.res
++    DEPENDS data_dirs ${IN_DIR}/translit/el.txt ${TRANSLIT_RES_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/translit -d ${OUT_DIR}/translit/ -i ${OUT_DIR} -k el.txt
++)
++
++# locales pool
 +
 +set(LOCALES_POOL_LIST
-+        af
-+		af_NA
-+		af_ZA
-+		agq
-+		agq_CM
-+		ak
-+		ak_GH
-+		am
-+		am_ET
-+		ar
-+		ar_001
-+		ar_AE
-+		ar_BH
-+		ar_DJ
-+		ar_DZ
-+		ar_EG
-+		ar_EH
-+		ar_ER
-+		ar_IL
-+		ar_IQ
-+		ar_JO
-+		ar_KM
-+		ar_KW
-+		ar_LB
-+		ar_LY
-+		ar_MA
-+		ar_MR
-+		ar_OM
-+		ar_PS
-+		ar_QA
-+		ar_SA
-+		ar_SD
-+		ar_SO
-+		ar_SS
-+		ar_SY
-+		ar_TD
-+		ar_TN
-+		ar_YE
-+		ars
-+		as
-+		as_IN
-+		asa
-+		asa_TZ
-+		ast
-+		ast_ES
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Cyrl_AZ
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		bas_CM
-+		be
-+		be_BY
-+		bem
-+		bem_ZM
-+		bez
-+		bez_TZ
-+		bg
-+		bg_BG
-+		bm
-+		bm_ML
-+		bn
-+		bn_BD
-+		bn_IN
-+		bo
-+		bo_CN
-+		bo_IN
-+		br
-+		br_FR
-+		brx
-+		brx_IN
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Cyrl_BA
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ca_AD
-+		ca_ES
-+		ca_FR
-+		ca_IT
-+		ccp
-+		ccp_BD
-+		ccp_IN
-+		ce
-+		ce_RU
-+		ceb
-+		ceb_PH
-+		cgg
-+		cgg_UG
-+		chr
-+		chr_US
-+		ckb
-+		ckb_IQ
-+		ckb_IR
-+		cs
-+		cs_CZ
-+		cy
-+		cy_GB
-+		da
-+		da_DK
-+		da_GL
-+		dav
-+		dav_KE
-+		de
-+		de_AT
-+		de_BE
-+		de_CH
-+		de_DE
-+		de_IT
-+		de_LI
-+		de_LU
-+		dje
-+		dje_NE
-+		dsb
-+		dsb_DE
-+		dua
-+		dua_CM
-+		dyo
-+		dyo_SN
-+		dz
-+		dz_BT
-+		ebu
-+		ebu_KE
-+		ee
-+		ee_GH
-+		ee_TG
-+		el
-+		el_CY
-+		el_GR
-+		en
-+		en_001
-+		en_150
-+		en_AE
-+		en_AG
-+		en_AI
-+		en_AS
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BI
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GU
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MH
-+		en_MO
-+		en_MP
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PR
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_UM
-+		en_US
-+		en_US_POSIX
-+		en_VC
-+		en_VG
-+		en_VI
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		eo_001
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EA
-+		es_EC
-+		es_ES
-+		es_GQ
-+		es_GT
-+		es_HN
-+		es_IC
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PH
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		et_EE
-+		eu
-+		eu_ES
-+		ewo
-+		ewo_CM
-+		fa
-+		fa_AF
-+		fa_IR
-+		ff
-+		ff_Adlm
-+		ff_Adlm_BF
-+		ff_Adlm_CM
-+		ff_Adlm_GH
-+		ff_Adlm_GM
-+		ff_Adlm_GN
-+		ff_Adlm_GW
-+		ff_Adlm_LR
-+		ff_Adlm_MR
-+		ff_Adlm_NE
-+		ff_Adlm_NG
-+		ff_Adlm_SL
-+		ff_Adlm_SN
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_BF
-+		ff_Latn_CM
-+		ff_Latn_GH
-+		ff_Latn_GM
-+		ff_Latn_GN
-+		ff_Latn_GW
-+		ff_Latn_LR
-+		ff_Latn_MR
-+		ff_Latn_NE
-+		ff_Latn_NG
-+		ff_Latn_SL
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fi_FI
-+		fil
-+		fil_PH
-+		fo
-+		fo_DK
-+		fo_FO
-+		fr
-+		fr_BE
-+		fr_BF
-+		fr_BI
-+		fr_BJ
-+		fr_BL
-+		fr_CA
-+		fr_CD
-+		fr_CF
-+		fr_CG
-+		fr_CH
-+		fr_CI
-+		fr_CM
-+		fr_DJ
-+		fr_DZ
-+		fr_FR
-+		fr_GA
-+		fr_GF
-+		fr_GN
-+		fr_GP
-+		fr_GQ
-+		fr_HT
-+		fr_KM
-+		fr_LU
-+		fr_MA
-+		fr_MC
-+		fr_MF
-+		fr_MG
-+		fr_ML
-+		fr_MQ
-+		fr_MR
-+		fr_MU
-+		fr_NC
-+		fr_NE
-+		fr_PF
-+		fr_PM
-+		fr_RE
-+		fr_RW
-+		fr_SC
-+		fr_SN
-+		fr_SY
-+		fr_TD
-+		fr_TG
-+		fr_TN
-+		fr_VU
-+		fr_WF
-+		fr_YT
-+		fur
-+		fur_IT
-+		fy
-+		fy_NL
-+		ga
-+		ga_GB
-+		ga_IE
-+		gd
-+		gd_GB
-+		gl
-+		gl_ES
-+		gsw
-+		gsw_CH
-+		gsw_FR
-+		gsw_LI
-+		gu
-+		gu_IN
-+		guz
-+		guz_KE
-+		gv
-+		gv_IM
-+		ha
-+		ha_GH
-+		ha_NE
-+		ha_NG
-+		haw
-+		haw_US
-+		he
-+		he_IL
-+		hi
-+		hi_IN
-+		hr
-+		hr_BA
-+		hr_HR
-+		hsb
-+		hsb_DE
-+		hu
-+		hu_HU
-+		hy
-+		hy_AM
-+		ia
-+		ia_001
-+		id
-+		id_ID
-+		ig
-+		ig_NG
-+		ii
-+		ii_CN
-+		in
-+		in_ID
-+		is
-+		is_IS
-+		it
-+		it_CH
-+		it_IT
-+		it_SM
-+		it_VA
-+		iw
-+		iw_IL
-+		ja
-+		ja_JP
-+		ja_JP_TRADITIONAL
-+		jgo
-+		jgo_CM
-+		jmc
-+		jmc_TZ
-+		jv
-+		jv_ID
-+		ka
-+		ka_GE
-+		kab
-+		kab_DZ
-+		kam
-+		kam_KE
-+		kde
-+		kde_TZ
-+		kea
-+		kea_CV
-+		khq
-+		khq_ML
-+		ki
-+		ki_KE
-+		kk
-+		kk_KZ
-+		kkj
-+		kkj_CM
-+		kl
-+		kl_GL
-+		kln
-+		kln_KE
-+		km
-+		km_KH
-+		kn
-+		kn_IN
-+		ko
-+		ko_KP
-+		ko_KR
-+		kok
-+		kok_IN
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksb_TZ
-+		ksf
-+		ksf_CM
-+		ksh
-+		ksh_DE
-+		ku
-+		ku_TR
-+		kw
-+		kw_GB
-+		ky
-+		ky_KG
-+		lag
-+		lag_TZ
-+		lb
-+		lb_LU
-+		lg
-+		lg_UG
-+		lkt
-+		lkt_US
-+		ln
-+		ln_AO
-+		ln_CD
-+		ln_CF
-+		ln_CG
-+		lo
-+		lo_LA
-+		lrc
-+		lrc_IQ
-+		lrc_IR
-+		lt
-+		lt_LT
-+		lu
-+		lu_CD
-+		luo
-+		luo_KE
-+		luy
-+		luy_KE
-+		lv
-+		lv_LV
-+		mai
-+		mai_IN
-+		mas
-+		mas_KE
-+		mas_TZ
-+		mer
-+		mer_KE
-+		mfe
-+		mfe_MU
-+		mg
-+		mg_MG
-+		mgh
-+		mgh_MZ
-+		mgo
-+		mgo_CM
-+		mi
-+		mi_NZ
-+		mk
-+		mk_MK
-+		ml
-+		ml_IN
-+		mn
-+		mn_MN
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		mr_IN
-+		ms
-+		ms_BN
-+		ms_ID
-+		ms_MY
-+		ms_SG
-+		mt
-+		mt_MT
-+		mua
-+		mua_CM
-+		my
-+		my_MM
-+		mzn
-+		mzn_IR
-+		naq
-+		naq_NA
-+		nb
-+		nb_NO
-+		nb_SJ
-+		nd
-+		nd_ZW
-+		nds
-+		nds_DE
-+		nds_NL
-+		ne
-+		ne_IN
-+		ne_NP
-+		nl
-+		nl_AW
-+		nl_BE
-+		nl_BQ
-+		nl_CW
-+		nl_NL
-+		nl_SR
-+		nl_SX
-+		nmg
-+		nmg_CM
-+		nn
-+		nn_NO
-+		nnh
-+		nnh_CM
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nus_SS
-+		nyn
-+		nyn_UG
-+		om
-+		om_ET
-+		om_KE
-+		or
-+		or_IN
-+		os
-+		os_GE
-+		os_RU
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pcm_NG
-+		pl
-+		pl_PL
-+		ps
-+		ps_AF
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_BR
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		qu_BO
-+		qu_EC
-+		qu_PE
-+		rm
-+		rm_CH
-+		rn
-+		rn_BI
-+		ro
-+		ro_MD
-+		ro_RO
-+		rof
-+		rof_TZ
-+		root
-+		ru
-+		ru_BY
-+		ru_KG
-+		ru_KZ
-+		ru_MD
-+		ru_RU
-+		ru_UA
-+		rw
-+		rw_RW
-+		rwk
-+		rwk_TZ
-+		sah
-+		sah_RU
-+		saq
-+		saq_KE
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sbp_TZ
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_Deva_IN
-+		sd_PK
-+		se
-+		se_FI
-+		se_NO
-+		se_SE
-+		seh
-+		seh_MZ
-+		ses
-+		ses_ML
-+		sg
-+		sg_CF
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_Latn_MA
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		si_LK
-+		sk
-+		sk_SK
-+		sl
-+		sl_SI
-+		smn
-+		smn_FI
-+		sn
-+		sn_ZW
-+		so
-+		so_DJ
-+		so_ET
-+		so_KE
-+		so_SO
-+		sq
-+		sq_AL
-+		sq_MK
-+		sq_XK
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_ME
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_XK
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sv_AX
-+		sv_FI
-+		sv_SE
-+		sw
-+		sw_CD
-+		sw_KE
-+		sw_TZ
-+		sw_UG
-+		ta
-+		ta_IN
-+		ta_LK
-+		ta_MY
-+		ta_SG
-+		te
-+		te_IN
-+		teo
-+		teo_KE
-+		teo_UG
-+		tg
-+		tg_TJ
-+		th
-+		th_TH
-+		th_TH_TRADITIONAL
-+		ti
-+		ti_ER
-+		ti_ET
-+		tk
-+		tk_TM
-+		tl
-+		tl_PH
-+		to
-+		to_TO
-+		tr
-+		tr_CY
-+		tr_TR
-+		tt
-+		tt_RU
-+		twq
-+		twq_NE
-+		tzm
-+		tzm_MA
-+		ug
-+		ug_CN
-+		uk
-+		uk_UA
-+		ur
-+		ur_IN
-+		ur_PK
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Cyrl_UZ
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Latn_LR
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vi_VN
-+		vun
-+		vun_TZ
-+		wae
-+		wae_CH
-+		wo
-+		wo_SN
-+		xh
-+		xh_ZA
-+		xog
-+		xog_UG
-+		yav
-+		yav_CM
-+		yi
-+		yi_001
-+		yo
-+		yo_BJ
-+		yo_NG
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zgh_MA
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_HK
-+		zh_Hans_MO
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu
-+		zu_ZA)
++    af
++    af_NA
++    af_ZA
++    agq
++    agq_CM
++    ak
++    ak_GH
++    am
++    am_ET
++    ar
++    ar_001
++    ar_AE
++    ar_BH
++    ar_DJ
++    ar_DZ
++    ar_EG
++    ar_EH
++    ar_ER
++    ar_IL
++    ar_IQ
++    ar_JO
++    ar_KM
++    ar_KW
++    ar_LB
++    ar_LY
++    ar_MA
++    ar_MR
++    ar_OM
++    ar_PS
++    ar_QA
++    ar_SA
++    ar_SD
++    ar_SO
++    ar_SS
++    ar_SY
++    ar_TD
++    ar_TN
++    ar_YE
++    ars
++    as
++    as_IN
++    asa
++    asa_TZ
++    ast
++    ast_ES
++    az
++    az_AZ
++    az_Cyrl
++    az_Cyrl_AZ
++    az_Latn
++    az_Latn_AZ
++    bas
++    bas_CM
++    be
++    be_BY
++    bem
++    bem_ZM
++    bez
++    bez_TZ
++    bg
++    bg_BG
++    bm
++    bm_ML
++    bn
++    bn_BD
++    bn_IN
++    bo
++    bo_CN
++    bo_IN
++    br
++    br_FR
++    brx
++    brx_IN
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Cyrl_BA
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ca_AD
++    ca_ES
++    ca_FR
++    ca_IT
++    ccp
++    ccp_BD
++    ccp_IN
++    ce
++    ce_RU
++    ceb
++    ceb_PH
++    cgg
++    cgg_UG
++    chr
++    chr_US
++    ckb
++    ckb_IQ
++    ckb_IR
++    cs
++    cs_CZ
++    cy
++    cy_GB
++    da
++    da_DK
++    da_GL
++    dav
++    dav_KE
++    de
++    de_AT
++    de_BE
++    de_CH
++    de_DE
++    de_IT
++    de_LI
++    de_LU
++    dje
++    dje_NE
++    dsb
++    dsb_DE
++    dua
++    dua_CM
++    dyo
++    dyo_SN
++    dz
++    dz_BT
++    ebu
++    ebu_KE
++    ee
++    ee_GH
++    ee_TG
++    el
++    el_CY
++    el_GR
++    en
++    en_001
++    en_150
++    en_AE
++    en_AG
++    en_AI
++    en_AS
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BI
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GU
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MH
++    en_MO
++    en_MP
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PR
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_UM
++    en_US
++    en_US_POSIX
++    en_VC
++    en_VG
++    en_VI
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    eo_001
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EA
++    es_EC
++    es_ES
++    es_GQ
++    es_GT
++    es_HN
++    es_IC
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PH
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    et_EE
++    eu
++    eu_ES
++    ewo
++    ewo_CM
++    fa
++    fa_AF
++    fa_IR
++    ff
++    ff_Adlm
++    ff_Adlm_BF
++    ff_Adlm_CM
++    ff_Adlm_GH
++    ff_Adlm_GM
++    ff_Adlm_GN
++    ff_Adlm_GW
++    ff_Adlm_LR
++    ff_Adlm_MR
++    ff_Adlm_NE
++    ff_Adlm_NG
++    ff_Adlm_SL
++    ff_Adlm_SN
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_BF
++    ff_Latn_CM
++    ff_Latn_GH
++    ff_Latn_GM
++    ff_Latn_GN
++    ff_Latn_GW
++    ff_Latn_LR
++    ff_Latn_MR
++    ff_Latn_NE
++    ff_Latn_NG
++    ff_Latn_SL
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fi_FI
++    fil
++    fil_PH
++    fo
++    fo_DK
++    fo_FO
++    fr
++    fr_BE
++    fr_BF
++    fr_BI
++    fr_BJ
++    fr_BL
++    fr_CA
++    fr_CD
++    fr_CF
++    fr_CG
++    fr_CH
++    fr_CI
++    fr_CM
++    fr_DJ
++    fr_DZ
++    fr_FR
++    fr_GA
++    fr_GF
++    fr_GN
++    fr_GP
++    fr_GQ
++    fr_HT
++    fr_KM
++    fr_LU
++    fr_MA
++    fr_MC
++    fr_MF
++    fr_MG
++    fr_ML
++    fr_MQ
++    fr_MR
++    fr_MU
++    fr_NC
++    fr_NE
++    fr_PF
++    fr_PM
++    fr_RE
++    fr_RW
++    fr_SC
++    fr_SN
++    fr_SY
++    fr_TD
++    fr_TG
++    fr_TN
++    fr_VU
++    fr_WF
++    fr_YT
++    fur
++    fur_IT
++    fy
++    fy_NL
++    ga
++    ga_GB
++    ga_IE
++    gd
++    gd_GB
++    gl
++    gl_ES
++    gsw
++    gsw_CH
++    gsw_FR
++    gsw_LI
++    gu
++    gu_IN
++    guz
++    guz_KE
++    gv
++    gv_IM
++    ha
++    ha_GH
++    ha_NE
++    ha_NG
++    haw
++    haw_US
++    he
++    he_IL
++    hi
++    hi_IN
++    hr
++    hr_BA
++    hr_HR
++    hsb
++    hsb_DE
++    hu
++    hu_HU
++    hy
++    hy_AM
++    ia
++    ia_001
++    id
++    id_ID
++    ig
++    ig_NG
++    ii
++    ii_CN
++    in
++    in_ID
++    is
++    is_IS
++    it
++    it_CH
++    it_IT
++    it_SM
++    it_VA
++    iw
++    iw_IL
++    ja
++    ja_JP
++    ja_JP_TRADITIONAL
++    jgo
++    jgo_CM
++    jmc
++    jmc_TZ
++    jv
++    jv_ID
++    ka
++    ka_GE
++    kab
++    kab_DZ
++    kam
++    kam_KE
++    kde
++    kde_TZ
++    kea
++    kea_CV
++    khq
++    khq_ML
++    ki
++    ki_KE
++    kk
++    kk_KZ
++    kkj
++    kkj_CM
++    kl
++    kl_GL
++    kln
++    kln_KE
++    km
++    km_KH
++    kn
++    kn_IN
++    ko
++    ko_KP
++    ko_KR
++    kok
++    kok_IN
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksb_TZ
++    ksf
++    ksf_CM
++    ksh
++    ksh_DE
++    ku
++    ku_TR
++    kw
++    kw_GB
++    ky
++    ky_KG
++    lag
++    lag_TZ
++    lb
++    lb_LU
++    lg
++    lg_UG
++    lkt
++    lkt_US
++    ln
++    ln_AO
++    ln_CD
++    ln_CF
++    ln_CG
++    lo
++    lo_LA
++    lrc
++    lrc_IQ
++    lrc_IR
++    lt
++    lt_LT
++    lu
++    lu_CD
++    luo
++    luo_KE
++    luy
++    luy_KE
++    lv
++    lv_LV
++    mai
++    mai_IN
++    mas
++    mas_KE
++    mas_TZ
++    mer
++    mer_KE
++    mfe
++    mfe_MU
++    mg
++    mg_MG
++    mgh
++    mgh_MZ
++    mgo
++    mgo_CM
++    mi
++    mi_NZ
++    mk
++    mk_MK
++    ml
++    ml_IN
++    mn
++    mn_MN
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    mr_IN
++    ms
++    ms_BN
++    ms_ID
++    ms_MY
++    ms_SG
++    mt
++    mt_MT
++    mua
++    mua_CM
++    my
++    my_MM
++    mzn
++    mzn_IR
++    naq
++    naq_NA
++    nb
++    nb_NO
++    nb_SJ
++    nd
++    nd_ZW
++    nds
++    nds_DE
++    nds_NL
++    ne
++    ne_IN
++    ne_NP
++    nl
++    nl_AW
++    nl_BE
++    nl_BQ
++    nl_CW
++    nl_NL
++    nl_SR
++    nl_SX
++    nmg
++    nmg_CM
++    nn
++    nn_NO
++    nnh
++    nnh_CM
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nus_SS
++    nyn
++    nyn_UG
++    om
++    om_ET
++    om_KE
++    or
++    or_IN
++    os
++    os_GE
++    os_RU
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pcm_NG
++    pl
++    pl_PL
++    ps
++    ps_AF
++    ps_PK
++    pt
++    pt_AO
++    pt_BR
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    qu_BO
++    qu_EC
++    qu_PE
++    rm
++    rm_CH
++    rn
++    rn_BI
++    ro
++    ro_MD
++    ro_RO
++    rof
++    rof_TZ
++    root
++    ru
++    ru_BY
++    ru_KG
++    ru_KZ
++    ru_MD
++    ru_RU
++    ru_UA
++    rw
++    rw_RW
++    rwk
++    rwk_TZ
++    sah
++    sah_RU
++    saq
++    saq_KE
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sbp_TZ
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_Deva_IN
++    sd_PK
++    se
++    se_FI
++    se_NO
++    se_SE
++    seh
++    seh_MZ
++    ses
++    ses_ML
++    sg
++    sg_CF
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_Latn_MA
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    si_LK
++    sk
++    sk_SK
++    sl
++    sl_SI
++    smn
++    smn_FI
++    sn
++    sn_ZW
++    so
++    so_DJ
++    so_ET
++    so_KE
++    so_SO
++    sq
++    sq_AL
++    sq_MK
++    sq_XK
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_ME
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_XK
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sv_AX
++    sv_FI
++    sv_SE
++    sw
++    sw_CD
++    sw_KE
++    sw_TZ
++    sw_UG
++    ta
++    ta_IN
++    ta_LK
++    ta_MY
++    ta_SG
++    te
++    te_IN
++    teo
++    teo_KE
++    teo_UG
++    tg
++    tg_TJ
++    th
++    th_TH
++    th_TH_TRADITIONAL
++    ti
++    ti_ER
++    ti_ET
++    tk
++    tk_TM
++    tl
++    tl_PH
++    to
++    to_TO
++    tr
++    tr_CY
++    tr_TR
++    tt
++    tt_RU
++    twq
++    twq_NE
++    tzm
++    tzm_MA
++    ug
++    ug_CN
++    uk
++    uk_UA
++    ur
++    ur_IN
++    ur_PK
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Cyrl_UZ
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Latn_LR
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vi_VN
++    vun
++    vun_TZ
++    wae
++    wae_CH
++    wo
++    wo_SN
++    xh
++    xh_ZA
++    xog
++    xog_UG
++    yav
++    yav_CM
++    yi
++    yi_001
++    yo
++    yo_BJ
++    yo_NG
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zgh_MA
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_HK
++    zh_Hans_MO
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++    zu_ZA
++)
 +
 +foreach(LOCALES_POOL_ITEM ${LOCALES_POOL_LIST})
-+  list(APPEND LOCALES_POOL_WRITE_FILES ${LOCALES_POOL_ITEM}.txt)
-+  list(APPEND LOCALES_POOL_WRITE_DEPS ${IN_DIR}/locales/${LOCALES_POOL_ITEM}.txt)
++    list(APPEND LOCALES_POOL_WRITE_FILES ${LOCALES_POOL_ITEM}.txt)
++    list(APPEND LOCALES_POOL_WRITE_DEPS ${IN_DIR}/locales/${LOCALES_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/pool.res
-+  DEPENDS data_dirs ${LOCALES_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --writePoolBundle -k ${LOCALES_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/pool.res
++    DEPENDS data_dirs ${LOCALES_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --writePoolBundle -k
++            ${LOCALES_POOL_WRITE_FILES}
 +)
 +
 +set(LOCALES_RES_DEPS ${OUT_DIR}/pool.res)
 +
 +function(generate_locale_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/locales/${ITEM}.txt ${LOCALES_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/locales/${ITEM}.txt ${LOCALES_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} --usePoolBundle
++                ${OUT_DIR}/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(LOCALES_POOL_ITEM ${LOCALES_POOL_LIST})
-+  generate_locale_item(${LOCALES_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/${LOCALES_POOL_ITEM}.res)
++    generate_locale_item(${LOCALES_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/${LOCALES_POOL_ITEM}.res)
 +endforeach()
 +
-+### locales index
++# locales index
 +
 +configure_file(${IN_DIR}/cmake-locales-index-txt-content.in ${TMP_DIR}/locales/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/locales/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/locales/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/locales -d ${OUT_DIR}/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
 +)
 +
-+### curr pool
++# curr pool
 +
-+set(CURR_POOL_LIST 
-+        af
-+		af_NA
-+		agq
-+		ak
-+		am
-+		ar
-+		ar_AE
-+		ar_DJ
-+		ar_ER
-+		ar_KM
-+		ar_LB
-+		ar_SA
-+		ar_SO
-+		ar_SS
-+		ars
-+		as
-+		asa
-+		ast
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		be
-+		bem
-+		bez
-+		bg
-+		bm
-+		bn
-+		bo
-+		bo_IN
-+		br
-+		brx
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ca_FR
-+		ccp
-+		ce
-+		ceb
-+		cgg
-+		chr
-+		ckb
-+		cs
-+		cy
-+		da
-+		dav
-+		de
-+		de_CH
-+		de_LI
-+		de_LU
-+		dje
-+		dsb
-+		dua
-+		dyo
-+		dz
-+		ebu
-+		ee
-+		el
-+		en
-+		en_001
-+		en_150
-+		en_AE
-+		en_AG
-+		en_AI
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BI
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MO
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_VC
-+		en_VG
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EC
-+		es_GQ
-+		es_GT
-+		es_HN
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PH
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		eu
-+		ewo
-+		fa
-+		fa_AF
-+		ff
-+		ff_Adlm
-+		ff_Adlm_BF
-+		ff_Adlm_CM
-+		ff_Adlm_GH
-+		ff_Adlm_GM
-+		ff_Adlm_GW
-+		ff_Adlm_LR
-+		ff_Adlm_MR
-+		ff_Adlm_NE
-+		ff_Adlm_NG
-+		ff_Adlm_SL
-+		ff_Adlm_SN
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_CM
-+		ff_Latn_GH
-+		ff_Latn_GM
-+		ff_Latn_GN
-+		ff_Latn_LR
-+		ff_Latn_MR
-+		ff_Latn_NG
-+		ff_Latn_SL
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fil
-+		fil_PH
-+		fo
-+		fo_DK
-+		fr
-+		fr_BI
-+		fr_CA
-+		fr_CD
-+		fr_DJ
-+		fr_DZ
-+		fr_GN
-+		fr_HT
-+		fr_KM
-+		fr_LU
-+		fr_MG
-+		fr_MR
-+		fr_MU
-+		fr_RW
-+		fr_SC
-+		fr_SY
-+		fr_TN
-+		fr_VU
-+		fur
-+		fy
-+		ga
-+		gd
-+		gl
-+		gsw
-+		gu
-+		guz
-+		gv
-+		ha
-+		ha_GH
-+		haw
-+		he
-+		he_IL
-+		hi
-+		hr
-+		hr_BA
-+		hsb
-+		hu
-+		hy
-+		ia
-+		id
-+		id_ID
-+		ig
-+		ii
-+		in
-+		in_ID
-+		is
-+		it
-+		iw
-+		iw_IL
-+		ja
-+		jgo
-+		jmc
-+		jv
-+		ka
-+		kab
-+		kam
-+		kde
-+		kea
-+		khq
-+		ki
-+		kk
-+		kkj
-+		kl
-+		kln
-+		km
-+		kn
-+		ko
-+		kok
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksf
-+		ksh
-+		ku
-+		kw
-+		ky
-+		lag
-+		lb
-+		lg
-+		lkt
-+		ln
-+		ln_AO
-+		lo
-+		lrc
-+		lt
-+		lu
-+		luo
-+		luy
-+		lv
-+		mai
-+		mas
-+		mas_TZ
-+		mer
-+		mfe
-+		mg
-+		mgh
-+		mgo
-+		mi
-+		mk
-+		ml
-+		mn
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		ms
-+		ms_BN
-+		ms_ID
-+		ms_SG
-+		mt
-+		mua
-+		my
-+		mzn
-+		naq
-+		nb
-+		nb_NO
-+		nd
-+		nds
-+		ne
-+		nl
-+		nl_AW
-+		nl_BQ
-+		nl_CW
-+		nl_SR
-+		nl_SX
-+		nmg
-+		nn
-+		nn_NO
-+		nnh
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nyn
-+		om
-+		om_KE
-+		or
-+		os
-+		os_RU
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pl
-+		ps
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		qu_BO
-+		qu_EC
-+		rm
-+		rn
-+		ro
-+		ro_MD
-+		rof
-+		root
-+		ru
-+		ru_BY
-+		ru_KG
-+		ru_KZ
-+		ru_MD
-+		rw
-+		rwk
-+		sah
-+		saq
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_PK
-+		se
-+		se_SE
-+		seh
-+		ses
-+		sg
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		sk
-+		sl
-+		smn
-+		sn
-+		so
-+		so_DJ
-+		so_ET
-+		so_KE
-+		sq
-+		sq_MK
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sw
-+		sw_CD
-+		sw_KE
-+		sw_UG
-+		ta
-+		ta_LK
-+		ta_MY
-+		ta_SG
-+		te
-+		teo
-+		teo_KE
-+		tg
-+		th
-+		ti
-+		ti_ER
-+		tk
-+		tl
-+		tl_PH
-+		to
-+		tr
-+		tt
-+		twq
-+		tzm
-+		ug
-+		uk
-+		ur
-+		ur_IN
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vun
-+		wae
-+		wo
-+		xh
-+		xog
-+		yav
-+		yi
-+		yo
-+		yo_BJ
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_HK
-+		zh_Hans_MO
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu)
++set(CURR_POOL_LIST
++    af
++    af_NA
++    agq
++    ak
++    am
++    ar
++    ar_AE
++    ar_DJ
++    ar_ER
++    ar_KM
++    ar_LB
++    ar_SA
++    ar_SO
++    ar_SS
++    ars
++    as
++    asa
++    ast
++    az
++    az_AZ
++    az_Cyrl
++    az_Latn
++    az_Latn_AZ
++    bas
++    be
++    bem
++    bez
++    bg
++    bm
++    bn
++    bo
++    bo_IN
++    br
++    brx
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ca_FR
++    ccp
++    ce
++    ceb
++    cgg
++    chr
++    ckb
++    cs
++    cy
++    da
++    dav
++    de
++    de_CH
++    de_LI
++    de_LU
++    dje
++    dsb
++    dua
++    dyo
++    dz
++    ebu
++    ee
++    el
++    en
++    en_001
++    en_150
++    en_AE
++    en_AG
++    en_AI
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BI
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MO
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_VC
++    en_VG
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EC
++    es_GQ
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PH
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    eu
++    ewo
++    fa
++    fa_AF
++    ff
++    ff_Adlm
++    ff_Adlm_BF
++    ff_Adlm_CM
++    ff_Adlm_GH
++    ff_Adlm_GM
++    ff_Adlm_GW
++    ff_Adlm_LR
++    ff_Adlm_MR
++    ff_Adlm_NE
++    ff_Adlm_NG
++    ff_Adlm_SL
++    ff_Adlm_SN
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_CM
++    ff_Latn_GH
++    ff_Latn_GM
++    ff_Latn_GN
++    ff_Latn_LR
++    ff_Latn_MR
++    ff_Latn_NG
++    ff_Latn_SL
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fil
++    fil_PH
++    fo
++    fo_DK
++    fr
++    fr_BI
++    fr_CA
++    fr_CD
++    fr_DJ
++    fr_DZ
++    fr_GN
++    fr_HT
++    fr_KM
++    fr_LU
++    fr_MG
++    fr_MR
++    fr_MU
++    fr_RW
++    fr_SC
++    fr_SY
++    fr_TN
++    fr_VU
++    fur
++    fy
++    ga
++    gd
++    gl
++    gsw
++    gu
++    guz
++    gv
++    ha
++    ha_GH
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hr_BA
++    hsb
++    hu
++    hy
++    ia
++    id
++    id_ID
++    ig
++    ii
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    jgo
++    jmc
++    jv
++    ka
++    kab
++    kam
++    kde
++    kea
++    khq
++    ki
++    kk
++    kkj
++    kl
++    kln
++    km
++    kn
++    ko
++    kok
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksf
++    ksh
++    ku
++    kw
++    ky
++    lag
++    lb
++    lg
++    lkt
++    ln
++    ln_AO
++    lo
++    lrc
++    lt
++    lu
++    luo
++    luy
++    lv
++    mai
++    mas
++    mas_TZ
++    mer
++    mfe
++    mg
++    mgh
++    mgo
++    mi
++    mk
++    ml
++    mn
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    ms
++    ms_BN
++    ms_ID
++    ms_SG
++    mt
++    mua
++    my
++    mzn
++    naq
++    nb
++    nb_NO
++    nd
++    nds
++    ne
++    nl
++    nl_AW
++    nl_BQ
++    nl_CW
++    nl_SR
++    nl_SX
++    nmg
++    nn
++    nn_NO
++    nnh
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nyn
++    om
++    om_KE
++    or
++    os
++    os_RU
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pl
++    ps
++    ps_PK
++    pt
++    pt_AO
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    qu_BO
++    qu_EC
++    rm
++    rn
++    ro
++    ro_MD
++    rof
++    root
++    ru
++    ru_BY
++    ru_KG
++    ru_KZ
++    ru_MD
++    rw
++    rwk
++    sah
++    saq
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_PK
++    se
++    se_SE
++    seh
++    ses
++    sg
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    sk
++    sl
++    smn
++    sn
++    so
++    so_DJ
++    so_ET
++    so_KE
++    sq
++    sq_MK
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sw
++    sw_CD
++    sw_KE
++    sw_UG
++    ta
++    ta_LK
++    ta_MY
++    ta_SG
++    te
++    teo
++    teo_KE
++    tg
++    th
++    ti
++    ti_ER
++    tk
++    tl
++    tl_PH
++    to
++    tr
++    tt
++    twq
++    tzm
++    ug
++    uk
++    ur
++    ur_IN
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vun
++    wae
++    wo
++    xh
++    xog
++    yav
++    yi
++    yo
++    yo_BJ
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_HK
++    zh_Hans_MO
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++)
 +
 +foreach(CURR_POOL_ITEM ${CURR_POOL_LIST})
-+  list(APPEND CURR_POOL_WRITE_FILES ${CURR_POOL_ITEM}.txt)
-+  list(APPEND CURR_POOL_WRITE_DEPS ${IN_DIR}/curr/${CURR_POOL_ITEM}.txt)
++    list(APPEND CURR_POOL_WRITE_FILES ${CURR_POOL_ITEM}.txt)
++    list(APPEND CURR_POOL_WRITE_DEPS ${IN_DIR}/curr/${CURR_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/curr/pool.res
-+  DEPENDS data_dirs ${CURR_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --writePoolBundle -k ${CURR_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/curr/pool.res
++    DEPENDS data_dirs ${CURR_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --writePoolBundle -k
++            ${CURR_POOL_WRITE_FILES}
 +)
 +
 +set(CURR_RES_DEPS ${OUT_DIR}/curr/pool.res)
 +
 +function(generate_curr_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/curr/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/curr/${ITEM}.txt ${CURR_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/curr/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/curr/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/curr/${ITEM}.txt ${CURR_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} --usePoolBundle
++                ${OUT_DIR}/curr/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(CURR_POOL_ITEM ${CURR_POOL_LIST})
-+  generate_curr_item(${CURR_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/curr/${CURR_POOL_ITEM}.res)
++    generate_curr_item(${CURR_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/curr/${CURR_POOL_ITEM}.res)
 +endforeach()
 +
-+### curr index
++# curr index
 +
 +configure_file(${IN_DIR}/cmake-curr-index-txt-content.in ${TMP_DIR}/curr/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/curr/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/curr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/curr/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/curr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/curr -d ${OUT_DIR}/curr/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +list(APPEND tmpdep ${OUT_DIR}/curr/${INDEX_NAME}.res)
 +
-+### lang pool
++# lang pool
 +
 +set(LANG_POOL_LIST
-+        af
-+		agq
-+		ak
-+		am
-+		ar
-+		ar_EG
-+		ar_LY
-+		ar_SA
-+		ars
-+		as
-+		asa
-+		ast
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		be
-+		bem
-+		bez
-+		bg
-+		bm
-+		bn
-+		bn_IN
-+		bo
-+		br
-+		brx
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ccp
-+		ce
-+		ceb
-+		cgg
-+		chr
-+		ckb
-+		cs
-+		cy
-+		da
-+		dav
-+		de
-+		de_AT
-+		de_CH
-+		de_LU
-+		dje
-+		dsb
-+		dua
-+		dyo
-+		dz
-+		ebu
-+		ee
-+		el
-+		en
-+		en_001
-+		en_150
-+		en_AG
-+		en_AI
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MO
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_VC
-+		en_VG
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EC
-+		es_GT
-+		es_HN
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		eu
-+		ewo
-+		fa
-+		fa_AF
-+		ff
-+		ff_Adlm
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_CM
-+		ff_Latn_GN
-+		ff_Latn_MR
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fil
-+		fil_PH
-+		fo
-+		fr
-+		fr_BE
-+		fr_CA
-+		fr_CH
-+		fur
-+		fy
-+		ga
-+		gd
-+		gl
-+		gsw
-+		gu
-+		guz
-+		gv
-+		ha
-+		ha_NE
-+		haw
-+		he
-+		he_IL
-+		hi
-+		hr
-+		hsb
-+		hu
-+		hy
-+		ia
-+		id
-+		id_ID
-+		ig
-+		ii
-+		in
-+		in_ID
-+		is
-+		it
-+		iw
-+		iw_IL
-+		ja
-+		jgo
-+		jmc
-+		jv
-+		ka
-+		kab
-+		kam
-+		kde
-+		kea
-+		khq
-+		ki
-+		kk
-+		kkj
-+		kl
-+		kln
-+		km
-+		kn
-+		ko
-+		kok
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksf
-+		ksh
-+		ku
-+		kw
-+		ky
-+		lag
-+		lb
-+		lg
-+		lkt
-+		ln
-+		lo
-+		lrc
-+		lt
-+		lu
-+		luo
-+		luy
-+		lv
-+		mai
-+		mas
-+		mer
-+		mfe
-+		mg
-+		mgh
-+		mgo
-+		mi
-+		mk
-+		ml
-+		mn
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		ms
-+		mt
-+		mua
-+		my
-+		mzn
-+		naq
-+		nb
-+		nb_NO
-+		nd
-+		nds
-+		ne
-+		nl
-+		nmg
-+		nn
-+		nn_NO
-+		nnh
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nyn
-+		om
-+		or
-+		os
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pl
-+		ps
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		rm
-+		rn
-+		ro
-+		ro_MD
-+		rof
-+		root
-+		ru
-+		rw
-+		rwk
-+		sah
-+		saq
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_PK
-+		se
-+		se_FI
-+		seh
-+		ses
-+		sg
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		sk
-+		sl
-+		smn
-+		sn
-+		so
-+		sq
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_ME
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_XK
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sv_FI
-+		sw
-+		sw_CD
-+		sw_KE
-+		ta
-+		te
-+		teo
-+		tg
-+		th
-+		ti
-+		tk
-+		tl
-+		tl_PH
-+		to
-+		tr
-+		tt
-+		twq
-+		tzm
-+		ug
-+		uk
-+		ur
-+		ur_IN
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vun
-+		wae
-+		wo
-+		xh
-+		xog
-+		yav
-+		yi
-+		yo
-+		yo_BJ
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu)
++    af
++    agq
++    ak
++    am
++    ar
++    ar_EG
++    ar_LY
++    ar_SA
++    ars
++    as
++    asa
++    ast
++    az
++    az_AZ
++    az_Cyrl
++    az_Latn
++    az_Latn_AZ
++    bas
++    be
++    bem
++    bez
++    bg
++    bm
++    bn
++    bn_IN
++    bo
++    br
++    brx
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ccp
++    ce
++    ceb
++    cgg
++    chr
++    ckb
++    cs
++    cy
++    da
++    dav
++    de
++    de_AT
++    de_CH
++    de_LU
++    dje
++    dsb
++    dua
++    dyo
++    dz
++    ebu
++    ee
++    el
++    en
++    en_001
++    en_150
++    en_AG
++    en_AI
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MO
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_VC
++    en_VG
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EC
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    eu
++    ewo
++    fa
++    fa_AF
++    ff
++    ff_Adlm
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_CM
++    ff_Latn_GN
++    ff_Latn_MR
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fil
++    fil_PH
++    fo
++    fr
++    fr_BE
++    fr_CA
++    fr_CH
++    fur
++    fy
++    ga
++    gd
++    gl
++    gsw
++    gu
++    guz
++    gv
++    ha
++    ha_NE
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hsb
++    hu
++    hy
++    ia
++    id
++    id_ID
++    ig
++    ii
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    jgo
++    jmc
++    jv
++    ka
++    kab
++    kam
++    kde
++    kea
++    khq
++    ki
++    kk
++    kkj
++    kl
++    kln
++    km
++    kn
++    ko
++    kok
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksf
++    ksh
++    ku
++    kw
++    ky
++    lag
++    lb
++    lg
++    lkt
++    ln
++    lo
++    lrc
++    lt
++    lu
++    luo
++    luy
++    lv
++    mai
++    mas
++    mer
++    mfe
++    mg
++    mgh
++    mgo
++    mi
++    mk
++    ml
++    mn
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    ms
++    mt
++    mua
++    my
++    mzn
++    naq
++    nb
++    nb_NO
++    nd
++    nds
++    ne
++    nl
++    nmg
++    nn
++    nn_NO
++    nnh
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nyn
++    om
++    or
++    os
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pl
++    ps
++    ps_PK
++    pt
++    pt_AO
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    rm
++    rn
++    ro
++    ro_MD
++    rof
++    root
++    ru
++    rw
++    rwk
++    sah
++    saq
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_PK
++    se
++    se_FI
++    seh
++    ses
++    sg
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    sk
++    sl
++    smn
++    sn
++    so
++    sq
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_ME
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_XK
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sv_FI
++    sw
++    sw_CD
++    sw_KE
++    ta
++    te
++    teo
++    tg
++    th
++    ti
++    tk
++    tl
++    tl_PH
++    to
++    tr
++    tt
++    twq
++    tzm
++    ug
++    uk
++    ur
++    ur_IN
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vun
++    wae
++    wo
++    xh
++    xog
++    yav
++    yi
++    yo
++    yo_BJ
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++)
 +
 +foreach(LANG_POOL_ITEM ${LANG_POOL_LIST})
-+  list(APPEND LANG_POOL_WRITE_FILES ${LANG_POOL_ITEM}.txt)
-+  list(APPEND LANG_POOL_WRITE_DEPS ${IN_DIR}/lang/${LANG_POOL_ITEM}.txt)
++    list(APPEND LANG_POOL_WRITE_FILES ${LANG_POOL_ITEM}.txt)
++    list(APPEND LANG_POOL_WRITE_DEPS ${IN_DIR}/lang/${LANG_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/lang/pool.res
-+  DEPENDS data_dirs ${LANG_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --writePoolBundle -k ${LANG_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/lang/pool.res
++    DEPENDS data_dirs ${LANG_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --writePoolBundle -k
++            ${LANG_POOL_WRITE_FILES}
 +)
 +
 +set(LANG_RES_DEPS ${OUT_DIR}/lang/pool.res)
 +
 +function(generate_lang_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/lang/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/lang/${ITEM}.txt ${LANG_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/lang/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/lang/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/lang/${ITEM}.txt ${LANG_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} --usePoolBundle
++                ${OUT_DIR}/lang/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(LANG_POOL_ITEM ${LANG_POOL_LIST})
-+  generate_lang_item(${LANG_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/lang/${LANG_POOL_ITEM}.res)
++    generate_lang_item(${LANG_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/lang/${LANG_POOL_ITEM}.res)
 +endforeach()
 +
-+### lang index
++# lang index
 +
 +configure_file(${IN_DIR}/cmake-lang-index-txt-content.in ${TMP_DIR}/lang/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/lang/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/lang/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/lang/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/lang/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/lang -d ${OUT_DIR}/lang/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### region
++# region
 +
 +set(REGION_POOL_LIST
-+        af
-+		agq
-+		ak
-+		am
-+		ar
-+		ar_AE
-+		ar_LY
-+		ar_SA
-+		ars
-+		as
-+		asa
-+		ast
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		be
-+		bem
-+		bez
-+		bg
-+		bm
-+		bn
-+		bn_IN
-+		bo
-+		bo_IN
-+		br
-+		brx
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ccp
-+		ce
-+		ceb
-+		cgg
-+		chr
-+		ckb
-+		cs
-+		cy
-+		da
-+		dav
-+		de
-+		de_AT
-+		de_CH
-+		dje
-+		dsb
-+		dua
-+		dyo
-+		dz
-+		ebu
-+		ee
-+		el
-+		en
-+		en_001
-+		en_150
-+		en_AG
-+		en_AI
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MO
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_VC
-+		en_VG
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EC
-+		es_GT
-+		es_HN
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		eu
-+		ewo
-+		fa
-+		fa_AF
-+		ff
-+		ff_Adlm
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_CM
-+		ff_Latn_GN
-+		ff_Latn_MR
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fil
-+		fil_PH
-+		fo
-+		fr
-+		fr_BE
-+		fr_CA
-+		fur
-+		fy
-+		ga
-+		gd
-+		gl
-+		gsw
-+		gu
-+		guz
-+		gv
-+		ha
-+		haw
-+		he
-+		he_IL
-+		hi
-+		hr
-+		hsb
-+		hu
-+		hy
-+		ia
-+		id
-+		id_ID
-+		ig
-+		ii
-+		in
-+		in_ID
-+		is
-+		it
-+		iw
-+		iw_IL
-+		ja
-+		jgo
-+		jmc
-+		jv
-+		ka
-+		kab
-+		kam
-+		kde
-+		kea
-+		khq
-+		ki
-+		kk
-+		kkj
-+		kl
-+		kln
-+		km
-+		kn
-+		ko
-+		ko_KP
-+		kok
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksf
-+		ksh
-+		ku
-+		kw
-+		ky
-+		lag
-+		lb
-+		lg
-+		lkt
-+		ln
-+		lo
-+		lrc
-+		lt
-+		lu
-+		luo
-+		luy
-+		lv
-+		mai
-+		mas
-+		mer
-+		mfe
-+		mg
-+		mgh
-+		mgo
-+		mi
-+		mk
-+		ml
-+		mn
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		ms
-+		mt
-+		mua
-+		my
-+		mzn
-+		naq
-+		nb
-+		nb_NO
-+		nd
-+		nds
-+		ne
-+		nl
-+		nmg
-+		nn
-+		nn_NO
-+		nnh
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nyn
-+		om
-+		or
-+		os
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pl
-+		ps
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		rm
-+		rn
-+		ro
-+		ro_MD
-+		rof
-+		root
-+		ru
-+		ru_UA
-+		rw
-+		rwk
-+		sah
-+		saq
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_PK
-+		se
-+		se_FI
-+		seh
-+		ses
-+		sg
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		sk
-+		sl
-+		smn
-+		sn
-+		so
-+		sq
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_ME
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_XK
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sw
-+		sw_CD
-+		sw_KE
-+		ta
-+		te
-+		teo
-+		tg
-+		th
-+		ti
-+		tk
-+		tl
-+		tl_PH
-+		to
-+		tr
-+		tt
-+		twq
-+		tzm
-+		ug
-+		uk
-+		ur
-+		ur_IN
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vun
-+		wae
-+		wo
-+		xh
-+		xog
-+		yav
-+		yi
-+		yo
-+		yo_BJ
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu)
++    af
++    agq
++    ak
++    am
++    ar
++    ar_AE
++    ar_LY
++    ar_SA
++    ars
++    as
++    asa
++    ast
++    az
++    az_AZ
++    az_Cyrl
++    az_Latn
++    az_Latn_AZ
++    bas
++    be
++    bem
++    bez
++    bg
++    bm
++    bn
++    bn_IN
++    bo
++    bo_IN
++    br
++    brx
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ccp
++    ce
++    ceb
++    cgg
++    chr
++    ckb
++    cs
++    cy
++    da
++    dav
++    de
++    de_AT
++    de_CH
++    dje
++    dsb
++    dua
++    dyo
++    dz
++    ebu
++    ee
++    el
++    en
++    en_001
++    en_150
++    en_AG
++    en_AI
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MO
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_VC
++    en_VG
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EC
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    eu
++    ewo
++    fa
++    fa_AF
++    ff
++    ff_Adlm
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_CM
++    ff_Latn_GN
++    ff_Latn_MR
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fil
++    fil_PH
++    fo
++    fr
++    fr_BE
++    fr_CA
++    fur
++    fy
++    ga
++    gd
++    gl
++    gsw
++    gu
++    guz
++    gv
++    ha
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hsb
++    hu
++    hy
++    ia
++    id
++    id_ID
++    ig
++    ii
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    jgo
++    jmc
++    jv
++    ka
++    kab
++    kam
++    kde
++    kea
++    khq
++    ki
++    kk
++    kkj
++    kl
++    kln
++    km
++    kn
++    ko
++    ko_KP
++    kok
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksf
++    ksh
++    ku
++    kw
++    ky
++    lag
++    lb
++    lg
++    lkt
++    ln
++    lo
++    lrc
++    lt
++    lu
++    luo
++    luy
++    lv
++    mai
++    mas
++    mer
++    mfe
++    mg
++    mgh
++    mgo
++    mi
++    mk
++    ml
++    mn
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    ms
++    mt
++    mua
++    my
++    mzn
++    naq
++    nb
++    nb_NO
++    nd
++    nds
++    ne
++    nl
++    nmg
++    nn
++    nn_NO
++    nnh
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nyn
++    om
++    or
++    os
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pl
++    ps
++    ps_PK
++    pt
++    pt_AO
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    rm
++    rn
++    ro
++    ro_MD
++    rof
++    root
++    ru
++    ru_UA
++    rw
++    rwk
++    sah
++    saq
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_PK
++    se
++    se_FI
++    seh
++    ses
++    sg
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    sk
++    sl
++    smn
++    sn
++    so
++    sq
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_ME
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_XK
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sw
++    sw_CD
++    sw_KE
++    ta
++    te
++    teo
++    tg
++    th
++    ti
++    tk
++    tl
++    tl_PH
++    to
++    tr
++    tt
++    twq
++    tzm
++    ug
++    uk
++    ur
++    ur_IN
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vun
++    wae
++    wo
++    xh
++    xog
++    yav
++    yi
++    yo
++    yo_BJ
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++)
 +
 +foreach(REGION_POOL_ITEM ${REGION_POOL_LIST})
-+  list(APPEND REGION_POOL_WRITE_FILES ${REGION_POOL_ITEM}.txt)
-+  list(APPEND REGION_POOL_WRITE_DEPS ${IN_DIR}/region/${REGION_POOL_ITEM}.txt)
++    list(APPEND REGION_POOL_WRITE_FILES ${REGION_POOL_ITEM}.txt)
++    list(APPEND REGION_POOL_WRITE_DEPS ${IN_DIR}/region/${REGION_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/region/pool.res
-+  DEPENDS data_dirs ${REGION_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} --writePoolBundle -k ${REGION_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/region/pool.res
++    DEPENDS data_dirs ${REGION_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
++            --writePoolBundle -k ${REGION_POOL_WRITE_FILES}
 +)
 +
 +set(REGION_RES_DEPS ${OUT_DIR}/region/pool.res)
 +
 +function(generate_region_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/region/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/region/${ITEM}.txt ${REGION_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/region/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/region/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/region/${ITEM}.txt ${REGION_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR}
++                --usePoolBundle ${OUT_DIR}/region/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(REGION_POOL_ITEM ${REGION_POOL_LIST})
-+  generate_region_item(${REGION_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/region/${REGION_POOL_ITEM}.res)
++    generate_region_item(${REGION_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/region/${REGION_POOL_ITEM}.res)
 +endforeach()
 +
-+### region index
++# region index
 +
 +configure_file(${IN_DIR}/cmake-region-index-txt-content.in ${TMP_DIR}/region/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/region/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/region/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/region/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/region/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/region -d ${OUT_DIR}/region/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### zone
++# zone
 +set(ZONE_POOL_LIST
-+        af
-+		agq
-+		ak
-+		am
-+		ar
-+		ar_SA
-+		ars
-+		as
-+		asa
-+		ast
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		be
-+		bem
-+		bez
-+		bg
-+		bm
-+		bn
-+		bo
-+		br
-+		brx
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ccp
-+		ce
-+		ceb
-+		cgg
-+		chr
-+		ckb
-+		cs
-+		cy
-+		da
-+		dav
-+		de
-+		de_CH
-+		dje
-+		dsb
-+		dua
-+		dyo
-+		dz
-+		ebu
-+		ee
-+		el
-+		en
-+		en_001
-+		en_150
-+		en_AE
-+		en_AG
-+		en_AI
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GU
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MH
-+		en_MO
-+		en_MP
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_VC
-+		en_VG
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EC
-+		es_GT
-+		es_HN
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		eu
-+		ewo
-+		fa
-+		ff
-+		ff_Adlm
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_CM
-+		ff_Latn_GN
-+		ff_Latn_MR
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fil
-+		fil_PH
-+		fo
-+		fr
-+		fr_CA
-+		fr_GF
-+		fur
-+		fy
-+		ga
-+		gd
-+		gl
-+		gsw
-+		gu
-+		guz
-+		gv
-+		ha
-+		haw
-+		he
-+		he_IL
-+		hi
-+		hr
-+		hsb
-+		hu
-+		hy
-+		ia
-+		id
-+		id_ID
-+		ig
-+		ii
-+		in
-+		in_ID
-+		is
-+		it
-+		iw
-+		iw_IL
-+		ja
-+		jgo
-+		jmc
-+		jv
-+		ka
-+		kab
-+		kam
-+		kde
-+		kea
-+		khq
-+		ki
-+		kk
-+		kkj
-+		kl
-+		kln
-+		km
-+		kn
-+		ko
-+		ko_KP
-+		kok
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksf
-+		ksh
-+		ku
-+		kw
-+		ky
-+		lag
-+		lb
-+		lg
-+		lkt
-+		ln
-+		lo
-+		lrc
-+		lt
-+		lu
-+		luo
-+		luy
-+		lv
-+		mai
-+		mas
-+		mer
-+		mfe
-+		mg
-+		mgh
-+		mgo
-+		mi
-+		mk
-+		ml
-+		mn
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		ms
-+		ms_ID
-+		mt
-+		mua
-+		my
-+		mzn
-+		naq
-+		nb
-+		nb_NO
-+		nd
-+		nds
-+		ne
-+		ne_IN
-+		nl
-+		nl_SR
-+		nmg
-+		nn
-+		nn_NO
-+		nnh
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nyn
-+		om
-+		or
-+		os
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pl
-+		ps
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		qu_BO
-+		qu_EC
-+		rm
-+		rn
-+		ro
-+		rof
-+		root
-+		ru
-+		rw
-+		rwk
-+		sah
-+		saq
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_PK
-+		se
-+		se_FI
-+		seh
-+		ses
-+		sg
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		sk
-+		sl
-+		smn
-+		sn
-+		so
-+		sq
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sw
-+		sw_KE
-+		ta
-+		ta_MY
-+		ta_SG
-+		te
-+		teo
-+		tg
-+		th
-+		ti
-+		tk
-+		tl
-+		tl_PH
-+		to
-+		tr
-+		tt
-+		twq
-+		tzdbNames
-+		tzm
-+		ug
-+		uk
-+		ur
-+		ur_IN
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vun
-+		wae
-+		wo
-+		xh
-+		xog
-+		yav
-+		yi
-+		yo
-+		yo_BJ
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu)
++    af
++    agq
++    ak
++    am
++    ar
++    ar_SA
++    ars
++    as
++    asa
++    ast
++    az
++    az_AZ
++    az_Cyrl
++    az_Latn
++    az_Latn_AZ
++    bas
++    be
++    bem
++    bez
++    bg
++    bm
++    bn
++    bo
++    br
++    brx
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ccp
++    ce
++    ceb
++    cgg
++    chr
++    ckb
++    cs
++    cy
++    da
++    dav
++    de
++    de_CH
++    dje
++    dsb
++    dua
++    dyo
++    dz
++    ebu
++    ee
++    el
++    en
++    en_001
++    en_150
++    en_AE
++    en_AG
++    en_AI
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GU
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MH
++    en_MO
++    en_MP
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_VC
++    en_VG
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EC
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    eu
++    ewo
++    fa
++    ff
++    ff_Adlm
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_CM
++    ff_Latn_GN
++    ff_Latn_MR
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fil
++    fil_PH
++    fo
++    fr
++    fr_CA
++    fr_GF
++    fur
++    fy
++    ga
++    gd
++    gl
++    gsw
++    gu
++    guz
++    gv
++    ha
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hsb
++    hu
++    hy
++    ia
++    id
++    id_ID
++    ig
++    ii
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    jgo
++    jmc
++    jv
++    ka
++    kab
++    kam
++    kde
++    kea
++    khq
++    ki
++    kk
++    kkj
++    kl
++    kln
++    km
++    kn
++    ko
++    ko_KP
++    kok
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksf
++    ksh
++    ku
++    kw
++    ky
++    lag
++    lb
++    lg
++    lkt
++    ln
++    lo
++    lrc
++    lt
++    lu
++    luo
++    luy
++    lv
++    mai
++    mas
++    mer
++    mfe
++    mg
++    mgh
++    mgo
++    mi
++    mk
++    ml
++    mn
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    ms
++    ms_ID
++    mt
++    mua
++    my
++    mzn
++    naq
++    nb
++    nb_NO
++    nd
++    nds
++    ne
++    ne_IN
++    nl
++    nl_SR
++    nmg
++    nn
++    nn_NO
++    nnh
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nyn
++    om
++    or
++    os
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pl
++    ps
++    ps_PK
++    pt
++    pt_AO
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    qu_BO
++    qu_EC
++    rm
++    rn
++    ro
++    rof
++    root
++    ru
++    rw
++    rwk
++    sah
++    saq
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_PK
++    se
++    se_FI
++    seh
++    ses
++    sg
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    sk
++    sl
++    smn
++    sn
++    so
++    sq
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sw
++    sw_KE
++    ta
++    ta_MY
++    ta_SG
++    te
++    teo
++    tg
++    th
++    ti
++    tk
++    tl
++    tl_PH
++    to
++    tr
++    tt
++    twq
++    tzdbNames
++    tzm
++    ug
++    uk
++    ur
++    ur_IN
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vun
++    wae
++    wo
++    xh
++    xog
++    yav
++    yi
++    yo
++    yo_BJ
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++)
 +
 +foreach(ZONE_POOL_ITEM ${ZONE_POOL_LIST})
-+  list(APPEND ZONE_POOL_WRITE_FILES ${ZONE_POOL_ITEM}.txt)
-+  list(APPEND ZONE_POOL_WRITE_DEPS ${IN_DIR}/zone/${ZONE_POOL_ITEM}.txt)
++    list(APPEND ZONE_POOL_WRITE_FILES ${ZONE_POOL_ITEM}.txt)
++    list(APPEND ZONE_POOL_WRITE_DEPS ${IN_DIR}/zone/${ZONE_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/zone/pool.res
-+  DEPENDS data_dirs ${ZONE_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --writePoolBundle -k ${ZONE_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/zone/pool.res
++    DEPENDS data_dirs ${ZONE_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --writePoolBundle -k
++            ${ZONE_POOL_WRITE_FILES}
 +)
 +
 +set(ZONE_RES_DEPS ${OUT_DIR}/zone/pool.res)
 +
 +function(generate_zone_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/zone/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/zone/${ITEM}.txt ${ZONE_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/zone/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/zone/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/zone/${ITEM}.txt ${ZONE_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} --usePoolBundle
++                ${OUT_DIR}/zone/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(ZONE_POOL_ITEM ${ZONE_POOL_LIST})
-+  generate_zone_item(${ZONE_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/zone/${ZONE_POOL_ITEM}.res)
++    generate_zone_item(${ZONE_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/zone/${ZONE_POOL_ITEM}.res)
 +endforeach()
 +
-+### zone index
++# zone index
 +
 +configure_file(${IN_DIR}/cmake-zone-index-txt-content.in ${TMP_DIR}/zone/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/zone/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/zone/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/zone/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/zone/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/zone -d ${OUT_DIR}/zone/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### unit pool
++# unit pool
 +
 +set(UNIT_POOL_LIST
-+        af
-+		agq
-+		ak
-+		am
-+		ar
-+		ar_SA
-+		ars
-+		as
-+		asa
-+		ast
-+		az
-+		az_AZ
-+		az_Cyrl
-+		az_Latn
-+		az_Latn_AZ
-+		bas
-+		be
-+		bem
-+		bez
-+		bg
-+		bm
-+		bn
-+		bo
-+		br
-+		brx
-+		bs
-+		bs_BA
-+		bs_Cyrl
-+		bs_Latn
-+		bs_Latn_BA
-+		ca
-+		ccp
-+		ce
-+		ceb
-+		cgg
-+		chr
-+		ckb
-+		cs
-+		cy
-+		da
-+		dav
-+		de
-+		de_CH
-+		dje
-+		dsb
-+		dua
-+		dyo
-+		dz
-+		ebu
-+		ee
-+		el
-+		en
-+		en_001
-+		en_150
-+		en_AG
-+		en_AI
-+		en_AT
-+		en_AU
-+		en_BB
-+		en_BE
-+		en_BM
-+		en_BS
-+		en_BW
-+		en_BZ
-+		en_CA
-+		en_CC
-+		en_CH
-+		en_CK
-+		en_CM
-+		en_CX
-+		en_CY
-+		en_DE
-+		en_DG
-+		en_DK
-+		en_DM
-+		en_ER
-+		en_FI
-+		en_FJ
-+		en_FK
-+		en_FM
-+		en_GB
-+		en_GD
-+		en_GG
-+		en_GH
-+		en_GI
-+		en_GM
-+		en_GY
-+		en_HK
-+		en_IE
-+		en_IL
-+		en_IM
-+		en_IN
-+		en_IO
-+		en_JE
-+		en_JM
-+		en_KE
-+		en_KI
-+		en_KN
-+		en_KY
-+		en_LC
-+		en_LR
-+		en_LS
-+		en_MG
-+		en_MO
-+		en_MS
-+		en_MT
-+		en_MU
-+		en_MW
-+		en_MY
-+		en_NA
-+		en_NF
-+		en_NG
-+		en_NH
-+		en_NL
-+		en_NR
-+		en_NU
-+		en_NZ
-+		en_PG
-+		en_PH
-+		en_PK
-+		en_PN
-+		en_PW
-+		en_RH
-+		en_RW
-+		en_SB
-+		en_SC
-+		en_SD
-+		en_SE
-+		en_SG
-+		en_SH
-+		en_SI
-+		en_SL
-+		en_SS
-+		en_SX
-+		en_SZ
-+		en_TC
-+		en_TK
-+		en_TO
-+		en_TT
-+		en_TV
-+		en_TZ
-+		en_UG
-+		en_VC
-+		en_VG
-+		en_VU
-+		en_WS
-+		en_ZA
-+		en_ZM
-+		en_ZW
-+		eo
-+		es
-+		es_419
-+		es_AR
-+		es_BO
-+		es_BR
-+		es_BZ
-+		es_CL
-+		es_CO
-+		es_CR
-+		es_CU
-+		es_DO
-+		es_EC
-+		es_GT
-+		es_HN
-+		es_MX
-+		es_NI
-+		es_PA
-+		es_PE
-+		es_PR
-+		es_PY
-+		es_SV
-+		es_US
-+		es_UY
-+		es_VE
-+		et
-+		eu
-+		ewo
-+		fa
-+		ff
-+		ff_Adlm
-+		ff_CM
-+		ff_GN
-+		ff_Latn
-+		ff_Latn_CM
-+		ff_Latn_GN
-+		ff_Latn_MR
-+		ff_Latn_SN
-+		ff_MR
-+		ff_SN
-+		fi
-+		fil
-+		fil_PH
-+		fo
-+		fr
-+		fr_CA
-+		fr_HT
-+		fur
-+		fy
-+		ga
-+		gd
-+		gl
-+		gsw
-+		gu
-+		guz
-+		gv
-+		ha
-+		haw
-+		he
-+		he_IL
-+		hi
-+		hr
-+		hsb
-+		hu
-+		hy
-+		ia
-+		id
-+		id_ID
-+		ig
-+		ii
-+		in
-+		in_ID
-+		is
-+		it
-+		iw
-+		iw_IL
-+		ja
-+		jgo
-+		jmc
-+		jv
-+		ka
-+		kab
-+		kam
-+		kde
-+		kea
-+		khq
-+		ki
-+		kk
-+		kkj
-+		kl
-+		kln
-+		km
-+		kn
-+		ko
-+		kok
-+		ks
-+		ks_Arab
-+		ks_Arab_IN
-+		ks_IN
-+		ksb
-+		ksf
-+		ksh
-+		ku
-+		kw
-+		ky
-+		lag
-+		lb
-+		lg
-+		lkt
-+		ln
-+		lo
-+		lrc
-+		lt
-+		lu
-+		luo
-+		luy
-+		lv
-+		mai
-+		mas
-+		mer
-+		mfe
-+		mg
-+		mgh
-+		mgo
-+		mi
-+		mk
-+		ml
-+		mn
-+		mni
-+		mni_Beng
-+		mni_Beng_IN
-+		mni_IN
-+		mo
-+		mr
-+		ms
-+		mt
-+		mua
-+		my
-+		mzn
-+		naq
-+		nb
-+		nb_NO
-+		nd
-+		nds
-+		ne
-+		nl
-+		nmg
-+		nn
-+		nn_NO
-+		nnh
-+		no
-+		no_NO
-+		no_NO_NY
-+		nus
-+		nyn
-+		om
-+		or
-+		os
-+		pa
-+		pa_Arab
-+		pa_Arab_PK
-+		pa_Guru
-+		pa_Guru_IN
-+		pa_IN
-+		pa_PK
-+		pcm
-+		pl
-+		ps
-+		ps_PK
-+		pt
-+		pt_AO
-+		pt_CH
-+		pt_CV
-+		pt_GQ
-+		pt_GW
-+		pt_LU
-+		pt_MO
-+		pt_MZ
-+		pt_PT
-+		pt_ST
-+		pt_TL
-+		qu
-+		rm
-+		rn
-+		ro
-+		ro_MD
-+		rof
-+		root
-+		ru
-+		rw
-+		rwk
-+		sah
-+		saq
-+		sat
-+		sat_IN
-+		sat_Olck
-+		sat_Olck_IN
-+		sbp
-+		sd
-+		sd_Arab
-+		sd_Arab_PK
-+		sd_Deva
-+		sd_PK
-+		se
-+		seh
-+		ses
-+		sg
-+		sh
-+		sh_BA
-+		sh_CS
-+		sh_YU
-+		shi
-+		shi_Latn
-+		shi_MA
-+		shi_Tfng
-+		shi_Tfng_MA
-+		si
-+		sk
-+		sl
-+		smn
-+		sn
-+		so
-+		sq
-+		sr
-+		sr_BA
-+		sr_CS
-+		sr_Cyrl
-+		sr_Cyrl_BA
-+		sr_Cyrl_CS
-+		sr_Cyrl_RS
-+		sr_Cyrl_XK
-+		sr_Cyrl_YU
-+		sr_Latn
-+		sr_Latn_BA
-+		sr_Latn_CS
-+		sr_Latn_ME
-+		sr_Latn_RS
-+		sr_Latn_YU
-+		sr_ME
-+		sr_RS
-+		sr_XK
-+		sr_YU
-+		su
-+		su_ID
-+		su_Latn
-+		su_Latn_ID
-+		sv
-+		sv_FI
-+		sw
-+		sw_KE
-+		ta
-+		te
-+		teo
-+		tg
-+		th
-+		ti
-+		tk
-+		tl
-+		tl_PH
-+		to
-+		tr
-+		tt
-+		twq
-+		tzm
-+		ug
-+		uk
-+		ur
-+		ur_IN
-+		uz
-+		uz_AF
-+		uz_Arab
-+		uz_Arab_AF
-+		uz_Cyrl
-+		uz_Latn
-+		uz_Latn_UZ
-+		uz_UZ
-+		vai
-+		vai_LR
-+		vai_Latn
-+		vai_Vaii
-+		vai_Vaii_LR
-+		vi
-+		vun
-+		wae
-+		wo
-+		xh
-+		xog
-+		yav
-+		yi
-+		yo
-+		yo_BJ
-+		yue
-+		yue_CN
-+		yue_HK
-+		yue_Hans
-+		yue_Hans_CN
-+		yue_Hant
-+		yue_Hant_HK
-+		zgh
-+		zh
-+		zh_CN
-+		zh_HK
-+		zh_Hans
-+		zh_Hans_CN
-+		zh_Hans_HK
-+		zh_Hans_MO
-+		zh_Hans_SG
-+		zh_Hant
-+		zh_Hant_HK
-+		zh_Hant_MO
-+		zh_Hant_TW
-+		zh_MO
-+		zh_SG
-+		zh_TW
-+		zu)
++    af
++    agq
++    ak
++    am
++    ar
++    ar_SA
++    ars
++    as
++    asa
++    ast
++    az
++    az_AZ
++    az_Cyrl
++    az_Latn
++    az_Latn_AZ
++    bas
++    be
++    bem
++    bez
++    bg
++    bm
++    bn
++    bo
++    br
++    brx
++    bs
++    bs_BA
++    bs_Cyrl
++    bs_Latn
++    bs_Latn_BA
++    ca
++    ccp
++    ce
++    ceb
++    cgg
++    chr
++    ckb
++    cs
++    cy
++    da
++    dav
++    de
++    de_CH
++    dje
++    dsb
++    dua
++    dyo
++    dz
++    ebu
++    ee
++    el
++    en
++    en_001
++    en_150
++    en_AG
++    en_AI
++    en_AT
++    en_AU
++    en_BB
++    en_BE
++    en_BM
++    en_BS
++    en_BW
++    en_BZ
++    en_CA
++    en_CC
++    en_CH
++    en_CK
++    en_CM
++    en_CX
++    en_CY
++    en_DE
++    en_DG
++    en_DK
++    en_DM
++    en_ER
++    en_FI
++    en_FJ
++    en_FK
++    en_FM
++    en_GB
++    en_GD
++    en_GG
++    en_GH
++    en_GI
++    en_GM
++    en_GY
++    en_HK
++    en_IE
++    en_IL
++    en_IM
++    en_IN
++    en_IO
++    en_JE
++    en_JM
++    en_KE
++    en_KI
++    en_KN
++    en_KY
++    en_LC
++    en_LR
++    en_LS
++    en_MG
++    en_MO
++    en_MS
++    en_MT
++    en_MU
++    en_MW
++    en_MY
++    en_NA
++    en_NF
++    en_NG
++    en_NH
++    en_NL
++    en_NR
++    en_NU
++    en_NZ
++    en_PG
++    en_PH
++    en_PK
++    en_PN
++    en_PW
++    en_RH
++    en_RW
++    en_SB
++    en_SC
++    en_SD
++    en_SE
++    en_SG
++    en_SH
++    en_SI
++    en_SL
++    en_SS
++    en_SX
++    en_SZ
++    en_TC
++    en_TK
++    en_TO
++    en_TT
++    en_TV
++    en_TZ
++    en_UG
++    en_VC
++    en_VG
++    en_VU
++    en_WS
++    en_ZA
++    en_ZM
++    en_ZW
++    eo
++    es
++    es_419
++    es_AR
++    es_BO
++    es_BR
++    es_BZ
++    es_CL
++    es_CO
++    es_CR
++    es_CU
++    es_DO
++    es_EC
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PE
++    es_PR
++    es_PY
++    es_SV
++    es_US
++    es_UY
++    es_VE
++    et
++    eu
++    ewo
++    fa
++    ff
++    ff_Adlm
++    ff_CM
++    ff_GN
++    ff_Latn
++    ff_Latn_CM
++    ff_Latn_GN
++    ff_Latn_MR
++    ff_Latn_SN
++    ff_MR
++    ff_SN
++    fi
++    fil
++    fil_PH
++    fo
++    fr
++    fr_CA
++    fr_HT
++    fur
++    fy
++    ga
++    gd
++    gl
++    gsw
++    gu
++    guz
++    gv
++    ha
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hsb
++    hu
++    hy
++    ia
++    id
++    id_ID
++    ig
++    ii
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    jgo
++    jmc
++    jv
++    ka
++    kab
++    kam
++    kde
++    kea
++    khq
++    ki
++    kk
++    kkj
++    kl
++    kln
++    km
++    kn
++    ko
++    kok
++    ks
++    ks_Arab
++    ks_Arab_IN
++    ks_IN
++    ksb
++    ksf
++    ksh
++    ku
++    kw
++    ky
++    lag
++    lb
++    lg
++    lkt
++    ln
++    lo
++    lrc
++    lt
++    lu
++    luo
++    luy
++    lv
++    mai
++    mas
++    mer
++    mfe
++    mg
++    mgh
++    mgo
++    mi
++    mk
++    ml
++    mn
++    mni
++    mni_Beng
++    mni_Beng_IN
++    mni_IN
++    mo
++    mr
++    ms
++    mt
++    mua
++    my
++    mzn
++    naq
++    nb
++    nb_NO
++    nd
++    nds
++    ne
++    nl
++    nmg
++    nn
++    nn_NO
++    nnh
++    no
++    no_NO
++    no_NO_NY
++    nus
++    nyn
++    om
++    or
++    os
++    pa
++    pa_Arab
++    pa_Arab_PK
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pa_PK
++    pcm
++    pl
++    ps
++    ps_PK
++    pt
++    pt_AO
++    pt_CH
++    pt_CV
++    pt_GQ
++    pt_GW
++    pt_LU
++    pt_MO
++    pt_MZ
++    pt_PT
++    pt_ST
++    pt_TL
++    qu
++    rm
++    rn
++    ro
++    ro_MD
++    rof
++    root
++    ru
++    rw
++    rwk
++    sah
++    saq
++    sat
++    sat_IN
++    sat_Olck
++    sat_Olck_IN
++    sbp
++    sd
++    sd_Arab
++    sd_Arab_PK
++    sd_Deva
++    sd_PK
++    se
++    seh
++    ses
++    sg
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    shi
++    shi_Latn
++    shi_MA
++    shi_Tfng
++    shi_Tfng_MA
++    si
++    sk
++    sl
++    smn
++    sn
++    so
++    sq
++    sr
++    sr_BA
++    sr_CS
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_CS
++    sr_Cyrl_RS
++    sr_Cyrl_XK
++    sr_Cyrl_YU
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_CS
++    sr_Latn_ME
++    sr_Latn_RS
++    sr_Latn_YU
++    sr_ME
++    sr_RS
++    sr_XK
++    sr_YU
++    su
++    su_ID
++    su_Latn
++    su_Latn_ID
++    sv
++    sv_FI
++    sw
++    sw_KE
++    ta
++    te
++    teo
++    tg
++    th
++    ti
++    tk
++    tl
++    tl_PH
++    to
++    tr
++    tt
++    twq
++    tzm
++    ug
++    uk
++    ur
++    ur_IN
++    uz
++    uz_AF
++    uz_Arab
++    uz_Arab_AF
++    uz_Cyrl
++    uz_Latn
++    uz_Latn_UZ
++    uz_UZ
++    vai
++    vai_LR
++    vai_Latn
++    vai_Vaii
++    vai_Vaii_LR
++    vi
++    vun
++    wae
++    wo
++    xh
++    xog
++    yav
++    yi
++    yo
++    yo_BJ
++    yue
++    yue_CN
++    yue_HK
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    yue_Hant_HK
++    zgh
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_HK
++    zh_Hans_MO
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
++)
 +
 +foreach(UNIT_POOL_ITEM ${UNIT_POOL_LIST})
-+  list(APPEND UNIT_POOL_WRITE_FILES ${UNIT_POOL_ITEM}.txt)
-+  list(APPEND UNIT_POOL_WRITE_DEPS ${IN_DIR}/unit/${UNIT_POOL_ITEM}.txt)
++    list(APPEND UNIT_POOL_WRITE_FILES ${UNIT_POOL_ITEM}.txt)
++    list(APPEND UNIT_POOL_WRITE_DEPS ${IN_DIR}/unit/${UNIT_POOL_ITEM}.txt)
 +endforeach()
 +
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/unit/pool.res
-+  DEPENDS data_dirs ${UNIT_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --writePoolBundle -k ${UNIT_POOL_WRITE_FILES}
++    OUTPUT ${OUT_DIR}/unit/pool.res
++    DEPENDS data_dirs ${UNIT_POOL_WRITE_DEPS} ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --writePoolBundle -k
++            ${UNIT_POOL_WRITE_FILES}
 +)
 +
 +set(UNIT_RES_DEPS ${OUT_DIR}/unit/pool.res)
 +
 +function(generate_unit_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/unit/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/unit/${ITEM}.txt ${UNIT_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --usePoolBundle ${OUT_DIR}/unit/ -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/unit/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/unit/${ITEM}.txt ${UNIT_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} --usePoolBundle
++                ${OUT_DIR}/unit/ -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(UNIT_POOL_ITEM ${UNIT_POOL_LIST})
-+  generate_unit_item(${UNIT_POOL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/unit/${UNIT_POOL_ITEM}.res)
++    generate_unit_item(${UNIT_POOL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/unit/${UNIT_POOL_ITEM}.res)
 +endforeach()
 +
-+### unit index
++# unit index
 +
 +configure_file(${IN_DIR}/cmake-unit-index-txt-content.in ${TMP_DIR}/unit/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/unit/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/unit/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/unit/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/unit/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/unit -d ${OUT_DIR}/unit/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### coll
++# coll
 +set(COLL_RES_DEPS
-+    	${OUT_DIR}/coll/ucadata.icu
-+		${OUT_DIR}/currencyNumericCodes.res
-+		${OUT_DIR}/dayPeriods.res
-+		${OUT_DIR}/genderList.res
-+		${OUT_DIR}/icustd.res
-+		${OUT_DIR}/icuver.res
-+		${OUT_DIR}/keyTypeData.res
-+		${OUT_DIR}/langInfo.res
-+		${OUT_DIR}/likelySubtags.res
-+		${OUT_DIR}/metaZones.res
-+		${OUT_DIR}/metadata.res
-+		${OUT_DIR}/numberingSystems.res
-+		${OUT_DIR}/pluralRanges.res
-+		${OUT_DIR}/plurals.res
-+		${OUT_DIR}/supplementalData.res
-+		${OUT_DIR}/timezoneTypes.res
-+		${OUT_DIR}/windowsZones.res
-+		${OUT_DIR}/zoneinfo64.res
-+		${IN_DIR}/unidata/UCARules.txt
++    ${OUT_DIR}/coll/ucadata.icu
++    ${OUT_DIR}/currencyNumericCodes.res
++    ${OUT_DIR}/dayPeriods.res
++    ${OUT_DIR}/genderList.res
++    ${OUT_DIR}/icustd.res
++    ${OUT_DIR}/icuver.res
++    ${OUT_DIR}/keyTypeData.res
++    ${OUT_DIR}/langInfo.res
++    ${OUT_DIR}/likelySubtags.res
++    ${OUT_DIR}/metaZones.res
++    ${OUT_DIR}/metadata.res
++    ${OUT_DIR}/numberingSystems.res
++    ${OUT_DIR}/pluralRanges.res
++    ${OUT_DIR}/plurals.res
++    ${OUT_DIR}/supplementalData.res
++    ${OUT_DIR}/timezoneTypes.res
++    ${OUT_DIR}/windowsZones.res
++    ${OUT_DIR}/zoneinfo64.res
++    ${IN_DIR}/unidata/UCARules.txt
 +)
 +
 +set(COLL_LIST
-+	af
-+	am
-+	ar
-+	ar_SA
-+	ars
-+	as
-+	az
-+	be
-+	bg
-+	bn
-+	bo
-+	bs
-+	bs_Cyrl
-+	ca
-+	ceb
-+	chr
-+	cs
-+	cy
-+	da
-+	de
-+	de_
-+	de_AT
-+	de__PHONEBOOK
-+	dsb
-+	dz
-+	ee
-+	el
-+	en
-+	en_US
-+	en_US_POSIX
-+	eo
-+	es
-+	es_
-+	es__TRADITIONAL
-+	et
-+	fa
-+	fa_AF
-+	ff
-+	ff_Adlm
-+	fi
-+	fil
-+	fo
-+	fr
-+	fr_CA
-+	ga
-+	gl
-+	gu
-+	ha
-+	haw
-+	he
-+	he_IL
-+	hi
-+	hr
-+	hsb
-+	hu
-+	hy
-+	id
-+	id_ID
-+	ig
-+	in
-+	in_ID
-+	is
-+	it
-+	iw
-+	iw_IL
-+	ja
-+	ka
-+	kk
-+	kl
-+	km
-+	kn
-+	ko
-+	kok
-+	ku
-+	ky
-+	lb
-+	lkt
-+	ln
-+	lo
-+	lt
-+	lv
-+	mk
-+	ml
-+	mn
-+	mo
-+	mr
-+	ms
-+	mt
-+	my
-+	nb
-+	nb_NO
-+	ne
-+	nl
-+	nn
-+	no
-+	no_NO
-+	om
-+	or
-+	pa
-+	pa_Guru
-+	pa_Guru_IN
-+	pa_IN
-+	pl
-+	ps
-+	pt
-+	ro
-+	root
-+	ru
-+	se
-+	sh
-+	sh_BA
-+	sh_CS
-+	sh_YU
-+	si
-+	sk
-+	sl
-+	smn
-+	sq
-+	sr
-+	sr_BA
-+	sr_Cyrl
-+	sr_Cyrl_BA
-+	sr_Cyrl_ME
-+	sr_Cyrl_RS
-+	sr_Latn
-+	sr_Latn_BA
-+	sr_Latn_RS
-+	sr_ME
-+	sr_RS
-+	sv
-+	sw
-+	ta
-+	te
-+	th
-+	tk
-+	to
-+	tr
-+	ug
-+	uk
-+	ur
-+	uz
-+	vi
-+	wae
-+	wo
-+	xh
-+	yi
-+	yo
-+	yue
-+	yue_CN
-+	yue_Hans
-+	yue_Hans_CN
-+	yue_Hant
-+	zh
-+	zh_CN
-+	zh_HK
-+	zh_Hans
-+	zh_Hans_CN
-+	zh_Hans_SG
-+	zh_Hant
-+	zh_Hant_HK
-+	zh_Hant_MO
-+	zh_Hant_TW
-+	zh_MO
-+	zh_SG
-+	zh_TW
-+	zu
++    af
++    am
++    ar
++    ar_SA
++    ars
++    as
++    az
++    be
++    bg
++    bn
++    bo
++    bs
++    bs_Cyrl
++    ca
++    ceb
++    chr
++    cs
++    cy
++    da
++    de
++    de_
++    de_AT
++    de__PHONEBOOK
++    dsb
++    dz
++    ee
++    el
++    en
++    en_US
++    en_US_POSIX
++    eo
++    es
++    es_
++    es__TRADITIONAL
++    et
++    fa
++    fa_AF
++    ff
++    ff_Adlm
++    fi
++    fil
++    fo
++    fr
++    fr_CA
++    ga
++    gl
++    gu
++    ha
++    haw
++    he
++    he_IL
++    hi
++    hr
++    hsb
++    hu
++    hy
++    id
++    id_ID
++    ig
++    in
++    in_ID
++    is
++    it
++    iw
++    iw_IL
++    ja
++    ka
++    kk
++    kl
++    km
++    kn
++    ko
++    kok
++    ku
++    ky
++    lb
++    lkt
++    ln
++    lo
++    lt
++    lv
++    mk
++    ml
++    mn
++    mo
++    mr
++    ms
++    mt
++    my
++    nb
++    nb_NO
++    ne
++    nl
++    nn
++    no
++    no_NO
++    om
++    or
++    pa
++    pa_Guru
++    pa_Guru_IN
++    pa_IN
++    pl
++    ps
++    pt
++    ro
++    root
++    ru
++    se
++    sh
++    sh_BA
++    sh_CS
++    sh_YU
++    si
++    sk
++    sl
++    smn
++    sq
++    sr
++    sr_BA
++    sr_Cyrl
++    sr_Cyrl_BA
++    sr_Cyrl_ME
++    sr_Cyrl_RS
++    sr_Latn
++    sr_Latn_BA
++    sr_Latn_RS
++    sr_ME
++    sr_RS
++    sv
++    sw
++    ta
++    te
++    th
++    tk
++    to
++    tr
++    ug
++    uk
++    ur
++    uz
++    vi
++    wae
++    wo
++    xh
++    yi
++    yo
++    yue
++    yue_CN
++    yue_Hans
++    yue_Hans_CN
++    yue_Hant
++    zh
++    zh_CN
++    zh_HK
++    zh_Hans
++    zh_Hans_CN
++    zh_Hans_SG
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_SG
++    zh_TW
++    zu
 +)
 +
 +function(generate_coll_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/coll/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/coll/${ITEM}.txt ${COLL_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/coll/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/coll/${ITEM}.txt ${COLL_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(COLL_ITEM ${COLL_LIST})
-+  generate_coll_item(${COLL_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/coll/${COLL_ITEM}.res)
++    generate_coll_item(${COLL_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/coll/${COLL_ITEM}.res)
 +endforeach()
 +
-+### coll index
++# coll index
 +
 +configure_file(${IN_DIR}/cmake-coll-index-txt-content.in ${TMP_DIR}/coll/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/coll/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/coll/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/coll/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/coll/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/coll -d ${OUT_DIR}/coll/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### brkitr res
++# brkitr res
 +
-+add_prefix(BRKITR_RES_DEPS ${OUT_DIR}
-+        brkitr/char.brk
-+		brkitr/line.brk
-+		brkitr/line_cj.brk
-+		brkitr/line_loose.brk
-+		brkitr/line_loose_cj.brk
-+		brkitr/line_normal.brk
-+		brkitr/line_normal_cj.brk
-+		brkitr/sent.brk
-+		brkitr/sent_el.brk
-+		brkitr/title.brk
-+		brkitr/word.brk
-+		brkitr/word_POSIX.brk
-+		brkitr/burmesedict.dict
-+		brkitr/cjdict.dict
-+		brkitr/khmerdict.dict
-+		brkitr/laodict.dict
-+		brkitr/thaidict.dict)
++add_prefix(
++    BRKITR_RES_DEPS
++    ${OUT_DIR}
++    brkitr/char.brk
++    brkitr/line.brk
++    brkitr/line_cj.brk
++    brkitr/line_loose.brk
++    brkitr/line_loose_cj.brk
++    brkitr/line_normal.brk
++    brkitr/line_normal_cj.brk
++    brkitr/sent.brk
++    brkitr/sent_el.brk
++    brkitr/title.brk
++    brkitr/word.brk
++    brkitr/word_POSIX.brk
++    brkitr/burmesedict.dict
++    brkitr/cjdict.dict
++    brkitr/khmerdict.dict
++    brkitr/laodict.dict
++    brkitr/thaidict.dict
++)
 +
-+set(BRKITR_RES_LIST 
-+	de
-+	el
-+	en
-+	en_US
-+	en_US_POSIX
-+	es
-+	fr
-+	it
-+	ja
-+	pt
-+	root
-+	ru
-+	zh
-+	zh_Hant
++set(BRKITR_RES_LIST
++    de
++    el
++    en
++    en_US
++    en_US_POSIX
++    es
++    fr
++    it
++    ja
++    pt
++    root
++    ru
++    zh
++    zh_Hant
 +)
 +
 +function(generate_brkitr_res_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/brkitr/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/brkitr/${ITEM}.txt ${BRKITR_RES_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/brkitr/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/brkitr/${ITEM}.txt ${BRKITR_RES_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
++                ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(BRKITR_RES_ITEM ${BRKITR_RES_LIST})
-+  generate_brkitr_res_item(${BRKITR_RES_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRKITR_RES_ITEM}.res)
++    generate_brkitr_res_item(${BRKITR_RES_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/brkitr/${BRKITR_RES_ITEM}.res)
 +endforeach()
 +
-+### brkitr index
++# brkitr index
 +
 +configure_file(${IN_DIR}/cmake-brkitr-index-txt-content.in ${TMP_DIR}/brkitr/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/brkitr/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/brkitr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/brkitr/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/brkitr/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/brkitr -d ${OUT_DIR}/brkitr/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### rbnf
++# rbnf
 +
 +set(RBNF_LIST
 +    af
-+	ak
-+	am
-+	ar
-+	ar_SA
-+	ars
-+	az
-+	be
-+	bg
-+	bs
-+	ca
-+	ccp
-+	chr
-+	cs
-+	cy
-+	da
-+	de
-+	de_CH
-+	ee
-+	el
-+	en
-+	en_001
-+	en_IN
-+	eo
-+	es
-+	es_419
-+	es_DO
-+	es_GT
-+	es_HN
-+	es_MX
-+	es_NI
-+	es_PA
-+	es_PR
-+	es_SV
-+	es_US
-+	et
-+	fa
-+	fa_AF
-+	ff
-+	fi
-+	fil
-+	fo
-+	fr
-+	fr_BE
-+	fr_CH
-+	ga
-+	he
-+	hi
-+	hr
-+	hu
-+	hy
-+	id
-+	in
-+	is
-+	it
-+	iw
-+	ja
-+	ka
-+	kl
-+	km
-+	ko
-+	ky
-+	lb
-+	lo
-+	lrc
-+	lt
-+	lv
-+	mk
-+	ms
-+	mt
-+	my
-+	nb
-+	nl
-+	nn
-+	no
-+	pl
-+	pt
-+	pt_PT
-+	qu
-+	ro
-+	root
-+	ru
-+	se
-+	sh
-+	sk
-+	sl
-+	sq
-+	sr
-+	sr_Latn
-+	su
-+	sv
-+	sw
-+	ta
-+	th
-+	tr
-+	uk
-+	vi
-+	yue
-+	yue_Hans
-+	zh
-+	zh_HK
-+	zh_Hant
-+	zh_Hant_HK
-+	zh_Hant_MO
-+	zh_Hant_TW
-+	zh_MO
-+	zh_TW
++    ak
++    am
++    ar
++    ar_SA
++    ars
++    az
++    be
++    bg
++    bs
++    ca
++    ccp
++    chr
++    cs
++    cy
++    da
++    de
++    de_CH
++    ee
++    el
++    en
++    en_001
++    en_IN
++    eo
++    es
++    es_419
++    es_DO
++    es_GT
++    es_HN
++    es_MX
++    es_NI
++    es_PA
++    es_PR
++    es_SV
++    es_US
++    et
++    fa
++    fa_AF
++    ff
++    fi
++    fil
++    fo
++    fr
++    fr_BE
++    fr_CH
++    ga
++    he
++    hi
++    hr
++    hu
++    hy
++    id
++    in
++    is
++    it
++    iw
++    ja
++    ka
++    kl
++    km
++    ko
++    ky
++    lb
++    lo
++    lrc
++    lt
++    lv
++    mk
++    ms
++    mt
++    my
++    nb
++    nl
++    nn
++    no
++    pl
++    pt
++    pt_PT
++    qu
++    ro
++    root
++    ru
++    se
++    sh
++    sk
++    sl
++    sq
++    sr
++    sr_Latn
++    su
++    sv
++    sw
++    ta
++    th
++    tr
++    uk
++    vi
++    yue
++    yue_Hans
++    zh
++    zh_HK
++    zh_Hant
++    zh_Hant_HK
++    zh_Hant_MO
++    zh_Hant_TW
++    zh_MO
++    zh_TW
 +)
 +
 +function(generate_rbnf_item ITEM)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/rbnf/${ITEM}.res
-+    DEPENDS data_dirs ${IN_DIR}/rbnf/${ITEM}.txt ${RBNF_DEPS} ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${ITEM}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/rbnf/${ITEM}.res
++        DEPENDS data_dirs ${IN_DIR}/rbnf/${ITEM}.txt ${RBNF_DEPS} ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -s ${IN_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${ITEM}.txt
++    )
 +endfunction()
 +
 +foreach(RBNF_ITEM ${RBNF_LIST})
-+  generate_rbnf_item(${RBNF_ITEM})
-+  list(APPEND tmpdep ${OUT_DIR}/rbnf/${RBNF_ITEM}.res)
++    generate_rbnf_item(${RBNF_ITEM})
++    list(APPEND tmpdep ${OUT_DIR}/rbnf/${RBNF_ITEM}.res)
 +endforeach()
 +
-+### rbnf index
++# rbnf index
 +
 +configure_file(${IN_DIR}/cmake-rbnf-index-txt-content.in ${TMP_DIR}/rbnf/${INDEX_NAME}.txt)
 +add_custom_command(
-+  OUTPUT ${OUT_DIR}/rbnf/${INDEX_NAME}.res
-+  DEPENDS data_dirs ${TMP_DIR}/rbnf/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
-+  COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k ${INDEX_NAME}.txt
++    OUTPUT ${OUT_DIR}/rbnf/${INDEX_NAME}.res
++    DEPENDS data_dirs ${TMP_DIR}/rbnf/${INDEX_NAME}.txt ${TOOLBINDIR}/genrb
++    COMMAND ${TOOLBINDIR}/genrb -s ${TMP_DIR}/rbnf -d ${OUT_DIR}/rbnf/ -i ${OUT_DIR} -k
++            ${INDEX_NAME}.txt
 +)
 +
-+### icudata list
++# icudata list
 +
 +configure_file(${IN_DIR}/cmake-icudata-list-content.in ${TMP_DIR}/icudata.lst)
 +
-+### list
++# list
 +
 +set(ICUDATA_ALL_OUTPUT_FILES
-+        ${OUT_DIR}/${INDEX_NAME}.res 
-+		${OUT_DIR}/af.res
-+		${OUT_DIR}/af_NA.res
-+		${OUT_DIR}/af_ZA.res
-+		${OUT_DIR}/agq.res
-+		${OUT_DIR}/agq_CM.res
-+		${OUT_DIR}/ak.res
-+		${OUT_DIR}/ak_GH.res
-+		${OUT_DIR}/am.res
-+		${OUT_DIR}/am_ET.res
-+		${OUT_DIR}/ar.res
-+		${OUT_DIR}/ar_001.res
-+		${OUT_DIR}/ar_AE.res
-+		${OUT_DIR}/ar_BH.res
-+		${OUT_DIR}/ar_DJ.res
-+		${OUT_DIR}/ar_DZ.res
-+		${OUT_DIR}/ar_EG.res
-+		${OUT_DIR}/ar_EH.res
-+		${OUT_DIR}/ar_ER.res
-+		${OUT_DIR}/ar_IL.res
-+		${OUT_DIR}/ar_IQ.res
-+		${OUT_DIR}/ar_JO.res
-+		${OUT_DIR}/ar_KM.res
-+		${OUT_DIR}/ar_KW.res
-+		${OUT_DIR}/ar_LB.res
-+		${OUT_DIR}/ar_LY.res
-+		${OUT_DIR}/ar_MA.res
-+		${OUT_DIR}/ar_MR.res
-+		${OUT_DIR}/ar_OM.res
-+		${OUT_DIR}/ar_PS.res
-+		${OUT_DIR}/ar_QA.res
-+		${OUT_DIR}/ar_SA.res
-+		${OUT_DIR}/ar_SD.res
-+		${OUT_DIR}/ar_SO.res
-+		${OUT_DIR}/ar_SS.res
-+		${OUT_DIR}/ar_SY.res
-+		${OUT_DIR}/ar_TD.res
-+		${OUT_DIR}/ar_TN.res
-+		${OUT_DIR}/ar_YE.res
-+		${OUT_DIR}/ars.res
-+		${OUT_DIR}/as.res
-+		${OUT_DIR}/as_IN.res
-+		${OUT_DIR}/asa.res
-+		${OUT_DIR}/asa_TZ.res
-+		${OUT_DIR}/ast.res
-+		${OUT_DIR}/ast_ES.res
-+		${OUT_DIR}/az.res
-+		${OUT_DIR}/az_AZ.res
-+		${OUT_DIR}/az_Cyrl.res
-+		${OUT_DIR}/az_Cyrl_AZ.res
-+		${OUT_DIR}/az_Latn.res
-+		${OUT_DIR}/az_Latn_AZ.res
-+		${OUT_DIR}/bas.res
-+		${OUT_DIR}/bas_CM.res
-+		${OUT_DIR}/be.res
-+		${OUT_DIR}/be_BY.res
-+		${OUT_DIR}/bem.res
-+		${OUT_DIR}/bem_ZM.res
-+		${OUT_DIR}/bez.res
-+		${OUT_DIR}/bez_TZ.res
-+		${OUT_DIR}/bg.res
-+		${OUT_DIR}/bg_BG.res
-+		${OUT_DIR}/bm.res
-+		${OUT_DIR}/bm_ML.res
-+		${OUT_DIR}/bn.res
-+		${OUT_DIR}/bn_BD.res
-+		${OUT_DIR}/bn_IN.res
-+		${OUT_DIR}/bo.res
-+		${OUT_DIR}/bo_CN.res
-+		${OUT_DIR}/bo_IN.res
-+		${OUT_DIR}/br.res
-+		${OUT_DIR}/br_FR.res
-+		${OUT_DIR}/brkitr/${INDEX_NAME}.res
-+		${OUT_DIR}/brkitr/burmesedict.dict
-+		${OUT_DIR}/brkitr/char.brk
-+		${OUT_DIR}/brkitr/cjdict.dict
-+		${OUT_DIR}/brkitr/de.res
-+		${OUT_DIR}/brkitr/el.res
-+		${OUT_DIR}/brkitr/en.res
-+		${OUT_DIR}/brkitr/en_US.res
-+		${OUT_DIR}/brkitr/en_US_POSIX.res
-+		${OUT_DIR}/brkitr/es.res
-+		${OUT_DIR}/brkitr/fr.res
-+		${OUT_DIR}/brkitr/it.res
-+		${OUT_DIR}/brkitr/ja.res
-+		${OUT_DIR}/brkitr/khmerdict.dict
-+		${OUT_DIR}/brkitr/laodict.dict
-+		${OUT_DIR}/brkitr/line.brk
-+		${OUT_DIR}/brkitr/line_cj.brk
-+		${OUT_DIR}/brkitr/line_loose.brk
-+		${OUT_DIR}/brkitr/line_loose_cj.brk
-+		${OUT_DIR}/brkitr/line_normal.brk
-+		${OUT_DIR}/brkitr/line_normal_cj.brk
-+		${OUT_DIR}/brkitr/pt.res
-+		${OUT_DIR}/brkitr/root.res
-+		${OUT_DIR}/brkitr/ru.res
-+		${OUT_DIR}/brkitr/sent.brk
-+		${OUT_DIR}/brkitr/sent_el.brk
-+		${OUT_DIR}/brkitr/thaidict.dict
-+		${OUT_DIR}/brkitr/title.brk
-+		${OUT_DIR}/brkitr/word.brk
-+		${OUT_DIR}/brkitr/word_POSIX.brk
-+		${OUT_DIR}/brkitr/zh.res
-+		${OUT_DIR}/brkitr/zh_Hant.res
-+		${OUT_DIR}/brx.res
-+		${OUT_DIR}/brx_IN.res
-+		${OUT_DIR}/bs.res
-+		${OUT_DIR}/bs_BA.res
-+		${OUT_DIR}/bs_Cyrl.res
-+		${OUT_DIR}/bs_Cyrl_BA.res
-+		${OUT_DIR}/bs_Latn.res
-+		${OUT_DIR}/bs_Latn_BA.res
-+		${OUT_DIR}/ca.res
-+		${OUT_DIR}/ca_AD.res
-+		${OUT_DIR}/ca_ES.res
-+		${OUT_DIR}/ca_FR.res
-+		${OUT_DIR}/ca_IT.res
-+		${OUT_DIR}/ccp.res
-+		${OUT_DIR}/ccp_BD.res
-+		${OUT_DIR}/ccp_IN.res
-+		${OUT_DIR}/ce.res
-+		${OUT_DIR}/ce_RU.res
-+		${OUT_DIR}/ceb.res
-+		${OUT_DIR}/ceb_PH.res
-+		${OUT_DIR}/cgg.res
-+		${OUT_DIR}/cgg_UG.res
-+		${OUT_DIR}/chr.res
-+		${OUT_DIR}/chr_US.res
-+		${OUT_DIR}/ckb.res
-+		${OUT_DIR}/ckb_IQ.res
-+		${OUT_DIR}/ckb_IR.res
-+		${OUT_DIR}/cns-11643-1992.cnv
-+		${OUT_DIR}/cnvalias.icu
-+		${OUT_DIR}/coll/${INDEX_NAME}.res
-+		${OUT_DIR}/coll/af.res
-+		${OUT_DIR}/coll/am.res
-+		${OUT_DIR}/coll/ar.res
-+		${OUT_DIR}/coll/ar_SA.res
-+		${OUT_DIR}/coll/ars.res
-+		${OUT_DIR}/coll/as.res
-+		${OUT_DIR}/coll/az.res
-+		${OUT_DIR}/coll/be.res
-+		${OUT_DIR}/coll/bg.res
-+		${OUT_DIR}/coll/bn.res
-+		${OUT_DIR}/coll/bo.res
-+		${OUT_DIR}/coll/bs.res
-+		${OUT_DIR}/coll/bs_Cyrl.res
-+		${OUT_DIR}/coll/ca.res
-+		${OUT_DIR}/coll/ceb.res
-+		${OUT_DIR}/coll/chr.res
-+		${OUT_DIR}/coll/cs.res
-+		${OUT_DIR}/coll/cy.res
-+		${OUT_DIR}/coll/da.res
-+		${OUT_DIR}/coll/de.res
-+		${OUT_DIR}/coll/de_.res
-+		${OUT_DIR}/coll/de_AT.res
-+		${OUT_DIR}/coll/de__PHONEBOOK.res
-+		${OUT_DIR}/coll/dsb.res
-+		${OUT_DIR}/coll/dz.res
-+		${OUT_DIR}/coll/ee.res
-+		${OUT_DIR}/coll/el.res
-+		${OUT_DIR}/coll/en.res
-+		${OUT_DIR}/coll/en_US.res
-+		${OUT_DIR}/coll/en_US_POSIX.res
-+		${OUT_DIR}/coll/eo.res
-+		${OUT_DIR}/coll/es.res
-+		${OUT_DIR}/coll/es_.res
-+		${OUT_DIR}/coll/es__TRADITIONAL.res
-+		${OUT_DIR}/coll/et.res
-+		${OUT_DIR}/coll/fa.res
-+		${OUT_DIR}/coll/fa_AF.res
-+		${OUT_DIR}/coll/ff.res
-+		${OUT_DIR}/coll/ff_Adlm.res
-+		${OUT_DIR}/coll/fi.res
-+		${OUT_DIR}/coll/fil.res
-+		${OUT_DIR}/coll/fo.res
-+		${OUT_DIR}/coll/fr.res
-+		${OUT_DIR}/coll/fr_CA.res
-+		${OUT_DIR}/coll/ga.res
-+		${OUT_DIR}/coll/gl.res
-+		${OUT_DIR}/coll/gu.res
-+		${OUT_DIR}/coll/ha.res
-+		${OUT_DIR}/coll/haw.res
-+		${OUT_DIR}/coll/he.res
-+		${OUT_DIR}/coll/he_IL.res
-+		${OUT_DIR}/coll/hi.res
-+		${OUT_DIR}/coll/hr.res
-+		${OUT_DIR}/coll/hsb.res
-+		${OUT_DIR}/coll/hu.res
-+		${OUT_DIR}/coll/hy.res
-+		${OUT_DIR}/coll/id.res
-+		${OUT_DIR}/coll/id_ID.res
-+		${OUT_DIR}/coll/ig.res
-+		${OUT_DIR}/coll/in.res
-+		${OUT_DIR}/coll/in_ID.res
-+		${OUT_DIR}/coll/is.res
-+		${OUT_DIR}/coll/it.res
-+		${OUT_DIR}/coll/iw.res
-+		${OUT_DIR}/coll/iw_IL.res
-+		${OUT_DIR}/coll/ja.res
-+		${OUT_DIR}/coll/ka.res
-+		${OUT_DIR}/coll/kk.res
-+		${OUT_DIR}/coll/kl.res
-+		${OUT_DIR}/coll/km.res
-+		${OUT_DIR}/coll/kn.res
-+		${OUT_DIR}/coll/ko.res
-+		${OUT_DIR}/coll/kok.res
-+		${OUT_DIR}/coll/ku.res
-+		${OUT_DIR}/coll/ky.res
-+		${OUT_DIR}/coll/lb.res
-+		${OUT_DIR}/coll/lkt.res
-+		${OUT_DIR}/coll/ln.res
-+		${OUT_DIR}/coll/lo.res
-+		${OUT_DIR}/coll/lt.res
-+		${OUT_DIR}/coll/lv.res
-+		${OUT_DIR}/coll/mk.res
-+		${OUT_DIR}/coll/ml.res
-+		${OUT_DIR}/coll/mn.res
-+		${OUT_DIR}/coll/mo.res
-+		${OUT_DIR}/coll/mr.res
-+		${OUT_DIR}/coll/ms.res
-+		${OUT_DIR}/coll/mt.res
-+		${OUT_DIR}/coll/my.res
-+		${OUT_DIR}/coll/nb.res
-+		${OUT_DIR}/coll/nb_NO.res
-+		${OUT_DIR}/coll/ne.res
-+		${OUT_DIR}/coll/nl.res
-+		${OUT_DIR}/coll/nn.res
-+		${OUT_DIR}/coll/no.res
-+		${OUT_DIR}/coll/no_NO.res
-+		${OUT_DIR}/coll/om.res
-+		${OUT_DIR}/coll/or.res
-+		${OUT_DIR}/coll/pa.res
-+		${OUT_DIR}/coll/pa_Guru.res
-+		${OUT_DIR}/coll/pa_Guru_IN.res
-+		${OUT_DIR}/coll/pa_IN.res
-+		${OUT_DIR}/coll/pl.res
-+		${OUT_DIR}/coll/ps.res
-+		${OUT_DIR}/coll/pt.res
-+		${OUT_DIR}/coll/ro.res
-+		${OUT_DIR}/coll/root.res
-+		${OUT_DIR}/coll/ru.res
-+		${OUT_DIR}/coll/se.res
-+		${OUT_DIR}/coll/sh.res
-+		${OUT_DIR}/coll/sh_BA.res
-+		${OUT_DIR}/coll/sh_CS.res
-+		${OUT_DIR}/coll/sh_YU.res
-+		${OUT_DIR}/coll/si.res
-+		${OUT_DIR}/coll/sk.res
-+		${OUT_DIR}/coll/sl.res
-+		${OUT_DIR}/coll/smn.res
-+		${OUT_DIR}/coll/sq.res
-+		${OUT_DIR}/coll/sr.res
-+		${OUT_DIR}/coll/sr_BA.res
-+		${OUT_DIR}/coll/sr_Cyrl.res
-+		${OUT_DIR}/coll/sr_Cyrl_BA.res
-+		${OUT_DIR}/coll/sr_Cyrl_ME.res
-+		${OUT_DIR}/coll/sr_Cyrl_RS.res
-+		${OUT_DIR}/coll/sr_Latn.res
-+		${OUT_DIR}/coll/sr_Latn_BA.res
-+		${OUT_DIR}/coll/sr_Latn_RS.res
-+		${OUT_DIR}/coll/sr_ME.res
-+		${OUT_DIR}/coll/sr_RS.res
-+		${OUT_DIR}/coll/sv.res
-+		${OUT_DIR}/coll/sw.res
-+		${OUT_DIR}/coll/ta.res
-+		${OUT_DIR}/coll/te.res
-+		${OUT_DIR}/coll/th.res
-+		${OUT_DIR}/coll/tk.res
-+		${OUT_DIR}/coll/to.res
-+		${OUT_DIR}/coll/tr.res
-+		${OUT_DIR}/coll/ucadata.icu
-+		${OUT_DIR}/coll/ug.res
-+		${OUT_DIR}/coll/uk.res
-+		${OUT_DIR}/coll/ur.res
-+		${OUT_DIR}/coll/uz.res
-+		${OUT_DIR}/coll/vi.res
-+		${OUT_DIR}/coll/wae.res
-+		${OUT_DIR}/coll/wo.res
-+		${OUT_DIR}/coll/xh.res
-+		${OUT_DIR}/coll/yi.res
-+		${OUT_DIR}/coll/yo.res
-+		${OUT_DIR}/coll/yue.res
-+		${OUT_DIR}/coll/yue_CN.res
-+		${OUT_DIR}/coll/yue_Hans.res
-+		${OUT_DIR}/coll/yue_Hans_CN.res
-+		${OUT_DIR}/coll/yue_Hant.res
-+		${OUT_DIR}/coll/zh.res
-+		${OUT_DIR}/coll/zh_CN.res
-+		${OUT_DIR}/coll/zh_HK.res
-+		${OUT_DIR}/coll/zh_Hans.res
-+		${OUT_DIR}/coll/zh_Hans_CN.res
-+		${OUT_DIR}/coll/zh_Hans_SG.res
-+		${OUT_DIR}/coll/zh_Hant.res
-+		${OUT_DIR}/coll/zh_Hant_HK.res
-+		${OUT_DIR}/coll/zh_Hant_MO.res
-+		${OUT_DIR}/coll/zh_Hant_TW.res
-+		${OUT_DIR}/coll/zh_MO.res
-+		${OUT_DIR}/coll/zh_SG.res
-+		${OUT_DIR}/coll/zh_TW.res
-+		${OUT_DIR}/coll/zu.res
-+		${OUT_DIR}/confusables.cfu
-+		${OUT_DIR}/cs.res
-+		${OUT_DIR}/cs_CZ.res
-+		${OUT_DIR}/curr/${INDEX_NAME}.res
-+		${OUT_DIR}/curr/af.res
-+		${OUT_DIR}/curr/af_NA.res
-+		${OUT_DIR}/curr/agq.res
-+		${OUT_DIR}/curr/ak.res
-+		${OUT_DIR}/curr/am.res
-+		${OUT_DIR}/curr/ar.res
-+		${OUT_DIR}/curr/ar_AE.res
-+		${OUT_DIR}/curr/ar_DJ.res
-+		${OUT_DIR}/curr/ar_ER.res
-+		${OUT_DIR}/curr/ar_KM.res
-+		${OUT_DIR}/curr/ar_LB.res
-+		${OUT_DIR}/curr/ar_SA.res
-+		${OUT_DIR}/curr/ar_SO.res
-+		${OUT_DIR}/curr/ar_SS.res
-+		${OUT_DIR}/curr/ars.res
-+		${OUT_DIR}/curr/as.res
-+		${OUT_DIR}/curr/asa.res
-+		${OUT_DIR}/curr/ast.res
-+		${OUT_DIR}/curr/az.res
-+		${OUT_DIR}/curr/az_AZ.res
-+		${OUT_DIR}/curr/az_Cyrl.res
-+		${OUT_DIR}/curr/az_Latn.res
-+		${OUT_DIR}/curr/az_Latn_AZ.res
-+		${OUT_DIR}/curr/bas.res
-+		${OUT_DIR}/curr/be.res
-+		${OUT_DIR}/curr/bem.res
-+		${OUT_DIR}/curr/bez.res
-+		${OUT_DIR}/curr/bg.res
-+		${OUT_DIR}/curr/bm.res
-+		${OUT_DIR}/curr/bn.res
-+		${OUT_DIR}/curr/bo.res
-+		${OUT_DIR}/curr/bo_IN.res
-+		${OUT_DIR}/curr/br.res
-+		${OUT_DIR}/curr/brx.res
-+		${OUT_DIR}/curr/bs.res
-+		${OUT_DIR}/curr/bs_BA.res
-+		${OUT_DIR}/curr/bs_Cyrl.res
-+		${OUT_DIR}/curr/bs_Latn.res
-+		${OUT_DIR}/curr/bs_Latn_BA.res
-+		${OUT_DIR}/curr/ca.res
-+		${OUT_DIR}/curr/ca_FR.res
-+		${OUT_DIR}/curr/ccp.res
-+		${OUT_DIR}/curr/ce.res
-+		${OUT_DIR}/curr/ceb.res
-+		${OUT_DIR}/curr/cgg.res
-+		${OUT_DIR}/curr/chr.res
-+		${OUT_DIR}/curr/ckb.res
-+		${OUT_DIR}/curr/cs.res
-+		${OUT_DIR}/curr/cy.res
-+		${OUT_DIR}/curr/da.res
-+		${OUT_DIR}/curr/dav.res
-+		${OUT_DIR}/curr/de.res
-+		${OUT_DIR}/curr/de_CH.res
-+		${OUT_DIR}/curr/de_LI.res
-+		${OUT_DIR}/curr/de_LU.res
-+		${OUT_DIR}/curr/dje.res
-+		${OUT_DIR}/curr/dsb.res
-+		${OUT_DIR}/curr/dua.res
-+		${OUT_DIR}/curr/dyo.res
-+		${OUT_DIR}/curr/dz.res
-+		${OUT_DIR}/curr/ebu.res
-+		${OUT_DIR}/curr/ee.res
-+		${OUT_DIR}/curr/el.res
-+		${OUT_DIR}/curr/en.res
-+		${OUT_DIR}/curr/en_001.res
-+		${OUT_DIR}/curr/en_150.res
-+		${OUT_DIR}/curr/en_AE.res
-+		${OUT_DIR}/curr/en_AG.res
-+		${OUT_DIR}/curr/en_AI.res
-+		${OUT_DIR}/curr/en_AT.res
-+		${OUT_DIR}/curr/en_AU.res
-+		${OUT_DIR}/curr/en_BB.res
-+		${OUT_DIR}/curr/en_BE.res
-+		${OUT_DIR}/curr/en_BI.res
-+		${OUT_DIR}/curr/en_BM.res
-+		${OUT_DIR}/curr/en_BS.res
-+		${OUT_DIR}/curr/en_BW.res
-+		${OUT_DIR}/curr/en_BZ.res
-+		${OUT_DIR}/curr/en_CA.res
-+		${OUT_DIR}/curr/en_CC.res
-+		${OUT_DIR}/curr/en_CH.res
-+		${OUT_DIR}/curr/en_CK.res
-+		${OUT_DIR}/curr/en_CM.res
-+		${OUT_DIR}/curr/en_CX.res
-+		${OUT_DIR}/curr/en_CY.res
-+		${OUT_DIR}/curr/en_DE.res
-+		${OUT_DIR}/curr/en_DG.res
-+		${OUT_DIR}/curr/en_DK.res
-+		${OUT_DIR}/curr/en_DM.res
-+		${OUT_DIR}/curr/en_ER.res
-+		${OUT_DIR}/curr/en_FI.res
-+		${OUT_DIR}/curr/en_FJ.res
-+		${OUT_DIR}/curr/en_FK.res
-+		${OUT_DIR}/curr/en_FM.res
-+		${OUT_DIR}/curr/en_GB.res
-+		${OUT_DIR}/curr/en_GD.res
-+		${OUT_DIR}/curr/en_GG.res
-+		${OUT_DIR}/curr/en_GH.res
-+		${OUT_DIR}/curr/en_GI.res
-+		${OUT_DIR}/curr/en_GM.res
-+		${OUT_DIR}/curr/en_GY.res
-+		${OUT_DIR}/curr/en_HK.res
-+		${OUT_DIR}/curr/en_IE.res
-+		${OUT_DIR}/curr/en_IL.res
-+		${OUT_DIR}/curr/en_IM.res
-+		${OUT_DIR}/curr/en_IN.res
-+		${OUT_DIR}/curr/en_IO.res
-+		${OUT_DIR}/curr/en_JE.res
-+		${OUT_DIR}/curr/en_JM.res
-+		${OUT_DIR}/curr/en_KE.res
-+		${OUT_DIR}/curr/en_KI.res
-+		${OUT_DIR}/curr/en_KN.res
-+		${OUT_DIR}/curr/en_KY.res
-+		${OUT_DIR}/curr/en_LC.res
-+		${OUT_DIR}/curr/en_LR.res
-+		${OUT_DIR}/curr/en_LS.res
-+		${OUT_DIR}/curr/en_MG.res
-+		${OUT_DIR}/curr/en_MO.res
-+		${OUT_DIR}/curr/en_MS.res
-+		${OUT_DIR}/curr/en_MT.res
-+		${OUT_DIR}/curr/en_MU.res
-+		${OUT_DIR}/curr/en_MW.res
-+		${OUT_DIR}/curr/en_MY.res
-+		${OUT_DIR}/curr/en_NA.res
-+		${OUT_DIR}/curr/en_NF.res
-+		${OUT_DIR}/curr/en_NG.res
-+		${OUT_DIR}/curr/en_NH.res
-+		${OUT_DIR}/curr/en_NL.res
-+		${OUT_DIR}/curr/en_NR.res
-+		${OUT_DIR}/curr/en_NU.res
-+		${OUT_DIR}/curr/en_NZ.res
-+		${OUT_DIR}/curr/en_PG.res
-+		${OUT_DIR}/curr/en_PH.res
-+		${OUT_DIR}/curr/en_PK.res
-+		${OUT_DIR}/curr/en_PN.res
-+		${OUT_DIR}/curr/en_PW.res
-+		${OUT_DIR}/curr/en_RH.res
-+		${OUT_DIR}/curr/en_RW.res
-+		${OUT_DIR}/curr/en_SB.res
-+		${OUT_DIR}/curr/en_SC.res
-+		${OUT_DIR}/curr/en_SD.res
-+		${OUT_DIR}/curr/en_SE.res
-+		${OUT_DIR}/curr/en_SG.res
-+		${OUT_DIR}/curr/en_SH.res
-+		${OUT_DIR}/curr/en_SI.res
-+		${OUT_DIR}/curr/en_SL.res
-+		${OUT_DIR}/curr/en_SS.res
-+		${OUT_DIR}/curr/en_SX.res
-+		${OUT_DIR}/curr/en_SZ.res
-+		${OUT_DIR}/curr/en_TC.res
-+		${OUT_DIR}/curr/en_TK.res
-+		${OUT_DIR}/curr/en_TO.res
-+		${OUT_DIR}/curr/en_TT.res
-+		${OUT_DIR}/curr/en_TV.res
-+		${OUT_DIR}/curr/en_TZ.res
-+		${OUT_DIR}/curr/en_UG.res
-+		${OUT_DIR}/curr/en_VC.res
-+		${OUT_DIR}/curr/en_VG.res
-+		${OUT_DIR}/curr/en_VU.res
-+		${OUT_DIR}/curr/en_WS.res
-+		${OUT_DIR}/curr/en_ZA.res
-+		${OUT_DIR}/curr/en_ZM.res
-+		${OUT_DIR}/curr/en_ZW.res
-+		${OUT_DIR}/curr/eo.res
-+		${OUT_DIR}/curr/es.res
-+		${OUT_DIR}/curr/es_419.res
-+		${OUT_DIR}/curr/es_AR.res
-+		${OUT_DIR}/curr/es_BO.res
-+		${OUT_DIR}/curr/es_BR.res
-+		${OUT_DIR}/curr/es_BZ.res
-+		${OUT_DIR}/curr/es_CL.res
-+		${OUT_DIR}/curr/es_CO.res
-+		${OUT_DIR}/curr/es_CR.res
-+		${OUT_DIR}/curr/es_CU.res
-+		${OUT_DIR}/curr/es_DO.res
-+		${OUT_DIR}/curr/es_EC.res
-+		${OUT_DIR}/curr/es_GQ.res
-+		${OUT_DIR}/curr/es_GT.res
-+		${OUT_DIR}/curr/es_HN.res
-+		${OUT_DIR}/curr/es_MX.res
-+		${OUT_DIR}/curr/es_NI.res
-+		${OUT_DIR}/curr/es_PA.res
-+		${OUT_DIR}/curr/es_PE.res
-+		${OUT_DIR}/curr/es_PH.res
-+		${OUT_DIR}/curr/es_PR.res
-+		${OUT_DIR}/curr/es_PY.res
-+		${OUT_DIR}/curr/es_SV.res
-+		${OUT_DIR}/curr/es_US.res
-+		${OUT_DIR}/curr/es_UY.res
-+		${OUT_DIR}/curr/es_VE.res
-+		${OUT_DIR}/curr/et.res
-+		${OUT_DIR}/curr/eu.res
-+		${OUT_DIR}/curr/ewo.res
-+		${OUT_DIR}/curr/fa.res
-+		${OUT_DIR}/curr/fa_AF.res
-+		${OUT_DIR}/curr/ff.res
-+		${OUT_DIR}/curr/ff_Adlm.res
-+		${OUT_DIR}/curr/ff_Adlm_BF.res
-+		${OUT_DIR}/curr/ff_Adlm_CM.res
-+		${OUT_DIR}/curr/ff_Adlm_GH.res
-+		${OUT_DIR}/curr/ff_Adlm_GM.res
-+		${OUT_DIR}/curr/ff_Adlm_GW.res
-+		${OUT_DIR}/curr/ff_Adlm_LR.res
-+		${OUT_DIR}/curr/ff_Adlm_MR.res
-+		${OUT_DIR}/curr/ff_Adlm_NE.res
-+		${OUT_DIR}/curr/ff_Adlm_NG.res
-+		${OUT_DIR}/curr/ff_Adlm_SL.res
-+		${OUT_DIR}/curr/ff_Adlm_SN.res
-+		${OUT_DIR}/curr/ff_CM.res
-+		${OUT_DIR}/curr/ff_GN.res
-+		${OUT_DIR}/curr/ff_Latn.res
-+		${OUT_DIR}/curr/ff_Latn_CM.res
-+		${OUT_DIR}/curr/ff_Latn_GH.res
-+		${OUT_DIR}/curr/ff_Latn_GM.res
-+		${OUT_DIR}/curr/ff_Latn_GN.res
-+		${OUT_DIR}/curr/ff_Latn_LR.res
-+		${OUT_DIR}/curr/ff_Latn_MR.res
-+		${OUT_DIR}/curr/ff_Latn_NG.res
-+		${OUT_DIR}/curr/ff_Latn_SL.res
-+		${OUT_DIR}/curr/ff_Latn_SN.res
-+		${OUT_DIR}/curr/ff_MR.res
-+		${OUT_DIR}/curr/ff_SN.res
-+		${OUT_DIR}/curr/fi.res
-+		${OUT_DIR}/curr/fil.res
-+		${OUT_DIR}/curr/fil_PH.res
-+		${OUT_DIR}/curr/fo.res
-+		${OUT_DIR}/curr/fo_DK.res
-+		${OUT_DIR}/curr/fr.res
-+		${OUT_DIR}/curr/fr_BI.res
-+		${OUT_DIR}/curr/fr_CA.res
-+		${OUT_DIR}/curr/fr_CD.res
-+		${OUT_DIR}/curr/fr_DJ.res
-+		${OUT_DIR}/curr/fr_DZ.res
-+		${OUT_DIR}/curr/fr_GN.res
-+		${OUT_DIR}/curr/fr_HT.res
-+		${OUT_DIR}/curr/fr_KM.res
-+		${OUT_DIR}/curr/fr_LU.res
-+		${OUT_DIR}/curr/fr_MG.res
-+		${OUT_DIR}/curr/fr_MR.res
-+		${OUT_DIR}/curr/fr_MU.res
-+		${OUT_DIR}/curr/fr_RW.res
-+		${OUT_DIR}/curr/fr_SC.res
-+		${OUT_DIR}/curr/fr_SY.res
-+		${OUT_DIR}/curr/fr_TN.res
-+		${OUT_DIR}/curr/fr_VU.res
-+		${OUT_DIR}/curr/fur.res
-+		${OUT_DIR}/curr/fy.res
-+		${OUT_DIR}/curr/ga.res
-+		${OUT_DIR}/curr/gd.res
-+		${OUT_DIR}/curr/gl.res
-+		${OUT_DIR}/curr/gsw.res
-+		${OUT_DIR}/curr/gu.res
-+		${OUT_DIR}/curr/guz.res
-+		${OUT_DIR}/curr/gv.res
-+		${OUT_DIR}/curr/ha.res
-+		${OUT_DIR}/curr/ha_GH.res
-+		${OUT_DIR}/curr/haw.res
-+		${OUT_DIR}/curr/he.res
-+		${OUT_DIR}/curr/he_IL.res
-+		${OUT_DIR}/curr/hi.res
-+		${OUT_DIR}/curr/hr.res
-+		${OUT_DIR}/curr/hr_BA.res
-+		${OUT_DIR}/curr/hsb.res
-+		${OUT_DIR}/curr/hu.res
-+		${OUT_DIR}/curr/hy.res
-+		${OUT_DIR}/curr/ia.res
-+		${OUT_DIR}/curr/id.res
-+		${OUT_DIR}/curr/id_ID.res
-+		${OUT_DIR}/curr/ig.res
-+		${OUT_DIR}/curr/ii.res
-+		${OUT_DIR}/curr/in.res
-+		${OUT_DIR}/curr/in_ID.res
-+		${OUT_DIR}/curr/is.res
-+		${OUT_DIR}/curr/it.res
-+		${OUT_DIR}/curr/iw.res
-+		${OUT_DIR}/curr/iw_IL.res
-+		${OUT_DIR}/curr/ja.res
-+		${OUT_DIR}/curr/jgo.res
-+		${OUT_DIR}/curr/jmc.res
-+		${OUT_DIR}/curr/jv.res
-+		${OUT_DIR}/curr/ka.res
-+		${OUT_DIR}/curr/kab.res
-+		${OUT_DIR}/curr/kam.res
-+		${OUT_DIR}/curr/kde.res
-+		${OUT_DIR}/curr/kea.res
-+		${OUT_DIR}/curr/khq.res
-+		${OUT_DIR}/curr/ki.res
-+		${OUT_DIR}/curr/kk.res
-+		${OUT_DIR}/curr/kkj.res
-+		${OUT_DIR}/curr/kl.res
-+		${OUT_DIR}/curr/kln.res
-+		${OUT_DIR}/curr/km.res
-+		${OUT_DIR}/curr/kn.res
-+		${OUT_DIR}/curr/ko.res
-+		${OUT_DIR}/curr/kok.res
-+		${OUT_DIR}/curr/ks.res
-+		${OUT_DIR}/curr/ks_Arab.res
-+		${OUT_DIR}/curr/ks_Arab_IN.res
-+		${OUT_DIR}/curr/ks_IN.res
-+		${OUT_DIR}/curr/ksb.res
-+		${OUT_DIR}/curr/ksf.res
-+		${OUT_DIR}/curr/ksh.res
-+		${OUT_DIR}/curr/ku.res
-+		${OUT_DIR}/curr/kw.res
-+		${OUT_DIR}/curr/ky.res
-+		${OUT_DIR}/curr/lag.res
-+		${OUT_DIR}/curr/lb.res
-+		${OUT_DIR}/curr/lg.res
-+		${OUT_DIR}/curr/lkt.res
-+		${OUT_DIR}/curr/ln.res
-+		${OUT_DIR}/curr/ln_AO.res
-+		${OUT_DIR}/curr/lo.res
-+		${OUT_DIR}/curr/lrc.res
-+		${OUT_DIR}/curr/lt.res
-+		${OUT_DIR}/curr/lu.res
-+		${OUT_DIR}/curr/luo.res
-+		${OUT_DIR}/curr/luy.res
-+		${OUT_DIR}/curr/lv.res
-+		${OUT_DIR}/curr/mai.res
-+		${OUT_DIR}/curr/mas.res
-+		${OUT_DIR}/curr/mas_TZ.res
-+		${OUT_DIR}/curr/mer.res
-+		${OUT_DIR}/curr/mfe.res
-+		${OUT_DIR}/curr/mg.res
-+		${OUT_DIR}/curr/mgh.res
-+		${OUT_DIR}/curr/mgo.res
-+		${OUT_DIR}/curr/mi.res
-+		${OUT_DIR}/curr/mk.res
-+		${OUT_DIR}/curr/ml.res
-+		${OUT_DIR}/curr/mn.res
-+		${OUT_DIR}/curr/mni.res
-+		${OUT_DIR}/curr/mni_Beng.res
-+		${OUT_DIR}/curr/mni_Beng_IN.res
-+		${OUT_DIR}/curr/mni_IN.res
-+		${OUT_DIR}/curr/mo.res
-+		${OUT_DIR}/curr/mr.res
-+		${OUT_DIR}/curr/ms.res
-+		${OUT_DIR}/curr/ms_BN.res
-+		${OUT_DIR}/curr/ms_ID.res
-+		${OUT_DIR}/curr/ms_SG.res
-+		${OUT_DIR}/curr/mt.res
-+		${OUT_DIR}/curr/mua.res
-+		${OUT_DIR}/curr/my.res
-+		${OUT_DIR}/curr/mzn.res
-+		${OUT_DIR}/curr/naq.res
-+		${OUT_DIR}/curr/nb.res
-+		${OUT_DIR}/curr/nb_NO.res
-+		${OUT_DIR}/curr/nd.res
-+		${OUT_DIR}/curr/nds.res
-+		${OUT_DIR}/curr/ne.res
-+		${OUT_DIR}/curr/nl.res
-+		${OUT_DIR}/curr/nl_AW.res
-+		${OUT_DIR}/curr/nl_BQ.res
-+		${OUT_DIR}/curr/nl_CW.res
-+		${OUT_DIR}/curr/nl_SR.res
-+		${OUT_DIR}/curr/nl_SX.res
-+		${OUT_DIR}/curr/nmg.res
-+		${OUT_DIR}/curr/nn.res
-+		${OUT_DIR}/curr/nn_NO.res
-+		${OUT_DIR}/curr/nnh.res
-+		${OUT_DIR}/curr/no.res
-+		${OUT_DIR}/curr/no_NO.res
-+		${OUT_DIR}/curr/no_NO_NY.res
-+		${OUT_DIR}/curr/nus.res
-+		${OUT_DIR}/curr/nyn.res
-+		${OUT_DIR}/curr/om.res
-+		${OUT_DIR}/curr/om_KE.res
-+		${OUT_DIR}/curr/or.res
-+		${OUT_DIR}/curr/os.res
-+		${OUT_DIR}/curr/os_RU.res
-+		${OUT_DIR}/curr/pa.res
-+		${OUT_DIR}/curr/pa_Arab.res
-+		${OUT_DIR}/curr/pa_Arab_PK.res
-+		${OUT_DIR}/curr/pa_Guru.res
-+		${OUT_DIR}/curr/pa_Guru_IN.res
-+		${OUT_DIR}/curr/pa_IN.res
-+		${OUT_DIR}/curr/pa_PK.res
-+		${OUT_DIR}/curr/pcm.res
-+		${OUT_DIR}/curr/pl.res
-+		${OUT_DIR}/curr/pool.res
-+		${OUT_DIR}/curr/ps.res
-+		${OUT_DIR}/curr/ps_PK.res
-+		${OUT_DIR}/curr/pt.res
-+		${OUT_DIR}/curr/pt_AO.res
-+		${OUT_DIR}/curr/pt_CH.res
-+		${OUT_DIR}/curr/pt_CV.res
-+		${OUT_DIR}/curr/pt_GQ.res
-+		${OUT_DIR}/curr/pt_GW.res
-+		${OUT_DIR}/curr/pt_LU.res
-+		${OUT_DIR}/curr/pt_MO.res
-+		${OUT_DIR}/curr/pt_MZ.res
-+		${OUT_DIR}/curr/pt_PT.res
-+		${OUT_DIR}/curr/pt_ST.res
-+		${OUT_DIR}/curr/pt_TL.res
-+		${OUT_DIR}/curr/qu.res
-+		${OUT_DIR}/curr/qu_BO.res
-+		${OUT_DIR}/curr/qu_EC.res
-+		${OUT_DIR}/curr/rm.res
-+		${OUT_DIR}/curr/rn.res
-+		${OUT_DIR}/curr/ro.res
-+		${OUT_DIR}/curr/ro_MD.res
-+		${OUT_DIR}/curr/rof.res
-+		${OUT_DIR}/curr/root.res
-+		${OUT_DIR}/curr/ru.res
-+		${OUT_DIR}/curr/ru_BY.res
-+		${OUT_DIR}/curr/ru_KG.res
-+		${OUT_DIR}/curr/ru_KZ.res
-+		${OUT_DIR}/curr/ru_MD.res
-+		${OUT_DIR}/curr/rw.res
-+		${OUT_DIR}/curr/rwk.res
-+		${OUT_DIR}/curr/sah.res
-+		${OUT_DIR}/curr/saq.res
-+		${OUT_DIR}/curr/sat.res
-+		${OUT_DIR}/curr/sat_IN.res
-+		${OUT_DIR}/curr/sat_Olck.res
-+		${OUT_DIR}/curr/sat_Olck_IN.res
-+		${OUT_DIR}/curr/sbp.res
-+		${OUT_DIR}/curr/sd.res
-+		${OUT_DIR}/curr/sd_Arab.res
-+		${OUT_DIR}/curr/sd_Arab_PK.res
-+		${OUT_DIR}/curr/sd_Deva.res
-+		${OUT_DIR}/curr/sd_PK.res
-+		${OUT_DIR}/curr/se.res
-+		${OUT_DIR}/curr/se_SE.res
-+		${OUT_DIR}/curr/seh.res
-+		${OUT_DIR}/curr/ses.res
-+		${OUT_DIR}/curr/sg.res
-+		${OUT_DIR}/curr/sh.res
-+		${OUT_DIR}/curr/sh_BA.res
-+		${OUT_DIR}/curr/sh_CS.res
-+		${OUT_DIR}/curr/sh_YU.res
-+		${OUT_DIR}/curr/shi.res
-+		${OUT_DIR}/curr/shi_Latn.res
-+		${OUT_DIR}/curr/shi_MA.res
-+		${OUT_DIR}/curr/shi_Tfng.res
-+		${OUT_DIR}/curr/shi_Tfng_MA.res
-+		${OUT_DIR}/curr/si.res
-+		${OUT_DIR}/curr/sk.res
-+		${OUT_DIR}/curr/sl.res
-+		${OUT_DIR}/curr/smn.res
-+		${OUT_DIR}/curr/sn.res
-+		${OUT_DIR}/curr/so.res
-+		${OUT_DIR}/curr/so_DJ.res
-+		${OUT_DIR}/curr/so_ET.res
-+		${OUT_DIR}/curr/so_KE.res
-+		${OUT_DIR}/curr/sq.res
-+		${OUT_DIR}/curr/sq_MK.res
-+		${OUT_DIR}/curr/sr.res
-+		${OUT_DIR}/curr/sr_BA.res
-+		${OUT_DIR}/curr/sr_CS.res
-+		${OUT_DIR}/curr/sr_Cyrl.res
-+		${OUT_DIR}/curr/sr_Cyrl_BA.res
-+		${OUT_DIR}/curr/sr_Cyrl_CS.res
-+		${OUT_DIR}/curr/sr_Cyrl_RS.res
-+		${OUT_DIR}/curr/sr_Cyrl_XK.res
-+		${OUT_DIR}/curr/sr_Cyrl_YU.res
-+		${OUT_DIR}/curr/sr_Latn.res
-+		${OUT_DIR}/curr/sr_Latn_BA.res
-+		${OUT_DIR}/curr/sr_Latn_CS.res
-+		${OUT_DIR}/curr/sr_Latn_ME.res
-+		${OUT_DIR}/curr/sr_Latn_RS.res
-+		${OUT_DIR}/curr/sr_Latn_YU.res
-+		${OUT_DIR}/curr/sr_ME.res
-+		${OUT_DIR}/curr/sr_RS.res
-+		${OUT_DIR}/curr/sr_XK.res
-+		${OUT_DIR}/curr/sr_YU.res
-+		${OUT_DIR}/curr/su.res
-+		${OUT_DIR}/curr/su_ID.res
-+		${OUT_DIR}/curr/su_Latn.res
-+		${OUT_DIR}/curr/su_Latn_ID.res
-+		${OUT_DIR}/curr/supplementalData.res
-+		${OUT_DIR}/curr/sv.res
-+		${OUT_DIR}/curr/sw.res
-+		${OUT_DIR}/curr/sw_CD.res
-+		${OUT_DIR}/curr/sw_KE.res
-+		${OUT_DIR}/curr/sw_UG.res
-+		${OUT_DIR}/curr/ta.res
-+		${OUT_DIR}/curr/ta_LK.res
-+		${OUT_DIR}/curr/ta_MY.res
-+		${OUT_DIR}/curr/ta_SG.res
-+		${OUT_DIR}/curr/te.res
-+		${OUT_DIR}/curr/teo.res
-+		${OUT_DIR}/curr/teo_KE.res
-+		${OUT_DIR}/curr/tg.res
-+		${OUT_DIR}/curr/th.res
-+		${OUT_DIR}/curr/ti.res
-+		${OUT_DIR}/curr/ti_ER.res
-+		${OUT_DIR}/curr/tk.res
-+		${OUT_DIR}/curr/tl.res
-+		${OUT_DIR}/curr/tl_PH.res
-+		${OUT_DIR}/curr/to.res
-+		${OUT_DIR}/curr/tr.res
-+		${OUT_DIR}/curr/tt.res
-+		${OUT_DIR}/curr/twq.res
-+		${OUT_DIR}/curr/tzm.res
-+		${OUT_DIR}/curr/ug.res
-+		${OUT_DIR}/curr/uk.res
-+		${OUT_DIR}/curr/ur.res
-+		${OUT_DIR}/curr/ur_IN.res
-+		${OUT_DIR}/curr/uz.res
-+		${OUT_DIR}/curr/uz_AF.res
-+		${OUT_DIR}/curr/uz_Arab.res
-+		${OUT_DIR}/curr/uz_Arab_AF.res
-+		${OUT_DIR}/curr/uz_Cyrl.res
-+		${OUT_DIR}/curr/uz_Latn.res
-+		${OUT_DIR}/curr/uz_Latn_UZ.res
-+		${OUT_DIR}/curr/uz_UZ.res
-+		${OUT_DIR}/curr/vai.res
-+		${OUT_DIR}/curr/vai_LR.res
-+		${OUT_DIR}/curr/vai_Latn.res
-+		${OUT_DIR}/curr/vai_Vaii.res
-+		${OUT_DIR}/curr/vai_Vaii_LR.res
-+		${OUT_DIR}/curr/vi.res
-+		${OUT_DIR}/curr/vun.res
-+		${OUT_DIR}/curr/wae.res
-+		${OUT_DIR}/curr/wo.res
-+		${OUT_DIR}/curr/xh.res
-+		${OUT_DIR}/curr/xog.res
-+		${OUT_DIR}/curr/yav.res
-+		${OUT_DIR}/curr/yi.res
-+		${OUT_DIR}/curr/yo.res
-+		${OUT_DIR}/curr/yo_BJ.res
-+		${OUT_DIR}/curr/yue.res
-+		${OUT_DIR}/curr/yue_CN.res
-+		${OUT_DIR}/curr/yue_HK.res
-+		${OUT_DIR}/curr/yue_Hans.res
-+		${OUT_DIR}/curr/yue_Hans_CN.res
-+		${OUT_DIR}/curr/yue_Hant.res
-+		${OUT_DIR}/curr/yue_Hant_HK.res
-+		${OUT_DIR}/curr/zgh.res
-+		${OUT_DIR}/curr/zh.res
-+		${OUT_DIR}/curr/zh_CN.res
-+		${OUT_DIR}/curr/zh_HK.res
-+		${OUT_DIR}/curr/zh_Hans.res
-+		${OUT_DIR}/curr/zh_Hans_CN.res
-+		${OUT_DIR}/curr/zh_Hans_HK.res
-+		${OUT_DIR}/curr/zh_Hans_MO.res
-+		${OUT_DIR}/curr/zh_Hans_SG.res
-+		${OUT_DIR}/curr/zh_Hant.res
-+		${OUT_DIR}/curr/zh_Hant_HK.res
-+		${OUT_DIR}/curr/zh_Hant_MO.res
-+		${OUT_DIR}/curr/zh_Hant_TW.res
-+		${OUT_DIR}/curr/zh_MO.res
-+		${OUT_DIR}/curr/zh_SG.res
-+		${OUT_DIR}/curr/zh_TW.res
-+		${OUT_DIR}/curr/zu.res
-+		${OUT_DIR}/currencyNumericCodes.res
-+		${OUT_DIR}/cy.res
-+		${OUT_DIR}/cy_GB.res
-+		${OUT_DIR}/da.res
-+		${OUT_DIR}/da_DK.res
-+		${OUT_DIR}/da_GL.res
-+		${OUT_DIR}/dav.res
-+		${OUT_DIR}/dav_KE.res
-+		${OUT_DIR}/dayPeriods.res
-+		${OUT_DIR}/de.res
-+		${OUT_DIR}/de_AT.res
-+		${OUT_DIR}/de_BE.res
-+		${OUT_DIR}/de_CH.res
-+		${OUT_DIR}/de_DE.res
-+		${OUT_DIR}/de_IT.res
-+		${OUT_DIR}/de_LI.res
-+		${OUT_DIR}/de_LU.res
-+		${OUT_DIR}/dje.res
-+		${OUT_DIR}/dje_NE.res
-+		${OUT_DIR}/dsb.res
-+		${OUT_DIR}/dsb_DE.res
-+		${OUT_DIR}/dua.res
-+		${OUT_DIR}/dua_CM.res
-+		${OUT_DIR}/dyo.res
-+		${OUT_DIR}/dyo_SN.res
-+		${OUT_DIR}/dz.res
-+		${OUT_DIR}/dz_BT.res
-+		${OUT_DIR}/ebcdic-xml-us.cnv
-+		${OUT_DIR}/ebu.res
-+		${OUT_DIR}/ebu_KE.res
-+		${OUT_DIR}/ee.res
-+		${OUT_DIR}/ee_GH.res
-+		${OUT_DIR}/ee_TG.res
-+		${OUT_DIR}/el.res
-+		${OUT_DIR}/el_CY.res
-+		${OUT_DIR}/el_GR.res
-+		${OUT_DIR}/en.res
-+		${OUT_DIR}/en_001.res
-+		${OUT_DIR}/en_150.res
-+		${OUT_DIR}/en_AE.res
-+		${OUT_DIR}/en_AG.res
-+		${OUT_DIR}/en_AI.res
-+		${OUT_DIR}/en_AS.res
-+		${OUT_DIR}/en_AT.res
-+		${OUT_DIR}/en_AU.res
-+		${OUT_DIR}/en_BB.res
-+		${OUT_DIR}/en_BE.res
-+		${OUT_DIR}/en_BI.res
-+		${OUT_DIR}/en_BM.res
-+		${OUT_DIR}/en_BS.res
-+		${OUT_DIR}/en_BW.res
-+		${OUT_DIR}/en_BZ.res
-+		${OUT_DIR}/en_CA.res
-+		${OUT_DIR}/en_CC.res
-+		${OUT_DIR}/en_CH.res
-+		${OUT_DIR}/en_CK.res
-+		${OUT_DIR}/en_CM.res
-+		${OUT_DIR}/en_CX.res
-+		${OUT_DIR}/en_CY.res
-+		${OUT_DIR}/en_DE.res
-+		${OUT_DIR}/en_DG.res
-+		${OUT_DIR}/en_DK.res
-+		${OUT_DIR}/en_DM.res
-+		${OUT_DIR}/en_ER.res
-+		${OUT_DIR}/en_FI.res
-+		${OUT_DIR}/en_FJ.res
-+		${OUT_DIR}/en_FK.res
-+		${OUT_DIR}/en_FM.res
-+		${OUT_DIR}/en_GB.res
-+		${OUT_DIR}/en_GD.res
-+		${OUT_DIR}/en_GG.res
-+		${OUT_DIR}/en_GH.res
-+		${OUT_DIR}/en_GI.res
-+		${OUT_DIR}/en_GM.res
-+		${OUT_DIR}/en_GU.res
-+		${OUT_DIR}/en_GY.res
-+		${OUT_DIR}/en_HK.res
-+		${OUT_DIR}/en_IE.res
-+		${OUT_DIR}/en_IL.res
-+		${OUT_DIR}/en_IM.res
-+		${OUT_DIR}/en_IN.res
-+		${OUT_DIR}/en_IO.res
-+		${OUT_DIR}/en_JE.res
-+		${OUT_DIR}/en_JM.res
-+		${OUT_DIR}/en_KE.res
-+		${OUT_DIR}/en_KI.res
-+		${OUT_DIR}/en_KN.res
-+		${OUT_DIR}/en_KY.res
-+		${OUT_DIR}/en_LC.res
-+		${OUT_DIR}/en_LR.res
-+		${OUT_DIR}/en_LS.res
-+		${OUT_DIR}/en_MG.res
-+		${OUT_DIR}/en_MH.res
-+		${OUT_DIR}/en_MO.res
-+		${OUT_DIR}/en_MP.res
-+		${OUT_DIR}/en_MS.res
-+		${OUT_DIR}/en_MT.res
-+		${OUT_DIR}/en_MU.res
-+		${OUT_DIR}/en_MW.res
-+		${OUT_DIR}/en_MY.res
-+		${OUT_DIR}/en_NA.res
-+		${OUT_DIR}/en_NF.res
-+		${OUT_DIR}/en_NG.res
-+		${OUT_DIR}/en_NH.res
-+		${OUT_DIR}/en_NL.res
-+		${OUT_DIR}/en_NR.res
-+		${OUT_DIR}/en_NU.res
-+		${OUT_DIR}/en_NZ.res
-+		${OUT_DIR}/en_PG.res
-+		${OUT_DIR}/en_PH.res
-+		${OUT_DIR}/en_PK.res
-+		${OUT_DIR}/en_PN.res
-+		${OUT_DIR}/en_PR.res
-+		${OUT_DIR}/en_PW.res
-+		${OUT_DIR}/en_RH.res
-+		${OUT_DIR}/en_RW.res
-+		${OUT_DIR}/en_SB.res
-+		${OUT_DIR}/en_SC.res
-+		${OUT_DIR}/en_SD.res
-+		${OUT_DIR}/en_SE.res
-+		${OUT_DIR}/en_SG.res
-+		${OUT_DIR}/en_SH.res
-+		${OUT_DIR}/en_SI.res
-+		${OUT_DIR}/en_SL.res
-+		${OUT_DIR}/en_SS.res
-+		${OUT_DIR}/en_SX.res
-+		${OUT_DIR}/en_SZ.res
-+		${OUT_DIR}/en_TC.res
-+		${OUT_DIR}/en_TK.res
-+		${OUT_DIR}/en_TO.res
-+		${OUT_DIR}/en_TT.res
-+		${OUT_DIR}/en_TV.res
-+		${OUT_DIR}/en_TZ.res
-+		${OUT_DIR}/en_UG.res
-+		${OUT_DIR}/en_UM.res
-+		${OUT_DIR}/en_US.res
-+		${OUT_DIR}/en_US_POSIX.res
-+		${OUT_DIR}/en_VC.res
-+		${OUT_DIR}/en_VG.res
-+		${OUT_DIR}/en_VI.res
-+		${OUT_DIR}/en_VU.res
-+		${OUT_DIR}/en_WS.res
-+		${OUT_DIR}/en_ZA.res
-+		${OUT_DIR}/en_ZM.res
-+		${OUT_DIR}/en_ZW.res
-+		${OUT_DIR}/eo.res
-+		${OUT_DIR}/eo_001.res
-+		${OUT_DIR}/es.res
-+		${OUT_DIR}/es_419.res
-+		${OUT_DIR}/es_AR.res
-+		${OUT_DIR}/es_BO.res
-+		${OUT_DIR}/es_BR.res
-+		${OUT_DIR}/es_BZ.res
-+		${OUT_DIR}/es_CL.res
-+		${OUT_DIR}/es_CO.res
-+		${OUT_DIR}/es_CR.res
-+		${OUT_DIR}/es_CU.res
-+		${OUT_DIR}/es_DO.res
-+		${OUT_DIR}/es_EA.res
-+		${OUT_DIR}/es_EC.res
-+		${OUT_DIR}/es_ES.res
-+		${OUT_DIR}/es_GQ.res
-+		${OUT_DIR}/es_GT.res
-+		${OUT_DIR}/es_HN.res
-+		${OUT_DIR}/es_IC.res
-+		${OUT_DIR}/es_MX.res
-+		${OUT_DIR}/es_NI.res
-+		${OUT_DIR}/es_PA.res
-+		${OUT_DIR}/es_PE.res
-+		${OUT_DIR}/es_PH.res
-+		${OUT_DIR}/es_PR.res
-+		${OUT_DIR}/es_PY.res
-+		${OUT_DIR}/es_SV.res
-+		${OUT_DIR}/es_US.res
-+		${OUT_DIR}/es_UY.res
-+		${OUT_DIR}/es_VE.res
-+		${OUT_DIR}/et.res
-+		${OUT_DIR}/et_EE.res
-+		${OUT_DIR}/eu.res
-+		${OUT_DIR}/eu_ES.res
-+		${OUT_DIR}/euc-jp-2007.cnv
-+		${OUT_DIR}/euc-tw-2014.cnv
-+		${OUT_DIR}/ewo.res
-+		${OUT_DIR}/ewo_CM.res
-+		${OUT_DIR}/fa.res
-+		${OUT_DIR}/fa_AF.res
-+		${OUT_DIR}/fa_IR.res
-+		${OUT_DIR}/ff.res
-+		${OUT_DIR}/ff_Adlm.res
-+		${OUT_DIR}/ff_Adlm_BF.res
-+		${OUT_DIR}/ff_Adlm_CM.res
-+		${OUT_DIR}/ff_Adlm_GH.res
-+		${OUT_DIR}/ff_Adlm_GM.res
-+		${OUT_DIR}/ff_Adlm_GN.res
-+		${OUT_DIR}/ff_Adlm_GW.res
-+		${OUT_DIR}/ff_Adlm_LR.res
-+		${OUT_DIR}/ff_Adlm_MR.res
-+		${OUT_DIR}/ff_Adlm_NE.res
-+		${OUT_DIR}/ff_Adlm_NG.res
-+		${OUT_DIR}/ff_Adlm_SL.res
-+		${OUT_DIR}/ff_Adlm_SN.res
-+		${OUT_DIR}/ff_CM.res
-+		${OUT_DIR}/ff_GN.res
-+		${OUT_DIR}/ff_Latn.res
-+		${OUT_DIR}/ff_Latn_BF.res
-+		${OUT_DIR}/ff_Latn_CM.res
-+		${OUT_DIR}/ff_Latn_GH.res
-+		${OUT_DIR}/ff_Latn_GM.res
-+		${OUT_DIR}/ff_Latn_GN.res
-+		${OUT_DIR}/ff_Latn_GW.res
-+		${OUT_DIR}/ff_Latn_LR.res
-+		${OUT_DIR}/ff_Latn_MR.res
-+		${OUT_DIR}/ff_Latn_NE.res
-+		${OUT_DIR}/ff_Latn_NG.res
-+		${OUT_DIR}/ff_Latn_SL.res
-+		${OUT_DIR}/ff_Latn_SN.res
-+		${OUT_DIR}/ff_MR.res
-+		${OUT_DIR}/ff_SN.res
-+		${OUT_DIR}/fi.res
-+		${OUT_DIR}/fi_FI.res
-+		${OUT_DIR}/fil.res
-+		${OUT_DIR}/fil_PH.res
-+		${OUT_DIR}/fo.res
-+		${OUT_DIR}/fo_DK.res
-+		${OUT_DIR}/fo_FO.res
-+		${OUT_DIR}/fr.res
-+		${OUT_DIR}/fr_BE.res
-+		${OUT_DIR}/fr_BF.res
-+		${OUT_DIR}/fr_BI.res
-+		${OUT_DIR}/fr_BJ.res
-+		${OUT_DIR}/fr_BL.res
-+		${OUT_DIR}/fr_CA.res
-+		${OUT_DIR}/fr_CD.res
-+		${OUT_DIR}/fr_CF.res
-+		${OUT_DIR}/fr_CG.res
-+		${OUT_DIR}/fr_CH.res
-+		${OUT_DIR}/fr_CI.res
-+		${OUT_DIR}/fr_CM.res
-+		${OUT_DIR}/fr_DJ.res
-+		${OUT_DIR}/fr_DZ.res
-+		${OUT_DIR}/fr_FR.res
-+		${OUT_DIR}/fr_GA.res
-+		${OUT_DIR}/fr_GF.res
-+		${OUT_DIR}/fr_GN.res
-+		${OUT_DIR}/fr_GP.res
-+		${OUT_DIR}/fr_GQ.res
-+		${OUT_DIR}/fr_HT.res
-+		${OUT_DIR}/fr_KM.res
-+		${OUT_DIR}/fr_LU.res
-+		${OUT_DIR}/fr_MA.res
-+		${OUT_DIR}/fr_MC.res
-+		${OUT_DIR}/fr_MF.res
-+		${OUT_DIR}/fr_MG.res
-+		${OUT_DIR}/fr_ML.res
-+		${OUT_DIR}/fr_MQ.res
-+		${OUT_DIR}/fr_MR.res
-+		${OUT_DIR}/fr_MU.res
-+		${OUT_DIR}/fr_NC.res
-+		${OUT_DIR}/fr_NE.res
-+		${OUT_DIR}/fr_PF.res
-+		${OUT_DIR}/fr_PM.res
-+		${OUT_DIR}/fr_RE.res
-+		${OUT_DIR}/fr_RW.res
-+		${OUT_DIR}/fr_SC.res
-+		${OUT_DIR}/fr_SN.res
-+		${OUT_DIR}/fr_SY.res
-+		${OUT_DIR}/fr_TD.res
-+		${OUT_DIR}/fr_TG.res
-+		${OUT_DIR}/fr_TN.res
-+		${OUT_DIR}/fr_VU.res
-+		${OUT_DIR}/fr_WF.res
-+		${OUT_DIR}/fr_YT.res
-+		${OUT_DIR}/fur.res
-+		${OUT_DIR}/fur_IT.res
-+		${OUT_DIR}/fy.res
-+		${OUT_DIR}/fy_NL.res
-+		${OUT_DIR}/ga.res
-+		${OUT_DIR}/ga_GB.res
-+		${OUT_DIR}/ga_IE.res
-+		${OUT_DIR}/gb18030.cnv
-+		${OUT_DIR}/gd.res
-+		${OUT_DIR}/gd_GB.res
-+		${OUT_DIR}/genderList.res
-+		${OUT_DIR}/gl.res
-+		${OUT_DIR}/gl_ES.res
-+		${OUT_DIR}/gsm-03.38-2009.cnv
-+		${OUT_DIR}/gsw.res
-+		${OUT_DIR}/gsw_CH.res
-+		${OUT_DIR}/gsw_FR.res
-+		${OUT_DIR}/gsw_LI.res
-+		${OUT_DIR}/gu.res
-+		${OUT_DIR}/gu_IN.res
-+		${OUT_DIR}/guz.res
-+		${OUT_DIR}/guz_KE.res
-+		${OUT_DIR}/gv.res
-+		${OUT_DIR}/gv_IM.res
-+		${OUT_DIR}/ha.res
-+		${OUT_DIR}/ha_GH.res
-+		${OUT_DIR}/ha_NE.res
-+		${OUT_DIR}/ha_NG.res
-+		${OUT_DIR}/haw.res
-+		${OUT_DIR}/haw_US.res
-+		${OUT_DIR}/he.res
-+		${OUT_DIR}/he_IL.res
-+		${OUT_DIR}/hi.res
-+		${OUT_DIR}/hi_IN.res
-+		${OUT_DIR}/hr.res
-+		${OUT_DIR}/hr_BA.res
-+		${OUT_DIR}/hr_HR.res
-+		${OUT_DIR}/hsb.res
-+		${OUT_DIR}/hsb_DE.res
-+		${OUT_DIR}/hu.res
-+		${OUT_DIR}/hu_HU.res
-+		${OUT_DIR}/hy.res
-+		${OUT_DIR}/hy_AM.res
-+		${OUT_DIR}/ia.res
-+		${OUT_DIR}/ia_001.res
-+		${OUT_DIR}/ibm-1006_P100-1995.cnv
-+		${OUT_DIR}/ibm-1025_P100-1995.cnv
-+		${OUT_DIR}/ibm-1026_P100-1995.cnv
-+		${OUT_DIR}/ibm-1047_P100-1995.cnv
-+		${OUT_DIR}/ibm-1051_P100-1995.cnv
-+		${OUT_DIR}/ibm-1089_P100-1995.cnv
-+		${OUT_DIR}/ibm-1097_P100-1995.cnv
-+		${OUT_DIR}/ibm-1098_P100-1995.cnv
-+		${OUT_DIR}/ibm-1112_P100-1995.cnv
-+		${OUT_DIR}/ibm-1122_P100-1999.cnv
-+		${OUT_DIR}/ibm-1123_P100-1995.cnv
-+		${OUT_DIR}/ibm-1124_P100-1996.cnv
-+		${OUT_DIR}/ibm-1125_P100-1997.cnv
-+		${OUT_DIR}/ibm-1129_P100-1997.cnv
-+		${OUT_DIR}/ibm-1130_P100-1997.cnv
-+		${OUT_DIR}/ibm-1131_P100-1997.cnv
-+		${OUT_DIR}/ibm-1132_P100-1998.cnv
-+		${OUT_DIR}/ibm-1133_P100-1997.cnv
-+		${OUT_DIR}/ibm-1137_P100-1999.cnv
-+		${OUT_DIR}/ibm-1140_P100-1997.cnv
-+		${OUT_DIR}/ibm-1141_P100-1997.cnv
-+		${OUT_DIR}/ibm-1142_P100-1997.cnv
-+		${OUT_DIR}/ibm-1143_P100-1997.cnv
-+		${OUT_DIR}/ibm-1144_P100-1997.cnv
-+		${OUT_DIR}/ibm-1145_P100-1997.cnv
-+		${OUT_DIR}/ibm-1146_P100-1997.cnv
-+		${OUT_DIR}/ibm-1147_P100-1997.cnv
-+		${OUT_DIR}/ibm-1148_P100-1997.cnv
-+		${OUT_DIR}/ibm-1149_P100-1997.cnv
-+		${OUT_DIR}/ibm-1153_P100-1999.cnv
-+		${OUT_DIR}/ibm-1154_P100-1999.cnv
-+		${OUT_DIR}/ibm-1155_P100-1999.cnv
-+		${OUT_DIR}/ibm-1156_P100-1999.cnv
-+		${OUT_DIR}/ibm-1157_P100-1999.cnv
-+		${OUT_DIR}/ibm-1158_P100-1999.cnv
-+		${OUT_DIR}/ibm-1160_P100-1999.cnv
-+		${OUT_DIR}/ibm-1162_P100-1999.cnv
-+		${OUT_DIR}/ibm-1164_P100-1999.cnv
-+		${OUT_DIR}/ibm-1168_P100-2002.cnv
-+		${OUT_DIR}/ibm-1250_P100-1995.cnv
-+		${OUT_DIR}/ibm-1251_P100-1995.cnv
-+		${OUT_DIR}/ibm-1252_P100-2000.cnv
-+		${OUT_DIR}/ibm-1253_P100-1995.cnv
-+		${OUT_DIR}/ibm-1254_P100-1995.cnv
-+		${OUT_DIR}/ibm-1255_P100-1995.cnv
-+		${OUT_DIR}/ibm-1256_P110-1997.cnv
-+		${OUT_DIR}/ibm-1257_P100-1995.cnv
-+		${OUT_DIR}/ibm-1258_P100-1997.cnv
-+		${OUT_DIR}/ibm-12712_P100-1998.cnv
-+		${OUT_DIR}/ibm-1276_P100-1995.cnv
-+		${OUT_DIR}/ibm-1363_P110-1997.cnv
-+		${OUT_DIR}/ibm-1363_P11B-1998.cnv
-+		${OUT_DIR}/ibm-1364_P110-2007.cnv
-+		${OUT_DIR}/ibm-1371_P100-1999.cnv
-+		${OUT_DIR}/ibm-1373_P100-2002.cnv
-+		${OUT_DIR}/ibm-1375_P100-2008.cnv
-+		${OUT_DIR}/ibm-1383_P110-1999.cnv
-+		${OUT_DIR}/ibm-1386_P100-2001.cnv
-+		${OUT_DIR}/ibm-1388_P103-2001.cnv
-+		${OUT_DIR}/ibm-1390_P110-2003.cnv
-+		${OUT_DIR}/ibm-1399_P110-2003.cnv
-+		${OUT_DIR}/ibm-16684_P110-2003.cnv
-+		${OUT_DIR}/ibm-16804_X110-1999.cnv
-+		${OUT_DIR}/ibm-273_P100-1995.cnv
-+		${OUT_DIR}/ibm-277_P100-1995.cnv
-+		${OUT_DIR}/ibm-278_P100-1995.cnv
-+		${OUT_DIR}/ibm-280_P100-1995.cnv
-+		${OUT_DIR}/ibm-284_P100-1995.cnv
-+		${OUT_DIR}/ibm-285_P100-1995.cnv
-+		${OUT_DIR}/ibm-290_P100-1995.cnv
-+		${OUT_DIR}/ibm-297_P100-1995.cnv
-+		${OUT_DIR}/ibm-33722_P120-1999.cnv
-+		${OUT_DIR}/ibm-33722_P12A_P12A-2004_U2.cnv
-+		${OUT_DIR}/ibm-33722_P12A_P12A-2009_U2.cnv
-+		${OUT_DIR}/ibm-37_P100-1995.cnv
-+		${OUT_DIR}/ibm-420_X120-1999.cnv
-+		${OUT_DIR}/ibm-424_P100-1995.cnv
-+		${OUT_DIR}/ibm-437_P100-1995.cnv
-+		${OUT_DIR}/ibm-4517_P100-2005.cnv
-+		${OUT_DIR}/ibm-4899_P100-1998.cnv
-+		${OUT_DIR}/ibm-4909_P100-1999.cnv
-+		${OUT_DIR}/ibm-4971_P100-1999.cnv
-+		${OUT_DIR}/ibm-500_P100-1995.cnv
-+		${OUT_DIR}/ibm-5012_P100-1999.cnv
-+		${OUT_DIR}/ibm-5123_P100-1999.cnv
-+		${OUT_DIR}/ibm-5346_P100-1998.cnv
-+		${OUT_DIR}/ibm-5347_P100-1998.cnv
-+		${OUT_DIR}/ibm-5348_P100-1997.cnv
-+		${OUT_DIR}/ibm-5349_P100-1998.cnv
-+		${OUT_DIR}/ibm-5350_P100-1998.cnv
-+		${OUT_DIR}/ibm-5351_P100-1998.cnv
-+		${OUT_DIR}/ibm-5352_P100-1998.cnv
-+		${OUT_DIR}/ibm-5353_P100-1998.cnv
-+		${OUT_DIR}/ibm-5354_P100-1998.cnv
-+		${OUT_DIR}/ibm-5471_P100-2006.cnv
-+		${OUT_DIR}/ibm-5478_P100-1995.cnv
-+		${OUT_DIR}/ibm-720_P100-1997.cnv
-+		${OUT_DIR}/ibm-737_P100-1997.cnv
-+		${OUT_DIR}/ibm-775_P100-1996.cnv
-+		${OUT_DIR}/ibm-803_P100-1999.cnv
-+		${OUT_DIR}/ibm-813_P100-1995.cnv
-+		${OUT_DIR}/ibm-838_P100-1995.cnv
-+		${OUT_DIR}/ibm-8482_P100-1999.cnv
-+		${OUT_DIR}/ibm-850_P100-1995.cnv
-+		${OUT_DIR}/ibm-851_P100-1995.cnv
-+		${OUT_DIR}/ibm-852_P100-1995.cnv
-+		${OUT_DIR}/ibm-855_P100-1995.cnv
-+		${OUT_DIR}/ibm-856_P100-1995.cnv
-+		${OUT_DIR}/ibm-857_P100-1995.cnv
-+		${OUT_DIR}/ibm-858_P100-1997.cnv
-+		${OUT_DIR}/ibm-860_P100-1995.cnv
-+		${OUT_DIR}/ibm-861_P100-1995.cnv
-+		${OUT_DIR}/ibm-862_P100-1995.cnv
-+		${OUT_DIR}/ibm-863_P100-1995.cnv
-+		${OUT_DIR}/ibm-864_X110-1999.cnv
-+		${OUT_DIR}/ibm-865_P100-1995.cnv
-+		${OUT_DIR}/ibm-866_P100-1995.cnv
-+		${OUT_DIR}/ibm-867_P100-1998.cnv
-+		${OUT_DIR}/ibm-868_P100-1995.cnv
-+		${OUT_DIR}/ibm-869_P100-1995.cnv
-+		${OUT_DIR}/ibm-870_P100-1995.cnv
-+		${OUT_DIR}/ibm-871_P100-1995.cnv
-+		${OUT_DIR}/ibm-874_P100-1995.cnv
-+		${OUT_DIR}/ibm-875_P100-1995.cnv
-+		${OUT_DIR}/ibm-878_P100-1996.cnv
-+		${OUT_DIR}/ibm-9005_X110-2007.cnv
-+		${OUT_DIR}/ibm-901_P100-1999.cnv
-+		${OUT_DIR}/ibm-902_P100-1999.cnv
-+		${OUT_DIR}/ibm-9067_X100-2005.cnv
-+		${OUT_DIR}/ibm-912_P100-1995.cnv
-+		${OUT_DIR}/ibm-913_P100-2000.cnv
-+		${OUT_DIR}/ibm-914_P100-1995.cnv
-+		${OUT_DIR}/ibm-915_P100-1995.cnv
-+		${OUT_DIR}/ibm-916_P100-1995.cnv
-+		${OUT_DIR}/ibm-918_P100-1995.cnv
-+		${OUT_DIR}/ibm-920_P100-1995.cnv
-+		${OUT_DIR}/ibm-921_P100-1995.cnv
-+		${OUT_DIR}/ibm-922_P100-1999.cnv
-+		${OUT_DIR}/ibm-923_P100-1998.cnv
-+		${OUT_DIR}/ibm-930_P120-1999.cnv
-+		${OUT_DIR}/ibm-933_P110-1995.cnv
-+		${OUT_DIR}/ibm-935_P110-1999.cnv
-+		${OUT_DIR}/ibm-937_P110-1999.cnv
-+		${OUT_DIR}/ibm-939_P120-1999.cnv
-+		${OUT_DIR}/ibm-942_P12A-1999.cnv
-+		${OUT_DIR}/ibm-943_P130-1999.cnv
-+		${OUT_DIR}/ibm-943_P15A-2003.cnv
-+		${OUT_DIR}/ibm-9447_P100-2002.cnv
-+		${OUT_DIR}/ibm-9448_X100-2005.cnv
-+		${OUT_DIR}/ibm-9449_P100-2002.cnv
-+		${OUT_DIR}/ibm-949_P110-1999.cnv
-+		${OUT_DIR}/ibm-949_P11A-1999.cnv
-+		${OUT_DIR}/ibm-950_P110-1999.cnv
-+		${OUT_DIR}/ibm-954_P101-2007.cnv
-+		${OUT_DIR}/ibm-964_P110-1999.cnv
-+		${OUT_DIR}/ibm-970_P110_P110-2006_U2.cnv
-+		${OUT_DIR}/ibm-971_P100-1995.cnv
-+		${OUT_DIR}/icu-internal-25546.cnv
-+		${OUT_DIR}/icu-internal-compound-d1.cnv
-+		${OUT_DIR}/icu-internal-compound-d2.cnv
-+		${OUT_DIR}/icu-internal-compound-d3.cnv
-+		${OUT_DIR}/icu-internal-compound-d4.cnv
-+		${OUT_DIR}/icu-internal-compound-d5.cnv
-+		${OUT_DIR}/icu-internal-compound-d6.cnv
-+		${OUT_DIR}/icu-internal-compound-d7.cnv
-+		${OUT_DIR}/icu-internal-compound-s1.cnv
-+		${OUT_DIR}/icu-internal-compound-s2.cnv
-+		${OUT_DIR}/icu-internal-compound-s3.cnv
-+		${OUT_DIR}/icu-internal-compound-t.cnv
-+		${OUT_DIR}/icustd.res
-+		${OUT_DIR}/icuver.res
-+		${OUT_DIR}/id.res
-+		${OUT_DIR}/id_ID.res
-+		${OUT_DIR}/ig.res
-+		${OUT_DIR}/ig_NG.res
-+		${OUT_DIR}/ii.res
-+		${OUT_DIR}/ii_CN.res
-+		${OUT_DIR}/in.res
-+		${OUT_DIR}/in_ID.res
-+		${OUT_DIR}/is.res
-+		${OUT_DIR}/is_IS.res
-+		${OUT_DIR}/iso-8859_10-1998.cnv
-+		${OUT_DIR}/iso-8859_11-2001.cnv
-+		${OUT_DIR}/iso-8859_14-1998.cnv
-+		${OUT_DIR}/iso-ir-165.cnv
-+		${OUT_DIR}/it.res
-+		${OUT_DIR}/it_CH.res
-+		${OUT_DIR}/it_IT.res
-+		${OUT_DIR}/it_SM.res
-+		${OUT_DIR}/it_VA.res
-+		${OUT_DIR}/iw.res
-+		${OUT_DIR}/iw_IL.res
-+		${OUT_DIR}/ja.res
-+		${OUT_DIR}/ja_JP.res
-+		${OUT_DIR}/ja_JP_TRADITIONAL.res
-+		${OUT_DIR}/jgo.res
-+		${OUT_DIR}/jgo_CM.res
-+		${OUT_DIR}/jisx-212.cnv
-+		${OUT_DIR}/jmc.res
-+		${OUT_DIR}/jmc_TZ.res
-+		${OUT_DIR}/jv.res
-+		${OUT_DIR}/jv_ID.res
-+		${OUT_DIR}/ka.res
-+		${OUT_DIR}/ka_GE.res
-+		${OUT_DIR}/kab.res
-+		${OUT_DIR}/kab_DZ.res
-+		${OUT_DIR}/kam.res
-+		${OUT_DIR}/kam_KE.res
-+		${OUT_DIR}/kde.res
-+		${OUT_DIR}/kde_TZ.res
-+		${OUT_DIR}/kea.res
-+		${OUT_DIR}/kea_CV.res
-+		${OUT_DIR}/keyTypeData.res
-+		${OUT_DIR}/khq.res
-+		${OUT_DIR}/khq_ML.res
-+		${OUT_DIR}/ki.res
-+		${OUT_DIR}/ki_KE.res
-+		${OUT_DIR}/kk.res
-+		${OUT_DIR}/kk_KZ.res
-+		${OUT_DIR}/kkj.res
-+		${OUT_DIR}/kkj_CM.res
-+		${OUT_DIR}/kl.res
-+		${OUT_DIR}/kl_GL.res
-+		${OUT_DIR}/kln.res
-+		${OUT_DIR}/kln_KE.res
-+		${OUT_DIR}/km.res
-+		${OUT_DIR}/km_KH.res
-+		${OUT_DIR}/kn.res
-+		${OUT_DIR}/kn_IN.res
-+		${OUT_DIR}/ko.res
-+		${OUT_DIR}/ko_KP.res
-+		${OUT_DIR}/ko_KR.res
-+		${OUT_DIR}/kok.res
-+		${OUT_DIR}/kok_IN.res
-+		${OUT_DIR}/ks.res
-+		${OUT_DIR}/ks_Arab.res
-+		${OUT_DIR}/ks_Arab_IN.res
-+		${OUT_DIR}/ks_IN.res
-+		${OUT_DIR}/ksb.res
-+		${OUT_DIR}/ksb_TZ.res
-+		${OUT_DIR}/ksf.res
-+		${OUT_DIR}/ksf_CM.res
-+		${OUT_DIR}/ksh.res
-+		${OUT_DIR}/ksh_DE.res
-+		${OUT_DIR}/ku.res
-+		${OUT_DIR}/ku_TR.res
-+		${OUT_DIR}/kw.res
-+		${OUT_DIR}/kw_GB.res
-+		${OUT_DIR}/ky.res
-+		${OUT_DIR}/ky_KG.res
-+		${OUT_DIR}/lag.res
-+		${OUT_DIR}/lag_TZ.res
-+		${OUT_DIR}/lang/${INDEX_NAME}.res
-+		${OUT_DIR}/lang/af.res
-+		${OUT_DIR}/lang/agq.res
-+		${OUT_DIR}/lang/ak.res
-+		${OUT_DIR}/lang/am.res
-+		${OUT_DIR}/lang/ar.res
-+		${OUT_DIR}/lang/ar_EG.res
-+		${OUT_DIR}/lang/ar_LY.res
-+		${OUT_DIR}/lang/ar_SA.res
-+		${OUT_DIR}/lang/ars.res
-+		${OUT_DIR}/lang/as.res
-+		${OUT_DIR}/lang/asa.res
-+		${OUT_DIR}/lang/ast.res
-+		${OUT_DIR}/lang/az.res
-+		${OUT_DIR}/lang/az_AZ.res
-+		${OUT_DIR}/lang/az_Cyrl.res
-+		${OUT_DIR}/lang/az_Latn.res
-+		${OUT_DIR}/lang/az_Latn_AZ.res
-+		${OUT_DIR}/lang/bas.res
-+		${OUT_DIR}/lang/be.res
-+		${OUT_DIR}/lang/bem.res
-+		${OUT_DIR}/lang/bez.res
-+		${OUT_DIR}/lang/bg.res
-+		${OUT_DIR}/lang/bm.res
-+		${OUT_DIR}/lang/bn.res
-+		${OUT_DIR}/lang/bn_IN.res
-+		${OUT_DIR}/lang/bo.res
-+		${OUT_DIR}/lang/br.res
-+		${OUT_DIR}/lang/brx.res
-+		${OUT_DIR}/lang/bs.res
-+		${OUT_DIR}/lang/bs_BA.res
-+		${OUT_DIR}/lang/bs_Cyrl.res
-+		${OUT_DIR}/lang/bs_Latn.res
-+		${OUT_DIR}/lang/bs_Latn_BA.res
-+		${OUT_DIR}/lang/ca.res
-+		${OUT_DIR}/lang/ccp.res
-+		${OUT_DIR}/lang/ce.res
-+		${OUT_DIR}/lang/ceb.res
-+		${OUT_DIR}/lang/cgg.res
-+		${OUT_DIR}/lang/chr.res
-+		${OUT_DIR}/lang/ckb.res
-+		${OUT_DIR}/lang/cs.res
-+		${OUT_DIR}/lang/cy.res
-+		${OUT_DIR}/lang/da.res
-+		${OUT_DIR}/lang/dav.res
-+		${OUT_DIR}/lang/de.res
-+		${OUT_DIR}/lang/de_AT.res
-+		${OUT_DIR}/lang/de_CH.res
-+		${OUT_DIR}/lang/de_LU.res
-+		${OUT_DIR}/lang/dje.res
-+		${OUT_DIR}/lang/dsb.res
-+		${OUT_DIR}/lang/dua.res
-+		${OUT_DIR}/lang/dyo.res
-+		${OUT_DIR}/lang/dz.res
-+		${OUT_DIR}/lang/ebu.res
-+		${OUT_DIR}/lang/ee.res
-+		${OUT_DIR}/lang/el.res
-+		${OUT_DIR}/lang/en.res
-+		${OUT_DIR}/lang/en_001.res
-+		${OUT_DIR}/lang/en_150.res
-+		${OUT_DIR}/lang/en_AG.res
-+		${OUT_DIR}/lang/en_AI.res
-+		${OUT_DIR}/lang/en_AT.res
-+		${OUT_DIR}/lang/en_AU.res
-+		${OUT_DIR}/lang/en_BB.res
-+		${OUT_DIR}/lang/en_BE.res
-+		${OUT_DIR}/lang/en_BM.res
-+		${OUT_DIR}/lang/en_BS.res
-+		${OUT_DIR}/lang/en_BW.res
-+		${OUT_DIR}/lang/en_BZ.res
-+		${OUT_DIR}/lang/en_CA.res
-+		${OUT_DIR}/lang/en_CC.res
-+		${OUT_DIR}/lang/en_CH.res
-+		${OUT_DIR}/lang/en_CK.res
-+		${OUT_DIR}/lang/en_CM.res
-+		${OUT_DIR}/lang/en_CX.res
-+		${OUT_DIR}/lang/en_CY.res
-+		${OUT_DIR}/lang/en_DE.res
-+		${OUT_DIR}/lang/en_DG.res
-+		${OUT_DIR}/lang/en_DK.res
-+		${OUT_DIR}/lang/en_DM.res
-+		${OUT_DIR}/lang/en_ER.res
-+		${OUT_DIR}/lang/en_FI.res
-+		${OUT_DIR}/lang/en_FJ.res
-+		${OUT_DIR}/lang/en_FK.res
-+		${OUT_DIR}/lang/en_FM.res
-+		${OUT_DIR}/lang/en_GB.res
-+		${OUT_DIR}/lang/en_GD.res
-+		${OUT_DIR}/lang/en_GG.res
-+		${OUT_DIR}/lang/en_GH.res
-+		${OUT_DIR}/lang/en_GI.res
-+		${OUT_DIR}/lang/en_GM.res
-+		${OUT_DIR}/lang/en_GY.res
-+		${OUT_DIR}/lang/en_HK.res
-+		${OUT_DIR}/lang/en_IE.res
-+		${OUT_DIR}/lang/en_IL.res
-+		${OUT_DIR}/lang/en_IM.res
-+		${OUT_DIR}/lang/en_IN.res
-+		${OUT_DIR}/lang/en_IO.res
-+		${OUT_DIR}/lang/en_JE.res
-+		${OUT_DIR}/lang/en_JM.res
-+		${OUT_DIR}/lang/en_KE.res
-+		${OUT_DIR}/lang/en_KI.res
-+		${OUT_DIR}/lang/en_KN.res
-+		${OUT_DIR}/lang/en_KY.res
-+		${OUT_DIR}/lang/en_LC.res
-+		${OUT_DIR}/lang/en_LR.res
-+		${OUT_DIR}/lang/en_LS.res
-+		${OUT_DIR}/lang/en_MG.res
-+		${OUT_DIR}/lang/en_MO.res
-+		${OUT_DIR}/lang/en_MS.res
-+		${OUT_DIR}/lang/en_MT.res
-+		${OUT_DIR}/lang/en_MU.res
-+		${OUT_DIR}/lang/en_MW.res
-+		${OUT_DIR}/lang/en_MY.res
-+		${OUT_DIR}/lang/en_NA.res
-+		${OUT_DIR}/lang/en_NF.res
-+		${OUT_DIR}/lang/en_NG.res
-+		${OUT_DIR}/lang/en_NH.res
-+		${OUT_DIR}/lang/en_NL.res
-+		${OUT_DIR}/lang/en_NR.res
-+		${OUT_DIR}/lang/en_NU.res
-+		${OUT_DIR}/lang/en_NZ.res
-+		${OUT_DIR}/lang/en_PG.res
-+		${OUT_DIR}/lang/en_PH.res
-+		${OUT_DIR}/lang/en_PK.res
-+		${OUT_DIR}/lang/en_PN.res
-+		${OUT_DIR}/lang/en_PW.res
-+		${OUT_DIR}/lang/en_RH.res
-+		${OUT_DIR}/lang/en_RW.res
-+		${OUT_DIR}/lang/en_SB.res
-+		${OUT_DIR}/lang/en_SC.res
-+		${OUT_DIR}/lang/en_SD.res
-+		${OUT_DIR}/lang/en_SE.res
-+		${OUT_DIR}/lang/en_SG.res
-+		${OUT_DIR}/lang/en_SH.res
-+		${OUT_DIR}/lang/en_SI.res
-+		${OUT_DIR}/lang/en_SL.res
-+		${OUT_DIR}/lang/en_SS.res
-+		${OUT_DIR}/lang/en_SX.res
-+		${OUT_DIR}/lang/en_SZ.res
-+		${OUT_DIR}/lang/en_TC.res
-+		${OUT_DIR}/lang/en_TK.res
-+		${OUT_DIR}/lang/en_TO.res
-+		${OUT_DIR}/lang/en_TT.res
-+		${OUT_DIR}/lang/en_TV.res
-+		${OUT_DIR}/lang/en_TZ.res
-+		${OUT_DIR}/lang/en_UG.res
-+		${OUT_DIR}/lang/en_VC.res
-+		${OUT_DIR}/lang/en_VG.res
-+		${OUT_DIR}/lang/en_VU.res
-+		${OUT_DIR}/lang/en_WS.res
-+		${OUT_DIR}/lang/en_ZA.res
-+		${OUT_DIR}/lang/en_ZM.res
-+		${OUT_DIR}/lang/en_ZW.res
-+		${OUT_DIR}/lang/eo.res
-+		${OUT_DIR}/lang/es.res
-+		${OUT_DIR}/lang/es_419.res
-+		${OUT_DIR}/lang/es_AR.res
-+		${OUT_DIR}/lang/es_BO.res
-+		${OUT_DIR}/lang/es_BR.res
-+		${OUT_DIR}/lang/es_BZ.res
-+		${OUT_DIR}/lang/es_CL.res
-+		${OUT_DIR}/lang/es_CO.res
-+		${OUT_DIR}/lang/es_CR.res
-+		${OUT_DIR}/lang/es_CU.res
-+		${OUT_DIR}/lang/es_DO.res
-+		${OUT_DIR}/lang/es_EC.res
-+		${OUT_DIR}/lang/es_GT.res
-+		${OUT_DIR}/lang/es_HN.res
-+		${OUT_DIR}/lang/es_MX.res
-+		${OUT_DIR}/lang/es_NI.res
-+		${OUT_DIR}/lang/es_PA.res
-+		${OUT_DIR}/lang/es_PE.res
-+		${OUT_DIR}/lang/es_PR.res
-+		${OUT_DIR}/lang/es_PY.res
-+		${OUT_DIR}/lang/es_SV.res
-+		${OUT_DIR}/lang/es_US.res
-+		${OUT_DIR}/lang/es_UY.res
-+		${OUT_DIR}/lang/es_VE.res
-+		${OUT_DIR}/lang/et.res
-+		${OUT_DIR}/lang/eu.res
-+		${OUT_DIR}/lang/ewo.res
-+		${OUT_DIR}/lang/fa.res
-+		${OUT_DIR}/lang/fa_AF.res
-+		${OUT_DIR}/lang/ff.res
-+		${OUT_DIR}/lang/ff_Adlm.res
-+		${OUT_DIR}/lang/ff_CM.res
-+		${OUT_DIR}/lang/ff_GN.res
-+		${OUT_DIR}/lang/ff_Latn.res
-+		${OUT_DIR}/lang/ff_Latn_CM.res
-+		${OUT_DIR}/lang/ff_Latn_GN.res
-+		${OUT_DIR}/lang/ff_Latn_MR.res
-+		${OUT_DIR}/lang/ff_Latn_SN.res
-+		${OUT_DIR}/lang/ff_MR.res
-+		${OUT_DIR}/lang/ff_SN.res
-+		${OUT_DIR}/lang/fi.res
-+		${OUT_DIR}/lang/fil.res
-+		${OUT_DIR}/lang/fil_PH.res
-+		${OUT_DIR}/lang/fo.res
-+		${OUT_DIR}/lang/fr.res
-+		${OUT_DIR}/lang/fr_BE.res
-+		${OUT_DIR}/lang/fr_CA.res
-+		${OUT_DIR}/lang/fr_CH.res
-+		${OUT_DIR}/lang/fur.res
-+		${OUT_DIR}/lang/fy.res
-+		${OUT_DIR}/lang/ga.res
-+		${OUT_DIR}/lang/gd.res
-+		${OUT_DIR}/lang/gl.res
-+		${OUT_DIR}/lang/gsw.res
-+		${OUT_DIR}/lang/gu.res
-+		${OUT_DIR}/lang/guz.res
-+		${OUT_DIR}/lang/gv.res
-+		${OUT_DIR}/lang/ha.res
-+		${OUT_DIR}/lang/ha_NE.res
-+		${OUT_DIR}/lang/haw.res
-+		${OUT_DIR}/lang/he.res
-+		${OUT_DIR}/lang/he_IL.res
-+		${OUT_DIR}/lang/hi.res
-+		${OUT_DIR}/lang/hr.res
-+		${OUT_DIR}/lang/hsb.res
-+		${OUT_DIR}/lang/hu.res
-+		${OUT_DIR}/lang/hy.res
-+		${OUT_DIR}/lang/ia.res
-+		${OUT_DIR}/lang/id.res
-+		${OUT_DIR}/lang/id_ID.res
-+		${OUT_DIR}/lang/ig.res
-+		${OUT_DIR}/lang/ii.res
-+		${OUT_DIR}/lang/in.res
-+		${OUT_DIR}/lang/in_ID.res
-+		${OUT_DIR}/lang/is.res
-+		${OUT_DIR}/lang/it.res
-+		${OUT_DIR}/lang/iw.res
-+		${OUT_DIR}/lang/iw_IL.res
-+		${OUT_DIR}/lang/ja.res
-+		${OUT_DIR}/lang/jgo.res
-+		${OUT_DIR}/lang/jmc.res
-+		${OUT_DIR}/lang/jv.res
-+		${OUT_DIR}/lang/ka.res
-+		${OUT_DIR}/lang/kab.res
-+		${OUT_DIR}/lang/kam.res
-+		${OUT_DIR}/lang/kde.res
-+		${OUT_DIR}/lang/kea.res
-+		${OUT_DIR}/lang/khq.res
-+		${OUT_DIR}/lang/ki.res
-+		${OUT_DIR}/lang/kk.res
-+		${OUT_DIR}/lang/kkj.res
-+		${OUT_DIR}/lang/kl.res
-+		${OUT_DIR}/lang/kln.res
-+		${OUT_DIR}/lang/km.res
-+		${OUT_DIR}/lang/kn.res
-+		${OUT_DIR}/lang/ko.res
-+		${OUT_DIR}/lang/kok.res
-+		${OUT_DIR}/lang/ks.res
-+		${OUT_DIR}/lang/ks_Arab.res
-+		${OUT_DIR}/lang/ks_Arab_IN.res
-+		${OUT_DIR}/lang/ks_IN.res
-+		${OUT_DIR}/lang/ksb.res
-+		${OUT_DIR}/lang/ksf.res
-+		${OUT_DIR}/lang/ksh.res
-+		${OUT_DIR}/lang/ku.res
-+		${OUT_DIR}/lang/kw.res
-+		${OUT_DIR}/lang/ky.res
-+		${OUT_DIR}/lang/lag.res
-+		${OUT_DIR}/lang/lb.res
-+		${OUT_DIR}/lang/lg.res
-+		${OUT_DIR}/lang/lkt.res
-+		${OUT_DIR}/lang/ln.res
-+		${OUT_DIR}/lang/lo.res
-+		${OUT_DIR}/lang/lrc.res
-+		${OUT_DIR}/lang/lt.res
-+		${OUT_DIR}/lang/lu.res
-+		${OUT_DIR}/lang/luo.res
-+		${OUT_DIR}/lang/luy.res
-+		${OUT_DIR}/lang/lv.res
-+		${OUT_DIR}/lang/mai.res
-+		${OUT_DIR}/lang/mas.res
-+		${OUT_DIR}/lang/mer.res
-+		${OUT_DIR}/lang/mfe.res
-+		${OUT_DIR}/lang/mg.res
-+		${OUT_DIR}/lang/mgh.res
-+		${OUT_DIR}/lang/mgo.res
-+		${OUT_DIR}/lang/mi.res
-+		${OUT_DIR}/lang/mk.res
-+		${OUT_DIR}/lang/ml.res
-+		${OUT_DIR}/lang/mn.res
-+		${OUT_DIR}/lang/mni.res
-+		${OUT_DIR}/lang/mni_Beng.res
-+		${OUT_DIR}/lang/mni_Beng_IN.res
-+		${OUT_DIR}/lang/mni_IN.res
-+		${OUT_DIR}/lang/mo.res
-+		${OUT_DIR}/lang/mr.res
-+		${OUT_DIR}/lang/ms.res
-+		${OUT_DIR}/lang/mt.res
-+		${OUT_DIR}/lang/mua.res
-+		${OUT_DIR}/lang/my.res
-+		${OUT_DIR}/lang/mzn.res
-+		${OUT_DIR}/lang/naq.res
-+		${OUT_DIR}/lang/nb.res
-+		${OUT_DIR}/lang/nb_NO.res
-+		${OUT_DIR}/lang/nd.res
-+		${OUT_DIR}/lang/nds.res
-+		${OUT_DIR}/lang/ne.res
-+		${OUT_DIR}/lang/nl.res
-+		${OUT_DIR}/lang/nmg.res
-+		${OUT_DIR}/lang/nn.res
-+		${OUT_DIR}/lang/nn_NO.res
-+		${OUT_DIR}/lang/nnh.res
-+		${OUT_DIR}/lang/no.res
-+		${OUT_DIR}/lang/no_NO.res
-+		${OUT_DIR}/lang/no_NO_NY.res
-+		${OUT_DIR}/lang/nus.res
-+		${OUT_DIR}/lang/nyn.res
-+		${OUT_DIR}/lang/om.res
-+		${OUT_DIR}/lang/or.res
-+		${OUT_DIR}/lang/os.res
-+		${OUT_DIR}/lang/pa.res
-+		${OUT_DIR}/lang/pa_Arab.res
-+		${OUT_DIR}/lang/pa_Arab_PK.res
-+		${OUT_DIR}/lang/pa_Guru.res
-+		${OUT_DIR}/lang/pa_Guru_IN.res
-+		${OUT_DIR}/lang/pa_IN.res
-+		${OUT_DIR}/lang/pa_PK.res
-+		${OUT_DIR}/lang/pcm.res
-+		${OUT_DIR}/lang/pl.res
-+		${OUT_DIR}/lang/pool.res
-+		${OUT_DIR}/lang/ps.res
-+		${OUT_DIR}/lang/ps_PK.res
-+		${OUT_DIR}/lang/pt.res
-+		${OUT_DIR}/lang/pt_AO.res
-+		${OUT_DIR}/lang/pt_CH.res
-+		${OUT_DIR}/lang/pt_CV.res
-+		${OUT_DIR}/lang/pt_GQ.res
-+		${OUT_DIR}/lang/pt_GW.res
-+		${OUT_DIR}/lang/pt_LU.res
-+		${OUT_DIR}/lang/pt_MO.res
-+		${OUT_DIR}/lang/pt_MZ.res
-+		${OUT_DIR}/lang/pt_PT.res
-+		${OUT_DIR}/lang/pt_ST.res
-+		${OUT_DIR}/lang/pt_TL.res
-+		${OUT_DIR}/lang/qu.res
-+		${OUT_DIR}/lang/rm.res
-+		${OUT_DIR}/lang/rn.res
-+		${OUT_DIR}/lang/ro.res
-+		${OUT_DIR}/lang/ro_MD.res
-+		${OUT_DIR}/lang/rof.res
-+		${OUT_DIR}/lang/root.res
-+		${OUT_DIR}/lang/ru.res
-+		${OUT_DIR}/lang/rw.res
-+		${OUT_DIR}/lang/rwk.res
-+		${OUT_DIR}/lang/sah.res
-+		${OUT_DIR}/lang/saq.res
-+		${OUT_DIR}/lang/sat.res
-+		${OUT_DIR}/lang/sat_IN.res
-+		${OUT_DIR}/lang/sat_Olck.res
-+		${OUT_DIR}/lang/sat_Olck_IN.res
-+		${OUT_DIR}/lang/sbp.res
-+		${OUT_DIR}/lang/sd.res
-+		${OUT_DIR}/lang/sd_Arab.res
-+		${OUT_DIR}/lang/sd_Arab_PK.res
-+		${OUT_DIR}/lang/sd_Deva.res
-+		${OUT_DIR}/lang/sd_PK.res
-+		${OUT_DIR}/lang/se.res
-+		${OUT_DIR}/lang/se_FI.res
-+		${OUT_DIR}/lang/seh.res
-+		${OUT_DIR}/lang/ses.res
-+		${OUT_DIR}/lang/sg.res
-+		${OUT_DIR}/lang/sh.res
-+		${OUT_DIR}/lang/sh_BA.res
-+		${OUT_DIR}/lang/sh_CS.res
-+		${OUT_DIR}/lang/sh_YU.res
-+		${OUT_DIR}/lang/shi.res
-+		${OUT_DIR}/lang/shi_Latn.res
-+		${OUT_DIR}/lang/shi_MA.res
-+		${OUT_DIR}/lang/shi_Tfng.res
-+		${OUT_DIR}/lang/shi_Tfng_MA.res
-+		${OUT_DIR}/lang/si.res
-+		${OUT_DIR}/lang/sk.res
-+		${OUT_DIR}/lang/sl.res
-+		${OUT_DIR}/lang/smn.res
-+		${OUT_DIR}/lang/sn.res
-+		${OUT_DIR}/lang/so.res
-+		${OUT_DIR}/lang/sq.res
-+		${OUT_DIR}/lang/sr.res
-+		${OUT_DIR}/lang/sr_BA.res
-+		${OUT_DIR}/lang/sr_CS.res
-+		${OUT_DIR}/lang/sr_Cyrl.res
-+		${OUT_DIR}/lang/sr_Cyrl_BA.res
-+		${OUT_DIR}/lang/sr_Cyrl_CS.res
-+		${OUT_DIR}/lang/sr_Cyrl_ME.res
-+		${OUT_DIR}/lang/sr_Cyrl_RS.res
-+		${OUT_DIR}/lang/sr_Cyrl_XK.res
-+		${OUT_DIR}/lang/sr_Cyrl_YU.res
-+		${OUT_DIR}/lang/sr_Latn.res
-+		${OUT_DIR}/lang/sr_Latn_BA.res
-+		${OUT_DIR}/lang/sr_Latn_CS.res
-+		${OUT_DIR}/lang/sr_Latn_ME.res
-+		${OUT_DIR}/lang/sr_Latn_RS.res
-+		${OUT_DIR}/lang/sr_Latn_XK.res
-+		${OUT_DIR}/lang/sr_Latn_YU.res
-+		${OUT_DIR}/lang/sr_ME.res
-+		${OUT_DIR}/lang/sr_RS.res
-+		${OUT_DIR}/lang/sr_XK.res
-+		${OUT_DIR}/lang/sr_YU.res
-+		${OUT_DIR}/lang/su.res
-+		${OUT_DIR}/lang/su_ID.res
-+		${OUT_DIR}/lang/su_Latn.res
-+		${OUT_DIR}/lang/su_Latn_ID.res
-+		${OUT_DIR}/lang/sv.res
-+		${OUT_DIR}/lang/sv_FI.res
-+		${OUT_DIR}/lang/sw.res
-+		${OUT_DIR}/lang/sw_CD.res
-+		${OUT_DIR}/lang/sw_KE.res
-+		${OUT_DIR}/lang/ta.res
-+		${OUT_DIR}/lang/te.res
-+		${OUT_DIR}/lang/teo.res
-+		${OUT_DIR}/lang/tg.res
-+		${OUT_DIR}/lang/th.res
-+		${OUT_DIR}/lang/ti.res
-+		${OUT_DIR}/lang/tk.res
-+		${OUT_DIR}/lang/tl.res
-+		${OUT_DIR}/lang/tl_PH.res
-+		${OUT_DIR}/lang/to.res
-+		${OUT_DIR}/lang/tr.res
-+		${OUT_DIR}/lang/tt.res
-+		${OUT_DIR}/lang/twq.res
-+		${OUT_DIR}/lang/tzm.res
-+		${OUT_DIR}/lang/ug.res
-+		${OUT_DIR}/lang/uk.res
-+		${OUT_DIR}/lang/ur.res
-+		${OUT_DIR}/lang/ur_IN.res
-+		${OUT_DIR}/lang/uz.res
-+		${OUT_DIR}/lang/uz_AF.res
-+		${OUT_DIR}/lang/uz_Arab.res
-+		${OUT_DIR}/lang/uz_Arab_AF.res
-+		${OUT_DIR}/lang/uz_Cyrl.res
-+		${OUT_DIR}/lang/uz_Latn.res
-+		${OUT_DIR}/lang/uz_Latn_UZ.res
-+		${OUT_DIR}/lang/uz_UZ.res
-+		${OUT_DIR}/lang/vai.res
-+		${OUT_DIR}/lang/vai_LR.res
-+		${OUT_DIR}/lang/vai_Latn.res
-+		${OUT_DIR}/lang/vai_Vaii.res
-+		${OUT_DIR}/lang/vai_Vaii_LR.res
-+		${OUT_DIR}/lang/vi.res
-+		${OUT_DIR}/lang/vun.res
-+		${OUT_DIR}/lang/wae.res
-+		${OUT_DIR}/lang/wo.res
-+		${OUT_DIR}/lang/xh.res
-+		${OUT_DIR}/lang/xog.res
-+		${OUT_DIR}/lang/yav.res
-+		${OUT_DIR}/lang/yi.res
-+		${OUT_DIR}/lang/yo.res
-+		${OUT_DIR}/lang/yo_BJ.res
-+		${OUT_DIR}/lang/yue.res
-+		${OUT_DIR}/lang/yue_CN.res
-+		${OUT_DIR}/lang/yue_HK.res
-+		${OUT_DIR}/lang/yue_Hans.res
-+		${OUT_DIR}/lang/yue_Hans_CN.res
-+		${OUT_DIR}/lang/yue_Hant.res
-+		${OUT_DIR}/lang/yue_Hant_HK.res
-+		${OUT_DIR}/lang/zgh.res
-+		${OUT_DIR}/lang/zh.res
-+		${OUT_DIR}/lang/zh_CN.res
-+		${OUT_DIR}/lang/zh_HK.res
-+		${OUT_DIR}/lang/zh_Hans.res
-+		${OUT_DIR}/lang/zh_Hans_CN.res
-+		${OUT_DIR}/lang/zh_Hans_SG.res
-+		${OUT_DIR}/lang/zh_Hant.res
-+		${OUT_DIR}/lang/zh_Hant_HK.res
-+		${OUT_DIR}/lang/zh_Hant_MO.res
-+		${OUT_DIR}/lang/zh_Hant_TW.res
-+		${OUT_DIR}/lang/zh_MO.res
-+		${OUT_DIR}/lang/zh_SG.res
-+		${OUT_DIR}/lang/zh_TW.res
-+		${OUT_DIR}/lang/zu.res
-+		${OUT_DIR}/langInfo.res
-+		${OUT_DIR}/lb.res
-+		${OUT_DIR}/lb_LU.res
-+		${OUT_DIR}/lg.res
-+		${OUT_DIR}/lg_UG.res
-+		${OUT_DIR}/likelySubtags.res
-+		${OUT_DIR}/lkt.res
-+		${OUT_DIR}/lkt_US.res
-+		${OUT_DIR}/lmb-excp.cnv
-+		${OUT_DIR}/ln.res
-+		${OUT_DIR}/ln_AO.res
-+		${OUT_DIR}/ln_CD.res
-+		${OUT_DIR}/ln_CF.res
-+		${OUT_DIR}/ln_CG.res
-+		${OUT_DIR}/lo.res
-+		${OUT_DIR}/lo_LA.res
-+		${OUT_DIR}/lrc.res
-+		${OUT_DIR}/lrc_IQ.res
-+		${OUT_DIR}/lrc_IR.res
-+		${OUT_DIR}/lt.res
-+		${OUT_DIR}/lt_LT.res
-+		${OUT_DIR}/lu.res
-+		${OUT_DIR}/lu_CD.res
-+		${OUT_DIR}/luo.res
-+		${OUT_DIR}/luo_KE.res
-+		${OUT_DIR}/luy.res
-+		${OUT_DIR}/luy_KE.res
-+		${OUT_DIR}/lv.res
-+		${OUT_DIR}/lv_LV.res
-+		${OUT_DIR}/macos-0_2-10.2.cnv
-+		${OUT_DIR}/macos-29-10.2.cnv
-+		${OUT_DIR}/macos-35-10.2.cnv
-+		${OUT_DIR}/macos-6_2-10.4.cnv
-+		${OUT_DIR}/macos-7_3-10.2.cnv
-+		${OUT_DIR}/mai.res
-+		${OUT_DIR}/mai_IN.res
-+		${OUT_DIR}/mas.res
-+		${OUT_DIR}/mas_KE.res
-+		${OUT_DIR}/mas_TZ.res
-+		${OUT_DIR}/mer.res
-+		${OUT_DIR}/mer_KE.res
-+		${OUT_DIR}/metaZones.res
-+		${OUT_DIR}/metadata.res
-+		${OUT_DIR}/mfe.res
-+		${OUT_DIR}/mfe_MU.res
-+		${OUT_DIR}/mg.res
-+		${OUT_DIR}/mg_MG.res
-+		${OUT_DIR}/mgh.res
-+		${OUT_DIR}/mgh_MZ.res
-+		${OUT_DIR}/mgo.res
-+		${OUT_DIR}/mgo_CM.res
-+		${OUT_DIR}/mi.res
-+		${OUT_DIR}/mi_NZ.res
-+		${OUT_DIR}/mk.res
-+		${OUT_DIR}/mk_MK.res
-+		${OUT_DIR}/ml.res
-+		${OUT_DIR}/ml_IN.res
-+		${OUT_DIR}/mn.res
-+		${OUT_DIR}/mn_MN.res
-+		${OUT_DIR}/mni.res
-+		${OUT_DIR}/mni_Beng.res
-+		${OUT_DIR}/mni_Beng_IN.res
-+		${OUT_DIR}/mni_IN.res
-+		${OUT_DIR}/mo.res
-+		${OUT_DIR}/mr.res
-+		${OUT_DIR}/mr_IN.res
-+		${OUT_DIR}/ms.res
-+		${OUT_DIR}/ms_BN.res
-+		${OUT_DIR}/ms_ID.res
-+		${OUT_DIR}/ms_MY.res
-+		${OUT_DIR}/ms_SG.res
-+		${OUT_DIR}/mt.res
-+		${OUT_DIR}/mt_MT.res
-+		${OUT_DIR}/mua.res
-+		${OUT_DIR}/mua_CM.res
-+		${OUT_DIR}/my.res
-+		${OUT_DIR}/my_MM.res
-+		${OUT_DIR}/mzn.res
-+		${OUT_DIR}/mzn_IR.res
-+		${OUT_DIR}/naq.res
-+		${OUT_DIR}/naq_NA.res
-+		${OUT_DIR}/nb.res
-+		${OUT_DIR}/nb_NO.res
-+		${OUT_DIR}/nb_SJ.res
-+		${OUT_DIR}/nd.res
-+		${OUT_DIR}/nd_ZW.res
-+		${OUT_DIR}/nds.res
-+		${OUT_DIR}/nds_DE.res
-+		${OUT_DIR}/nds_NL.res
-+		${OUT_DIR}/ne.res
-+		${OUT_DIR}/ne_IN.res
-+		${OUT_DIR}/ne_NP.res
-+		${OUT_DIR}/nfkc.nrm
-+		${OUT_DIR}/nfkc_cf.nrm
-+		${OUT_DIR}/nl.res
-+		${OUT_DIR}/nl_AW.res
-+		${OUT_DIR}/nl_BE.res
-+		${OUT_DIR}/nl_BQ.res
-+		${OUT_DIR}/nl_CW.res
-+		${OUT_DIR}/nl_NL.res
-+		${OUT_DIR}/nl_SR.res
-+		${OUT_DIR}/nl_SX.res
-+		${OUT_DIR}/nmg.res
-+		${OUT_DIR}/nmg_CM.res
-+		${OUT_DIR}/nn.res
-+		${OUT_DIR}/nn_NO.res
-+		${OUT_DIR}/nnh.res
-+		${OUT_DIR}/nnh_CM.res
-+		${OUT_DIR}/no.res
-+		${OUT_DIR}/no_NO.res
-+		${OUT_DIR}/no_NO_NY.res
-+		${OUT_DIR}/numberingSystems.res
-+		${OUT_DIR}/nus.res
-+		${OUT_DIR}/nus_SS.res
-+		${OUT_DIR}/nyn.res
-+		${OUT_DIR}/nyn_UG.res
-+		${OUT_DIR}/om.res
-+		${OUT_DIR}/om_ET.res
-+		${OUT_DIR}/om_KE.res
-+		${OUT_DIR}/or.res
-+		${OUT_DIR}/or_IN.res
-+		${OUT_DIR}/os.res
-+		${OUT_DIR}/os_GE.res
-+		${OUT_DIR}/os_RU.res
-+		${OUT_DIR}/pa.res
-+		${OUT_DIR}/pa_Arab.res
-+		${OUT_DIR}/pa_Arab_PK.res
-+		${OUT_DIR}/pa_Guru.res
-+		${OUT_DIR}/pa_Guru_IN.res
-+		${OUT_DIR}/pa_IN.res
-+		${OUT_DIR}/pa_PK.res
-+		${OUT_DIR}/pcm.res
-+		${OUT_DIR}/pcm_NG.res
-+		${OUT_DIR}/pl.res
-+		${OUT_DIR}/pl_PL.res
-+		${OUT_DIR}/pluralRanges.res
-+		${OUT_DIR}/plurals.res
-+		${OUT_DIR}/pool.res
-+		${OUT_DIR}/ps.res
-+		${OUT_DIR}/ps_AF.res
-+		${OUT_DIR}/ps_PK.res
-+		${OUT_DIR}/pt.res
-+		${OUT_DIR}/pt_AO.res
-+		${OUT_DIR}/pt_BR.res
-+		${OUT_DIR}/pt_CH.res
-+		${OUT_DIR}/pt_CV.res
-+		${OUT_DIR}/pt_GQ.res
-+		${OUT_DIR}/pt_GW.res
-+		${OUT_DIR}/pt_LU.res
-+		${OUT_DIR}/pt_MO.res
-+		${OUT_DIR}/pt_MZ.res
-+		${OUT_DIR}/pt_PT.res
-+		${OUT_DIR}/pt_ST.res
-+		${OUT_DIR}/pt_TL.res
-+		${OUT_DIR}/qu.res
-+		${OUT_DIR}/qu_BO.res
-+		${OUT_DIR}/qu_EC.res
-+		${OUT_DIR}/qu_PE.res
-+		${OUT_DIR}/rbnf/${INDEX_NAME}.res
-+		${OUT_DIR}/rbnf/af.res
-+		${OUT_DIR}/rbnf/ak.res
-+		${OUT_DIR}/rbnf/am.res
-+		${OUT_DIR}/rbnf/ar.res
-+		${OUT_DIR}/rbnf/ar_SA.res
-+		${OUT_DIR}/rbnf/ars.res
-+		${OUT_DIR}/rbnf/az.res
-+		${OUT_DIR}/rbnf/be.res
-+		${OUT_DIR}/rbnf/bg.res
-+		${OUT_DIR}/rbnf/bs.res
-+		${OUT_DIR}/rbnf/ca.res
-+		${OUT_DIR}/rbnf/ccp.res
-+		${OUT_DIR}/rbnf/chr.res
-+		${OUT_DIR}/rbnf/cs.res
-+		${OUT_DIR}/rbnf/cy.res
-+		${OUT_DIR}/rbnf/da.res
-+		${OUT_DIR}/rbnf/de.res
-+		${OUT_DIR}/rbnf/de_CH.res
-+		${OUT_DIR}/rbnf/ee.res
-+		${OUT_DIR}/rbnf/el.res
-+		${OUT_DIR}/rbnf/en.res
-+		${OUT_DIR}/rbnf/en_001.res
-+		${OUT_DIR}/rbnf/en_IN.res
-+		${OUT_DIR}/rbnf/eo.res
-+		${OUT_DIR}/rbnf/es.res
-+		${OUT_DIR}/rbnf/es_419.res
-+		${OUT_DIR}/rbnf/es_DO.res
-+		${OUT_DIR}/rbnf/es_GT.res
-+		${OUT_DIR}/rbnf/es_HN.res
-+		${OUT_DIR}/rbnf/es_MX.res
-+		${OUT_DIR}/rbnf/es_NI.res
-+		${OUT_DIR}/rbnf/es_PA.res
-+		${OUT_DIR}/rbnf/es_PR.res
-+		${OUT_DIR}/rbnf/es_SV.res
-+		${OUT_DIR}/rbnf/es_US.res
-+		${OUT_DIR}/rbnf/et.res
-+		${OUT_DIR}/rbnf/fa.res
-+		${OUT_DIR}/rbnf/fa_AF.res
-+		${OUT_DIR}/rbnf/ff.res
-+		${OUT_DIR}/rbnf/fi.res
-+		${OUT_DIR}/rbnf/fil.res
-+		${OUT_DIR}/rbnf/fo.res
-+		${OUT_DIR}/rbnf/fr.res
-+		${OUT_DIR}/rbnf/fr_BE.res
-+		${OUT_DIR}/rbnf/fr_CH.res
-+		${OUT_DIR}/rbnf/ga.res
-+		${OUT_DIR}/rbnf/he.res
-+		${OUT_DIR}/rbnf/hi.res
-+		${OUT_DIR}/rbnf/hr.res
-+		${OUT_DIR}/rbnf/hu.res
-+		${OUT_DIR}/rbnf/hy.res
-+		${OUT_DIR}/rbnf/id.res
-+		${OUT_DIR}/rbnf/in.res
-+		${OUT_DIR}/rbnf/is.res
-+		${OUT_DIR}/rbnf/it.res
-+		${OUT_DIR}/rbnf/iw.res
-+		${OUT_DIR}/rbnf/ja.res
-+		${OUT_DIR}/rbnf/ka.res
-+		${OUT_DIR}/rbnf/kl.res
-+		${OUT_DIR}/rbnf/km.res
-+		${OUT_DIR}/rbnf/ko.res
-+		${OUT_DIR}/rbnf/ky.res
-+		${OUT_DIR}/rbnf/lb.res
-+		${OUT_DIR}/rbnf/lo.res
-+		${OUT_DIR}/rbnf/lrc.res
-+		${OUT_DIR}/rbnf/lt.res
-+		${OUT_DIR}/rbnf/lv.res
-+		${OUT_DIR}/rbnf/mk.res
-+		${OUT_DIR}/rbnf/ms.res
-+		${OUT_DIR}/rbnf/mt.res
-+		${OUT_DIR}/rbnf/my.res
-+		${OUT_DIR}/rbnf/nb.res
-+		${OUT_DIR}/rbnf/nl.res
-+		${OUT_DIR}/rbnf/nn.res
-+		${OUT_DIR}/rbnf/no.res
-+		${OUT_DIR}/rbnf/pl.res
-+		${OUT_DIR}/rbnf/pt.res
-+		${OUT_DIR}/rbnf/pt_PT.res
-+		${OUT_DIR}/rbnf/qu.res
-+		${OUT_DIR}/rbnf/ro.res
-+		${OUT_DIR}/rbnf/root.res
-+		${OUT_DIR}/rbnf/ru.res
-+		${OUT_DIR}/rbnf/se.res
-+		${OUT_DIR}/rbnf/sh.res
-+		${OUT_DIR}/rbnf/sk.res
-+		${OUT_DIR}/rbnf/sl.res
-+		${OUT_DIR}/rbnf/sq.res
-+		${OUT_DIR}/rbnf/sr.res
-+		${OUT_DIR}/rbnf/sr_Latn.res
-+		${OUT_DIR}/rbnf/su.res
-+		${OUT_DIR}/rbnf/sv.res
-+		${OUT_DIR}/rbnf/sw.res
-+		${OUT_DIR}/rbnf/ta.res
-+		${OUT_DIR}/rbnf/th.res
-+		${OUT_DIR}/rbnf/tr.res
-+		${OUT_DIR}/rbnf/uk.res
-+		${OUT_DIR}/rbnf/vi.res
-+		${OUT_DIR}/rbnf/yue.res
-+		${OUT_DIR}/rbnf/yue_Hans.res
-+		${OUT_DIR}/rbnf/zh.res
-+		${OUT_DIR}/rbnf/zh_HK.res
-+		${OUT_DIR}/rbnf/zh_Hant.res
-+		${OUT_DIR}/rbnf/zh_Hant_HK.res
-+		${OUT_DIR}/rbnf/zh_Hant_MO.res
-+		${OUT_DIR}/rbnf/zh_Hant_TW.res
-+		${OUT_DIR}/rbnf/zh_MO.res
-+		${OUT_DIR}/rbnf/zh_TW.res
-+		${OUT_DIR}/region/${INDEX_NAME}.res
-+		${OUT_DIR}/region/af.res
-+		${OUT_DIR}/region/agq.res
-+		${OUT_DIR}/region/ak.res
-+		${OUT_DIR}/region/am.res
-+		${OUT_DIR}/region/ar.res
-+		${OUT_DIR}/region/ar_AE.res
-+		${OUT_DIR}/region/ar_LY.res
-+		${OUT_DIR}/region/ar_SA.res
-+		${OUT_DIR}/region/ars.res
-+		${OUT_DIR}/region/as.res
-+		${OUT_DIR}/region/asa.res
-+		${OUT_DIR}/region/ast.res
-+		${OUT_DIR}/region/az.res
-+		${OUT_DIR}/region/az_AZ.res
-+		${OUT_DIR}/region/az_Cyrl.res
-+		${OUT_DIR}/region/az_Latn.res
-+		${OUT_DIR}/region/az_Latn_AZ.res
-+		${OUT_DIR}/region/bas.res
-+		${OUT_DIR}/region/be.res
-+		${OUT_DIR}/region/bem.res
-+		${OUT_DIR}/region/bez.res
-+		${OUT_DIR}/region/bg.res
-+		${OUT_DIR}/region/bm.res
-+		${OUT_DIR}/region/bn.res
-+		${OUT_DIR}/region/bn_IN.res
-+		${OUT_DIR}/region/bo.res
-+		${OUT_DIR}/region/bo_IN.res
-+		${OUT_DIR}/region/br.res
-+		${OUT_DIR}/region/brx.res
-+		${OUT_DIR}/region/bs.res
-+		${OUT_DIR}/region/bs_BA.res
-+		${OUT_DIR}/region/bs_Cyrl.res
-+		${OUT_DIR}/region/bs_Latn.res
-+		${OUT_DIR}/region/bs_Latn_BA.res
-+		${OUT_DIR}/region/ca.res
-+		${OUT_DIR}/region/ccp.res
-+		${OUT_DIR}/region/ce.res
-+		${OUT_DIR}/region/ceb.res
-+		${OUT_DIR}/region/cgg.res
-+		${OUT_DIR}/region/chr.res
-+		${OUT_DIR}/region/ckb.res
-+		${OUT_DIR}/region/cs.res
-+		${OUT_DIR}/region/cy.res
-+		${OUT_DIR}/region/da.res
-+		${OUT_DIR}/region/dav.res
-+		${OUT_DIR}/region/de.res
-+		${OUT_DIR}/region/de_AT.res
-+		${OUT_DIR}/region/de_CH.res
-+		${OUT_DIR}/region/dje.res
-+		${OUT_DIR}/region/dsb.res
-+		${OUT_DIR}/region/dua.res
-+		${OUT_DIR}/region/dyo.res
-+		${OUT_DIR}/region/dz.res
-+		${OUT_DIR}/region/ebu.res
-+		${OUT_DIR}/region/ee.res
-+		${OUT_DIR}/region/el.res
-+		${OUT_DIR}/region/en.res
-+		${OUT_DIR}/region/en_001.res
-+		${OUT_DIR}/region/en_150.res
-+		${OUT_DIR}/region/en_AG.res
-+		${OUT_DIR}/region/en_AI.res
-+		${OUT_DIR}/region/en_AT.res
-+		${OUT_DIR}/region/en_AU.res
-+		${OUT_DIR}/region/en_BB.res
-+		${OUT_DIR}/region/en_BE.res
-+		${OUT_DIR}/region/en_BM.res
-+		${OUT_DIR}/region/en_BS.res
-+		${OUT_DIR}/region/en_BW.res
-+		${OUT_DIR}/region/en_BZ.res
-+		${OUT_DIR}/region/en_CA.res
-+		${OUT_DIR}/region/en_CC.res
-+		${OUT_DIR}/region/en_CH.res
-+		${OUT_DIR}/region/en_CK.res
-+		${OUT_DIR}/region/en_CM.res
-+		${OUT_DIR}/region/en_CX.res
-+		${OUT_DIR}/region/en_CY.res
-+		${OUT_DIR}/region/en_DE.res
-+		${OUT_DIR}/region/en_DG.res
-+		${OUT_DIR}/region/en_DK.res
-+		${OUT_DIR}/region/en_DM.res
-+		${OUT_DIR}/region/en_ER.res
-+		${OUT_DIR}/region/en_FI.res
-+		${OUT_DIR}/region/en_FJ.res
-+		${OUT_DIR}/region/en_FK.res
-+		${OUT_DIR}/region/en_FM.res
-+		${OUT_DIR}/region/en_GB.res
-+		${OUT_DIR}/region/en_GD.res
-+		${OUT_DIR}/region/en_GG.res
-+		${OUT_DIR}/region/en_GH.res
-+		${OUT_DIR}/region/en_GI.res
-+		${OUT_DIR}/region/en_GM.res
-+		${OUT_DIR}/region/en_GY.res
-+		${OUT_DIR}/region/en_HK.res
-+		${OUT_DIR}/region/en_IE.res
-+		${OUT_DIR}/region/en_IL.res
-+		${OUT_DIR}/region/en_IM.res
-+		${OUT_DIR}/region/en_IN.res
-+		${OUT_DIR}/region/en_IO.res
-+		${OUT_DIR}/region/en_JE.res
-+		${OUT_DIR}/region/en_JM.res
-+		${OUT_DIR}/region/en_KE.res
-+		${OUT_DIR}/region/en_KI.res
-+		${OUT_DIR}/region/en_KN.res
-+		${OUT_DIR}/region/en_KY.res
-+		${OUT_DIR}/region/en_LC.res
-+		${OUT_DIR}/region/en_LR.res
-+		${OUT_DIR}/region/en_LS.res
-+		${OUT_DIR}/region/en_MG.res
-+		${OUT_DIR}/region/en_MO.res
-+		${OUT_DIR}/region/en_MS.res
-+		${OUT_DIR}/region/en_MT.res
-+		${OUT_DIR}/region/en_MU.res
-+		${OUT_DIR}/region/en_MW.res
-+		${OUT_DIR}/region/en_MY.res
-+		${OUT_DIR}/region/en_NA.res
-+		${OUT_DIR}/region/en_NF.res
-+		${OUT_DIR}/region/en_NG.res
-+		${OUT_DIR}/region/en_NH.res
-+		${OUT_DIR}/region/en_NL.res
-+		${OUT_DIR}/region/en_NR.res
-+		${OUT_DIR}/region/en_NU.res
-+		${OUT_DIR}/region/en_NZ.res
-+		${OUT_DIR}/region/en_PG.res
-+		${OUT_DIR}/region/en_PH.res
-+		${OUT_DIR}/region/en_PK.res
-+		${OUT_DIR}/region/en_PN.res
-+		${OUT_DIR}/region/en_PW.res
-+		${OUT_DIR}/region/en_RH.res
-+		${OUT_DIR}/region/en_RW.res
-+		${OUT_DIR}/region/en_SB.res
-+		${OUT_DIR}/region/en_SC.res
-+		${OUT_DIR}/region/en_SD.res
-+		${OUT_DIR}/region/en_SE.res
-+		${OUT_DIR}/region/en_SG.res
-+		${OUT_DIR}/region/en_SH.res
-+		${OUT_DIR}/region/en_SI.res
-+		${OUT_DIR}/region/en_SL.res
-+		${OUT_DIR}/region/en_SS.res
-+		${OUT_DIR}/region/en_SX.res
-+		${OUT_DIR}/region/en_SZ.res
-+		${OUT_DIR}/region/en_TC.res
-+		${OUT_DIR}/region/en_TK.res
-+		${OUT_DIR}/region/en_TO.res
-+		${OUT_DIR}/region/en_TT.res
-+		${OUT_DIR}/region/en_TV.res
-+		${OUT_DIR}/region/en_TZ.res
-+		${OUT_DIR}/region/en_UG.res
-+		${OUT_DIR}/region/en_VC.res
-+		${OUT_DIR}/region/en_VG.res
-+		${OUT_DIR}/region/en_VU.res
-+		${OUT_DIR}/region/en_WS.res
-+		${OUT_DIR}/region/en_ZA.res
-+		${OUT_DIR}/region/en_ZM.res
-+		${OUT_DIR}/region/en_ZW.res
-+		${OUT_DIR}/region/eo.res
-+		${OUT_DIR}/region/es.res
-+		${OUT_DIR}/region/es_419.res
-+		${OUT_DIR}/region/es_AR.res
-+		${OUT_DIR}/region/es_BO.res
-+		${OUT_DIR}/region/es_BR.res
-+		${OUT_DIR}/region/es_BZ.res
-+		${OUT_DIR}/region/es_CL.res
-+		${OUT_DIR}/region/es_CO.res
-+		${OUT_DIR}/region/es_CR.res
-+		${OUT_DIR}/region/es_CU.res
-+		${OUT_DIR}/region/es_DO.res
-+		${OUT_DIR}/region/es_EC.res
-+		${OUT_DIR}/region/es_GT.res
-+		${OUT_DIR}/region/es_HN.res
-+		${OUT_DIR}/region/es_MX.res
-+		${OUT_DIR}/region/es_NI.res
-+		${OUT_DIR}/region/es_PA.res
-+		${OUT_DIR}/region/es_PE.res
-+		${OUT_DIR}/region/es_PR.res
-+		${OUT_DIR}/region/es_PY.res
-+		${OUT_DIR}/region/es_SV.res
-+		${OUT_DIR}/region/es_US.res
-+		${OUT_DIR}/region/es_UY.res
-+		${OUT_DIR}/region/es_VE.res
-+		${OUT_DIR}/region/et.res
-+		${OUT_DIR}/region/eu.res
-+		${OUT_DIR}/region/ewo.res
-+		${OUT_DIR}/region/fa.res
-+		${OUT_DIR}/region/fa_AF.res
-+		${OUT_DIR}/region/ff.res
-+		${OUT_DIR}/region/ff_Adlm.res
-+		${OUT_DIR}/region/ff_CM.res
-+		${OUT_DIR}/region/ff_GN.res
-+		${OUT_DIR}/region/ff_Latn.res
-+		${OUT_DIR}/region/ff_Latn_CM.res
-+		${OUT_DIR}/region/ff_Latn_GN.res
-+		${OUT_DIR}/region/ff_Latn_MR.res
-+		${OUT_DIR}/region/ff_Latn_SN.res
-+		${OUT_DIR}/region/ff_MR.res
-+		${OUT_DIR}/region/ff_SN.res
-+		${OUT_DIR}/region/fi.res
-+		${OUT_DIR}/region/fil.res
-+		${OUT_DIR}/region/fil_PH.res
-+		${OUT_DIR}/region/fo.res
-+		${OUT_DIR}/region/fr.res
-+		${OUT_DIR}/region/fr_BE.res
-+		${OUT_DIR}/region/fr_CA.res
-+		${OUT_DIR}/region/fur.res
-+		${OUT_DIR}/region/fy.res
-+		${OUT_DIR}/region/ga.res
-+		${OUT_DIR}/region/gd.res
-+		${OUT_DIR}/region/gl.res
-+		${OUT_DIR}/region/gsw.res
-+		${OUT_DIR}/region/gu.res
-+		${OUT_DIR}/region/guz.res
-+		${OUT_DIR}/region/gv.res
-+		${OUT_DIR}/region/ha.res
-+		${OUT_DIR}/region/haw.res
-+		${OUT_DIR}/region/he.res
-+		${OUT_DIR}/region/he_IL.res
-+		${OUT_DIR}/region/hi.res
-+		${OUT_DIR}/region/hr.res
-+		${OUT_DIR}/region/hsb.res
-+		${OUT_DIR}/region/hu.res
-+		${OUT_DIR}/region/hy.res
-+		${OUT_DIR}/region/ia.res
-+		${OUT_DIR}/region/id.res
-+		${OUT_DIR}/region/id_ID.res
-+		${OUT_DIR}/region/ig.res
-+		${OUT_DIR}/region/ii.res
-+		${OUT_DIR}/region/in.res
-+		${OUT_DIR}/region/in_ID.res
-+		${OUT_DIR}/region/is.res
-+		${OUT_DIR}/region/it.res
-+		${OUT_DIR}/region/iw.res
-+		${OUT_DIR}/region/iw_IL.res
-+		${OUT_DIR}/region/ja.res
-+		${OUT_DIR}/region/jgo.res
-+		${OUT_DIR}/region/jmc.res
-+		${OUT_DIR}/region/jv.res
-+		${OUT_DIR}/region/ka.res
-+		${OUT_DIR}/region/kab.res
-+		${OUT_DIR}/region/kam.res
-+		${OUT_DIR}/region/kde.res
-+		${OUT_DIR}/region/kea.res
-+		${OUT_DIR}/region/khq.res
-+		${OUT_DIR}/region/ki.res
-+		${OUT_DIR}/region/kk.res
-+		${OUT_DIR}/region/kkj.res
-+		${OUT_DIR}/region/kl.res
-+		${OUT_DIR}/region/kln.res
-+		${OUT_DIR}/region/km.res
-+		${OUT_DIR}/region/kn.res
-+		${OUT_DIR}/region/ko.res
-+		${OUT_DIR}/region/ko_KP.res
-+		${OUT_DIR}/region/kok.res
-+		${OUT_DIR}/region/ks.res
-+		${OUT_DIR}/region/ks_Arab.res
-+		${OUT_DIR}/region/ks_Arab_IN.res
-+		${OUT_DIR}/region/ks_IN.res
-+		${OUT_DIR}/region/ksb.res
-+		${OUT_DIR}/region/ksf.res
-+		${OUT_DIR}/region/ksh.res
-+		${OUT_DIR}/region/ku.res
-+		${OUT_DIR}/region/kw.res
-+		${OUT_DIR}/region/ky.res
-+		${OUT_DIR}/region/lag.res
-+		${OUT_DIR}/region/lb.res
-+		${OUT_DIR}/region/lg.res
-+		${OUT_DIR}/region/lkt.res
-+		${OUT_DIR}/region/ln.res
-+		${OUT_DIR}/region/lo.res
-+		${OUT_DIR}/region/lrc.res
-+		${OUT_DIR}/region/lt.res
-+		${OUT_DIR}/region/lu.res
-+		${OUT_DIR}/region/luo.res
-+		${OUT_DIR}/region/luy.res
-+		${OUT_DIR}/region/lv.res
-+		${OUT_DIR}/region/mai.res
-+		${OUT_DIR}/region/mas.res
-+		${OUT_DIR}/region/mer.res
-+		${OUT_DIR}/region/mfe.res
-+		${OUT_DIR}/region/mg.res
-+		${OUT_DIR}/region/mgh.res
-+		${OUT_DIR}/region/mgo.res
-+		${OUT_DIR}/region/mi.res
-+		${OUT_DIR}/region/mk.res
-+		${OUT_DIR}/region/ml.res
-+		${OUT_DIR}/region/mn.res
-+		${OUT_DIR}/region/mni.res
-+		${OUT_DIR}/region/mni_Beng.res
-+		${OUT_DIR}/region/mni_Beng_IN.res
-+		${OUT_DIR}/region/mni_IN.res
-+		${OUT_DIR}/region/mo.res
-+		${OUT_DIR}/region/mr.res
-+		${OUT_DIR}/region/ms.res
-+		${OUT_DIR}/region/mt.res
-+		${OUT_DIR}/region/mua.res
-+		${OUT_DIR}/region/my.res
-+		${OUT_DIR}/region/mzn.res
-+		${OUT_DIR}/region/naq.res
-+		${OUT_DIR}/region/nb.res
-+		${OUT_DIR}/region/nb_NO.res
-+		${OUT_DIR}/region/nd.res
-+		${OUT_DIR}/region/nds.res
-+		${OUT_DIR}/region/ne.res
-+		${OUT_DIR}/region/nl.res
-+		${OUT_DIR}/region/nmg.res
-+		${OUT_DIR}/region/nn.res
-+		${OUT_DIR}/region/nn_NO.res
-+		${OUT_DIR}/region/nnh.res
-+		${OUT_DIR}/region/no.res
-+		${OUT_DIR}/region/no_NO.res
-+		${OUT_DIR}/region/no_NO_NY.res
-+		${OUT_DIR}/region/nus.res
-+		${OUT_DIR}/region/nyn.res
-+		${OUT_DIR}/region/om.res
-+		${OUT_DIR}/region/or.res
-+		${OUT_DIR}/region/os.res
-+		${OUT_DIR}/region/pa.res
-+		${OUT_DIR}/region/pa_Arab.res
-+		${OUT_DIR}/region/pa_Arab_PK.res
-+		${OUT_DIR}/region/pa_Guru.res
-+		${OUT_DIR}/region/pa_Guru_IN.res
-+		${OUT_DIR}/region/pa_IN.res
-+		${OUT_DIR}/region/pa_PK.res
-+		${OUT_DIR}/region/pcm.res
-+		${OUT_DIR}/region/pl.res
-+		${OUT_DIR}/region/pool.res
-+		${OUT_DIR}/region/ps.res
-+		${OUT_DIR}/region/ps_PK.res
-+		${OUT_DIR}/region/pt.res
-+		${OUT_DIR}/region/pt_AO.res
-+		${OUT_DIR}/region/pt_CH.res
-+		${OUT_DIR}/region/pt_CV.res
-+		${OUT_DIR}/region/pt_GQ.res
-+		${OUT_DIR}/region/pt_GW.res
-+		${OUT_DIR}/region/pt_LU.res
-+		${OUT_DIR}/region/pt_MO.res
-+		${OUT_DIR}/region/pt_MZ.res
-+		${OUT_DIR}/region/pt_PT.res
-+		${OUT_DIR}/region/pt_ST.res
-+		${OUT_DIR}/region/pt_TL.res
-+		${OUT_DIR}/region/qu.res
-+		${OUT_DIR}/region/rm.res
-+		${OUT_DIR}/region/rn.res
-+		${OUT_DIR}/region/ro.res
-+		${OUT_DIR}/region/ro_MD.res
-+		${OUT_DIR}/region/rof.res
-+		${OUT_DIR}/region/root.res
-+		${OUT_DIR}/region/ru.res
-+		${OUT_DIR}/region/ru_UA.res
-+		${OUT_DIR}/region/rw.res
-+		${OUT_DIR}/region/rwk.res
-+		${OUT_DIR}/region/sah.res
-+		${OUT_DIR}/region/saq.res
-+		${OUT_DIR}/region/sat.res
-+		${OUT_DIR}/region/sat_IN.res
-+		${OUT_DIR}/region/sat_Olck.res
-+		${OUT_DIR}/region/sat_Olck_IN.res
-+		${OUT_DIR}/region/sbp.res
-+		${OUT_DIR}/region/sd.res
-+		${OUT_DIR}/region/sd_Arab.res
-+		${OUT_DIR}/region/sd_Arab_PK.res
-+		${OUT_DIR}/region/sd_Deva.res
-+		${OUT_DIR}/region/sd_PK.res
-+		${OUT_DIR}/region/se.res
-+		${OUT_DIR}/region/se_FI.res
-+		${OUT_DIR}/region/seh.res
-+		${OUT_DIR}/region/ses.res
-+		${OUT_DIR}/region/sg.res
-+		${OUT_DIR}/region/sh.res
-+		${OUT_DIR}/region/sh_BA.res
-+		${OUT_DIR}/region/sh_CS.res
-+		${OUT_DIR}/region/sh_YU.res
-+		${OUT_DIR}/region/shi.res
-+		${OUT_DIR}/region/shi_Latn.res
-+		${OUT_DIR}/region/shi_MA.res
-+		${OUT_DIR}/region/shi_Tfng.res
-+		${OUT_DIR}/region/shi_Tfng_MA.res
-+		${OUT_DIR}/region/si.res
-+		${OUT_DIR}/region/sk.res
-+		${OUT_DIR}/region/sl.res
-+		${OUT_DIR}/region/smn.res
-+		${OUT_DIR}/region/sn.res
-+		${OUT_DIR}/region/so.res
-+		${OUT_DIR}/region/sq.res
-+		${OUT_DIR}/region/sr.res
-+		${OUT_DIR}/region/sr_BA.res
-+		${OUT_DIR}/region/sr_CS.res
-+		${OUT_DIR}/region/sr_Cyrl.res
-+		${OUT_DIR}/region/sr_Cyrl_BA.res
-+		${OUT_DIR}/region/sr_Cyrl_CS.res
-+		${OUT_DIR}/region/sr_Cyrl_ME.res
-+		${OUT_DIR}/region/sr_Cyrl_RS.res
-+		${OUT_DIR}/region/sr_Cyrl_XK.res
-+		${OUT_DIR}/region/sr_Cyrl_YU.res
-+		${OUT_DIR}/region/sr_Latn.res
-+		${OUT_DIR}/region/sr_Latn_BA.res
-+		${OUT_DIR}/region/sr_Latn_CS.res
-+		${OUT_DIR}/region/sr_Latn_ME.res
-+		${OUT_DIR}/region/sr_Latn_RS.res
-+		${OUT_DIR}/region/sr_Latn_XK.res
-+		${OUT_DIR}/region/sr_Latn_YU.res
-+		${OUT_DIR}/region/sr_ME.res
-+		${OUT_DIR}/region/sr_RS.res
-+		${OUT_DIR}/region/sr_XK.res
-+		${OUT_DIR}/region/sr_YU.res
-+		${OUT_DIR}/region/su.res
-+		${OUT_DIR}/region/su_ID.res
-+		${OUT_DIR}/region/su_Latn.res
-+		${OUT_DIR}/region/su_Latn_ID.res
-+		${OUT_DIR}/region/sv.res
-+		${OUT_DIR}/region/sw.res
-+		${OUT_DIR}/region/sw_CD.res
-+		${OUT_DIR}/region/sw_KE.res
-+		${OUT_DIR}/region/ta.res
-+		${OUT_DIR}/region/te.res
-+		${OUT_DIR}/region/teo.res
-+		${OUT_DIR}/region/tg.res
-+		${OUT_DIR}/region/th.res
-+		${OUT_DIR}/region/ti.res
-+		${OUT_DIR}/region/tk.res
-+		${OUT_DIR}/region/tl.res
-+		${OUT_DIR}/region/tl_PH.res
-+		${OUT_DIR}/region/to.res
-+		${OUT_DIR}/region/tr.res
-+		${OUT_DIR}/region/tt.res
-+		${OUT_DIR}/region/twq.res
-+		${OUT_DIR}/region/tzm.res
-+		${OUT_DIR}/region/ug.res
-+		${OUT_DIR}/region/uk.res
-+		${OUT_DIR}/region/ur.res
-+		${OUT_DIR}/region/ur_IN.res
-+		${OUT_DIR}/region/uz.res
-+		${OUT_DIR}/region/uz_AF.res
-+		${OUT_DIR}/region/uz_Arab.res
-+		${OUT_DIR}/region/uz_Arab_AF.res
-+		${OUT_DIR}/region/uz_Cyrl.res
-+		${OUT_DIR}/region/uz_Latn.res
-+		${OUT_DIR}/region/uz_Latn_UZ.res
-+		${OUT_DIR}/region/uz_UZ.res
-+		${OUT_DIR}/region/vai.res
-+		${OUT_DIR}/region/vai_LR.res
-+		${OUT_DIR}/region/vai_Latn.res
-+		${OUT_DIR}/region/vai_Vaii.res
-+		${OUT_DIR}/region/vai_Vaii_LR.res
-+		${OUT_DIR}/region/vi.res
-+		${OUT_DIR}/region/vun.res
-+		${OUT_DIR}/region/wae.res
-+		${OUT_DIR}/region/wo.res
-+		${OUT_DIR}/region/xh.res
-+		${OUT_DIR}/region/xog.res
-+		${OUT_DIR}/region/yav.res
-+		${OUT_DIR}/region/yi.res
-+		${OUT_DIR}/region/yo.res
-+		${OUT_DIR}/region/yo_BJ.res
-+		${OUT_DIR}/region/yue.res
-+		${OUT_DIR}/region/yue_CN.res
-+		${OUT_DIR}/region/yue_HK.res
-+		${OUT_DIR}/region/yue_Hans.res
-+		${OUT_DIR}/region/yue_Hans_CN.res
-+		${OUT_DIR}/region/yue_Hant.res
-+		${OUT_DIR}/region/yue_Hant_HK.res
-+		${OUT_DIR}/region/zgh.res
-+		${OUT_DIR}/region/zh.res
-+		${OUT_DIR}/region/zh_CN.res
-+		${OUT_DIR}/region/zh_HK.res
-+		${OUT_DIR}/region/zh_Hans.res
-+		${OUT_DIR}/region/zh_Hans_CN.res
-+		${OUT_DIR}/region/zh_Hans_SG.res
-+		${OUT_DIR}/region/zh_Hant.res
-+		${OUT_DIR}/region/zh_Hant_HK.res
-+		${OUT_DIR}/region/zh_Hant_MO.res
-+		${OUT_DIR}/region/zh_Hant_TW.res
-+		${OUT_DIR}/region/zh_MO.res
-+		${OUT_DIR}/region/zh_SG.res
-+		${OUT_DIR}/region/zh_TW.res
-+		${OUT_DIR}/region/zu.res
-+		${OUT_DIR}/rfc3491.spp
-+		${OUT_DIR}/rfc3530cs.spp
-+		${OUT_DIR}/rfc3530csci.spp
-+		${OUT_DIR}/rfc3530mixp.spp
-+		${OUT_DIR}/rfc3722.spp
-+		${OUT_DIR}/rfc3920node.spp
-+		${OUT_DIR}/rfc3920res.spp
-+		${OUT_DIR}/rfc4011.spp
-+		${OUT_DIR}/rfc4013.spp
-+		${OUT_DIR}/rfc4505.spp
-+		${OUT_DIR}/rfc4518.spp
-+		${OUT_DIR}/rfc4518ci.spp
-+		${OUT_DIR}/rm.res
-+		${OUT_DIR}/rm_CH.res
-+		${OUT_DIR}/rn.res
-+		${OUT_DIR}/rn_BI.res
-+		${OUT_DIR}/ro.res
-+		${OUT_DIR}/ro_MD.res
-+		${OUT_DIR}/ro_RO.res
-+		${OUT_DIR}/rof.res
-+		${OUT_DIR}/rof_TZ.res
-+		${OUT_DIR}/root.res
-+		${OUT_DIR}/ru.res
-+		${OUT_DIR}/ru_BY.res
-+		${OUT_DIR}/ru_KG.res
-+		${OUT_DIR}/ru_KZ.res
-+		${OUT_DIR}/ru_MD.res
-+		${OUT_DIR}/ru_RU.res
-+		${OUT_DIR}/ru_UA.res
-+		${OUT_DIR}/rw.res
-+		${OUT_DIR}/rw_RW.res
-+		${OUT_DIR}/rwk.res
-+		${OUT_DIR}/rwk_TZ.res
-+		${OUT_DIR}/sah.res
-+		${OUT_DIR}/sah_RU.res
-+		${OUT_DIR}/saq.res
-+		${OUT_DIR}/saq_KE.res
-+		${OUT_DIR}/sat.res
-+		${OUT_DIR}/sat_IN.res
-+		${OUT_DIR}/sat_Olck.res
-+		${OUT_DIR}/sat_Olck_IN.res
-+		${OUT_DIR}/sbp.res
-+		${OUT_DIR}/sbp_TZ.res
-+		${OUT_DIR}/sd.res
-+		${OUT_DIR}/sd_Arab.res
-+		${OUT_DIR}/sd_Arab_PK.res
-+		${OUT_DIR}/sd_Deva.res
-+		${OUT_DIR}/sd_Deva_IN.res
-+		${OUT_DIR}/sd_PK.res
-+		${OUT_DIR}/se.res
-+		${OUT_DIR}/se_FI.res
-+		${OUT_DIR}/se_NO.res
-+		${OUT_DIR}/se_SE.res
-+		${OUT_DIR}/seh.res
-+		${OUT_DIR}/seh_MZ.res
-+		${OUT_DIR}/ses.res
-+		${OUT_DIR}/ses_ML.res
-+		${OUT_DIR}/sg.res
-+		${OUT_DIR}/sg_CF.res
-+		${OUT_DIR}/sh.res
-+		${OUT_DIR}/sh_BA.res
-+		${OUT_DIR}/sh_CS.res
-+		${OUT_DIR}/sh_YU.res
-+		${OUT_DIR}/shi.res
-+		${OUT_DIR}/shi_Latn.res
-+		${OUT_DIR}/shi_Latn_MA.res
-+		${OUT_DIR}/shi_MA.res
-+		${OUT_DIR}/shi_Tfng.res
-+		${OUT_DIR}/shi_Tfng_MA.res
-+		${OUT_DIR}/si.res
-+		${OUT_DIR}/si_LK.res
-+		${OUT_DIR}/sk.res
-+		${OUT_DIR}/sk_SK.res
-+		${OUT_DIR}/sl.res
-+		${OUT_DIR}/sl_SI.res
-+		${OUT_DIR}/smn.res
-+		${OUT_DIR}/smn_FI.res
-+		${OUT_DIR}/sn.res
-+		${OUT_DIR}/sn_ZW.res
-+		${OUT_DIR}/so.res
-+		${OUT_DIR}/so_DJ.res
-+		${OUT_DIR}/so_ET.res
-+		${OUT_DIR}/so_KE.res
-+		${OUT_DIR}/so_SO.res
-+		${OUT_DIR}/sq.res
-+		${OUT_DIR}/sq_AL.res
-+		${OUT_DIR}/sq_MK.res
-+		${OUT_DIR}/sq_XK.res
-+		${OUT_DIR}/sr.res
-+		${OUT_DIR}/sr_BA.res
-+		${OUT_DIR}/sr_CS.res
-+		${OUT_DIR}/sr_Cyrl.res
-+		${OUT_DIR}/sr_Cyrl_BA.res
-+		${OUT_DIR}/sr_Cyrl_CS.res
-+		${OUT_DIR}/sr_Cyrl_ME.res
-+		${OUT_DIR}/sr_Cyrl_RS.res
-+		${OUT_DIR}/sr_Cyrl_XK.res
-+		${OUT_DIR}/sr_Cyrl_YU.res
-+		${OUT_DIR}/sr_Latn.res
-+		${OUT_DIR}/sr_Latn_BA.res
-+		${OUT_DIR}/sr_Latn_CS.res
-+		${OUT_DIR}/sr_Latn_ME.res
-+		${OUT_DIR}/sr_Latn_RS.res
-+		${OUT_DIR}/sr_Latn_XK.res
-+		${OUT_DIR}/sr_Latn_YU.res
-+		${OUT_DIR}/sr_ME.res
-+		${OUT_DIR}/sr_RS.res
-+		${OUT_DIR}/sr_XK.res
-+		${OUT_DIR}/sr_YU.res
-+		${OUT_DIR}/su.res
-+		${OUT_DIR}/su_ID.res
-+		${OUT_DIR}/su_Latn.res
-+		${OUT_DIR}/su_Latn_ID.res
-+		${OUT_DIR}/supplementalData.res
-+		${OUT_DIR}/sv.res
-+		${OUT_DIR}/sv_AX.res
-+		${OUT_DIR}/sv_FI.res
-+		${OUT_DIR}/sv_SE.res
-+		${OUT_DIR}/sw.res
-+		${OUT_DIR}/sw_CD.res
-+		${OUT_DIR}/sw_KE.res
-+		${OUT_DIR}/sw_TZ.res
-+		${OUT_DIR}/sw_UG.res
-+		${OUT_DIR}/ta.res
-+		${OUT_DIR}/ta_IN.res
-+		${OUT_DIR}/ta_LK.res
-+		${OUT_DIR}/ta_MY.res
-+		${OUT_DIR}/ta_SG.res
-+		${OUT_DIR}/te.res
-+		${OUT_DIR}/te_IN.res
-+		${OUT_DIR}/teo.res
-+		${OUT_DIR}/teo_KE.res
-+		${OUT_DIR}/teo_UG.res
-+		${OUT_DIR}/tg.res
-+		${OUT_DIR}/tg_TJ.res
-+		${OUT_DIR}/th.res
-+		${OUT_DIR}/th_TH.res
-+		${OUT_DIR}/th_TH_TRADITIONAL.res
-+		${OUT_DIR}/ti.res
-+		${OUT_DIR}/ti_ER.res
-+		${OUT_DIR}/ti_ET.res
-+		${OUT_DIR}/timezoneTypes.res
-+		${OUT_DIR}/tk.res
-+		${OUT_DIR}/tk_TM.res
-+		${OUT_DIR}/tl.res
-+		${OUT_DIR}/tl_PH.res
-+		${OUT_DIR}/to.res
-+		${OUT_DIR}/to_TO.res
-+		${OUT_DIR}/tr.res
-+		${OUT_DIR}/tr_CY.res
-+		${OUT_DIR}/tr_TR.res
-+		${OUT_DIR}/translit/el.res
-+		${OUT_DIR}/translit/en.res
-+		${OUT_DIR}/translit/root.res
-+		${OUT_DIR}/tt.res
-+		${OUT_DIR}/tt_RU.res
-+		${OUT_DIR}/twq.res
-+		${OUT_DIR}/twq_NE.res
-+		${OUT_DIR}/tzm.res
-+		${OUT_DIR}/tzm_MA.res
-+		${OUT_DIR}/ug.res
-+		${OUT_DIR}/ug_CN.res
-+		${OUT_DIR}/uk.res
-+		${OUT_DIR}/uk_UA.res
-+		${OUT_DIR}/ulayout.icu
-+		${OUT_DIR}/unames.icu
-+		${OUT_DIR}/unit/${INDEX_NAME}.res
-+		${OUT_DIR}/unit/af.res
-+		${OUT_DIR}/unit/agq.res
-+		${OUT_DIR}/unit/ak.res
-+		${OUT_DIR}/unit/am.res
-+		${OUT_DIR}/unit/ar.res
-+		${OUT_DIR}/unit/ar_SA.res
-+		${OUT_DIR}/unit/ars.res
-+		${OUT_DIR}/unit/as.res
-+		${OUT_DIR}/unit/asa.res
-+		${OUT_DIR}/unit/ast.res
-+		${OUT_DIR}/unit/az.res
-+		${OUT_DIR}/unit/az_AZ.res
-+		${OUT_DIR}/unit/az_Cyrl.res
-+		${OUT_DIR}/unit/az_Latn.res
-+		${OUT_DIR}/unit/az_Latn_AZ.res
-+		${OUT_DIR}/unit/bas.res
-+		${OUT_DIR}/unit/be.res
-+		${OUT_DIR}/unit/bem.res
-+		${OUT_DIR}/unit/bez.res
-+		${OUT_DIR}/unit/bg.res
-+		${OUT_DIR}/unit/bm.res
-+		${OUT_DIR}/unit/bn.res
-+		${OUT_DIR}/unit/bo.res
-+		${OUT_DIR}/unit/br.res
-+		${OUT_DIR}/unit/brx.res
-+		${OUT_DIR}/unit/bs.res
-+		${OUT_DIR}/unit/bs_BA.res
-+		${OUT_DIR}/unit/bs_Cyrl.res
-+		${OUT_DIR}/unit/bs_Latn.res
-+		${OUT_DIR}/unit/bs_Latn_BA.res
-+		${OUT_DIR}/unit/ca.res
-+		${OUT_DIR}/unit/ccp.res
-+		${OUT_DIR}/unit/ce.res
-+		${OUT_DIR}/unit/ceb.res
-+		${OUT_DIR}/unit/cgg.res
-+		${OUT_DIR}/unit/chr.res
-+		${OUT_DIR}/unit/ckb.res
-+		${OUT_DIR}/unit/cs.res
-+		${OUT_DIR}/unit/cy.res
-+		${OUT_DIR}/unit/da.res
-+		${OUT_DIR}/unit/dav.res
-+		${OUT_DIR}/unit/de.res
-+		${OUT_DIR}/unit/de_CH.res
-+		${OUT_DIR}/unit/dje.res
-+		${OUT_DIR}/unit/dsb.res
-+		${OUT_DIR}/unit/dua.res
-+		${OUT_DIR}/unit/dyo.res
-+		${OUT_DIR}/unit/dz.res
-+		${OUT_DIR}/unit/ebu.res
-+		${OUT_DIR}/unit/ee.res
-+		${OUT_DIR}/unit/el.res
-+		${OUT_DIR}/unit/en.res
-+		${OUT_DIR}/unit/en_001.res
-+		${OUT_DIR}/unit/en_150.res
-+		${OUT_DIR}/unit/en_AG.res
-+		${OUT_DIR}/unit/en_AI.res
-+		${OUT_DIR}/unit/en_AT.res
-+		${OUT_DIR}/unit/en_AU.res
-+		${OUT_DIR}/unit/en_BB.res
-+		${OUT_DIR}/unit/en_BE.res
-+		${OUT_DIR}/unit/en_BM.res
-+		${OUT_DIR}/unit/en_BS.res
-+		${OUT_DIR}/unit/en_BW.res
-+		${OUT_DIR}/unit/en_BZ.res
-+		${OUT_DIR}/unit/en_CA.res
-+		${OUT_DIR}/unit/en_CC.res
-+		${OUT_DIR}/unit/en_CH.res
-+		${OUT_DIR}/unit/en_CK.res
-+		${OUT_DIR}/unit/en_CM.res
-+		${OUT_DIR}/unit/en_CX.res
-+		${OUT_DIR}/unit/en_CY.res
-+		${OUT_DIR}/unit/en_DE.res
-+		${OUT_DIR}/unit/en_DG.res
-+		${OUT_DIR}/unit/en_DK.res
-+		${OUT_DIR}/unit/en_DM.res
-+		${OUT_DIR}/unit/en_ER.res
-+		${OUT_DIR}/unit/en_FI.res
-+		${OUT_DIR}/unit/en_FJ.res
-+		${OUT_DIR}/unit/en_FK.res
-+		${OUT_DIR}/unit/en_FM.res
-+		${OUT_DIR}/unit/en_GB.res
-+		${OUT_DIR}/unit/en_GD.res
-+		${OUT_DIR}/unit/en_GG.res
-+		${OUT_DIR}/unit/en_GH.res
-+		${OUT_DIR}/unit/en_GI.res
-+		${OUT_DIR}/unit/en_GM.res
-+		${OUT_DIR}/unit/en_GY.res
-+		${OUT_DIR}/unit/en_HK.res
-+		${OUT_DIR}/unit/en_IE.res
-+		${OUT_DIR}/unit/en_IL.res
-+		${OUT_DIR}/unit/en_IM.res
-+		${OUT_DIR}/unit/en_IN.res
-+		${OUT_DIR}/unit/en_IO.res
-+		${OUT_DIR}/unit/en_JE.res
-+		${OUT_DIR}/unit/en_JM.res
-+		${OUT_DIR}/unit/en_KE.res
-+		${OUT_DIR}/unit/en_KI.res
-+		${OUT_DIR}/unit/en_KN.res
-+		${OUT_DIR}/unit/en_KY.res
-+		${OUT_DIR}/unit/en_LC.res
-+		${OUT_DIR}/unit/en_LR.res
-+		${OUT_DIR}/unit/en_LS.res
-+		${OUT_DIR}/unit/en_MG.res
-+		${OUT_DIR}/unit/en_MO.res
-+		${OUT_DIR}/unit/en_MS.res
-+		${OUT_DIR}/unit/en_MT.res
-+		${OUT_DIR}/unit/en_MU.res
-+		${OUT_DIR}/unit/en_MW.res
-+		${OUT_DIR}/unit/en_MY.res
-+		${OUT_DIR}/unit/en_NA.res
-+		${OUT_DIR}/unit/en_NF.res
-+		${OUT_DIR}/unit/en_NG.res
-+		${OUT_DIR}/unit/en_NH.res
-+		${OUT_DIR}/unit/en_NL.res
-+		${OUT_DIR}/unit/en_NR.res
-+		${OUT_DIR}/unit/en_NU.res
-+		${OUT_DIR}/unit/en_NZ.res
-+		${OUT_DIR}/unit/en_PG.res
-+		${OUT_DIR}/unit/en_PH.res
-+		${OUT_DIR}/unit/en_PK.res
-+		${OUT_DIR}/unit/en_PN.res
-+		${OUT_DIR}/unit/en_PW.res
-+		${OUT_DIR}/unit/en_RH.res
-+		${OUT_DIR}/unit/en_RW.res
-+		${OUT_DIR}/unit/en_SB.res
-+		${OUT_DIR}/unit/en_SC.res
-+		${OUT_DIR}/unit/en_SD.res
-+		${OUT_DIR}/unit/en_SE.res
-+		${OUT_DIR}/unit/en_SG.res
-+		${OUT_DIR}/unit/en_SH.res
-+		${OUT_DIR}/unit/en_SI.res
-+		${OUT_DIR}/unit/en_SL.res
-+		${OUT_DIR}/unit/en_SS.res
-+		${OUT_DIR}/unit/en_SX.res
-+		${OUT_DIR}/unit/en_SZ.res
-+		${OUT_DIR}/unit/en_TC.res
-+		${OUT_DIR}/unit/en_TK.res
-+		${OUT_DIR}/unit/en_TO.res
-+		${OUT_DIR}/unit/en_TT.res
-+		${OUT_DIR}/unit/en_TV.res
-+		${OUT_DIR}/unit/en_TZ.res
-+		${OUT_DIR}/unit/en_UG.res
-+		${OUT_DIR}/unit/en_VC.res
-+		${OUT_DIR}/unit/en_VG.res
-+		${OUT_DIR}/unit/en_VU.res
-+		${OUT_DIR}/unit/en_WS.res
-+		${OUT_DIR}/unit/en_ZA.res
-+		${OUT_DIR}/unit/en_ZM.res
-+		${OUT_DIR}/unit/en_ZW.res
-+		${OUT_DIR}/unit/eo.res
-+		${OUT_DIR}/unit/es.res
-+		${OUT_DIR}/unit/es_419.res
-+		${OUT_DIR}/unit/es_AR.res
-+		${OUT_DIR}/unit/es_BO.res
-+		${OUT_DIR}/unit/es_BR.res
-+		${OUT_DIR}/unit/es_BZ.res
-+		${OUT_DIR}/unit/es_CL.res
-+		${OUT_DIR}/unit/es_CO.res
-+		${OUT_DIR}/unit/es_CR.res
-+		${OUT_DIR}/unit/es_CU.res
-+		${OUT_DIR}/unit/es_DO.res
-+		${OUT_DIR}/unit/es_EC.res
-+		${OUT_DIR}/unit/es_GT.res
-+		${OUT_DIR}/unit/es_HN.res
-+		${OUT_DIR}/unit/es_MX.res
-+		${OUT_DIR}/unit/es_NI.res
-+		${OUT_DIR}/unit/es_PA.res
-+		${OUT_DIR}/unit/es_PE.res
-+		${OUT_DIR}/unit/es_PR.res
-+		${OUT_DIR}/unit/es_PY.res
-+		${OUT_DIR}/unit/es_SV.res
-+		${OUT_DIR}/unit/es_US.res
-+		${OUT_DIR}/unit/es_UY.res
-+		${OUT_DIR}/unit/es_VE.res
-+		${OUT_DIR}/unit/et.res
-+		${OUT_DIR}/unit/eu.res
-+		${OUT_DIR}/unit/ewo.res
-+		${OUT_DIR}/unit/fa.res
-+		${OUT_DIR}/unit/ff.res
-+		${OUT_DIR}/unit/ff_Adlm.res
-+		${OUT_DIR}/unit/ff_CM.res
-+		${OUT_DIR}/unit/ff_GN.res
-+		${OUT_DIR}/unit/ff_Latn.res
-+		${OUT_DIR}/unit/ff_Latn_CM.res
-+		${OUT_DIR}/unit/ff_Latn_GN.res
-+		${OUT_DIR}/unit/ff_Latn_MR.res
-+		${OUT_DIR}/unit/ff_Latn_SN.res
-+		${OUT_DIR}/unit/ff_MR.res
-+		${OUT_DIR}/unit/ff_SN.res
-+		${OUT_DIR}/unit/fi.res
-+		${OUT_DIR}/unit/fil.res
-+		${OUT_DIR}/unit/fil_PH.res
-+		${OUT_DIR}/unit/fo.res
-+		${OUT_DIR}/unit/fr.res
-+		${OUT_DIR}/unit/fr_CA.res
-+		${OUT_DIR}/unit/fr_HT.res
-+		${OUT_DIR}/unit/fur.res
-+		${OUT_DIR}/unit/fy.res
-+		${OUT_DIR}/unit/ga.res
-+		${OUT_DIR}/unit/gd.res
-+		${OUT_DIR}/unit/gl.res
-+		${OUT_DIR}/unit/gsw.res
-+		${OUT_DIR}/unit/gu.res
-+		${OUT_DIR}/unit/guz.res
-+		${OUT_DIR}/unit/gv.res
-+		${OUT_DIR}/unit/ha.res
-+		${OUT_DIR}/unit/haw.res
-+		${OUT_DIR}/unit/he.res
-+		${OUT_DIR}/unit/he_IL.res
-+		${OUT_DIR}/unit/hi.res
-+		${OUT_DIR}/unit/hr.res
-+		${OUT_DIR}/unit/hsb.res
-+		${OUT_DIR}/unit/hu.res
-+		${OUT_DIR}/unit/hy.res
-+		${OUT_DIR}/unit/ia.res
-+		${OUT_DIR}/unit/id.res
-+		${OUT_DIR}/unit/id_ID.res
-+		${OUT_DIR}/unit/ig.res
-+		${OUT_DIR}/unit/ii.res
-+		${OUT_DIR}/unit/in.res
-+		${OUT_DIR}/unit/in_ID.res
-+		${OUT_DIR}/unit/is.res
-+		${OUT_DIR}/unit/it.res
-+		${OUT_DIR}/unit/iw.res
-+		${OUT_DIR}/unit/iw_IL.res
-+		${OUT_DIR}/unit/ja.res
-+		${OUT_DIR}/unit/jgo.res
-+		${OUT_DIR}/unit/jmc.res
-+		${OUT_DIR}/unit/jv.res
-+		${OUT_DIR}/unit/ka.res
-+		${OUT_DIR}/unit/kab.res
-+		${OUT_DIR}/unit/kam.res
-+		${OUT_DIR}/unit/kde.res
-+		${OUT_DIR}/unit/kea.res
-+		${OUT_DIR}/unit/khq.res
-+		${OUT_DIR}/unit/ki.res
-+		${OUT_DIR}/unit/kk.res
-+		${OUT_DIR}/unit/kkj.res
-+		${OUT_DIR}/unit/kl.res
-+		${OUT_DIR}/unit/kln.res
-+		${OUT_DIR}/unit/km.res
-+		${OUT_DIR}/unit/kn.res
-+		${OUT_DIR}/unit/ko.res
-+		${OUT_DIR}/unit/kok.res
-+		${OUT_DIR}/unit/ks.res
-+		${OUT_DIR}/unit/ks_Arab.res
-+		${OUT_DIR}/unit/ks_Arab_IN.res
-+		${OUT_DIR}/unit/ks_IN.res
-+		${OUT_DIR}/unit/ksb.res
-+		${OUT_DIR}/unit/ksf.res
-+		${OUT_DIR}/unit/ksh.res
-+		${OUT_DIR}/unit/ku.res
-+		${OUT_DIR}/unit/kw.res
-+		${OUT_DIR}/unit/ky.res
-+		${OUT_DIR}/unit/lag.res
-+		${OUT_DIR}/unit/lb.res
-+		${OUT_DIR}/unit/lg.res
-+		${OUT_DIR}/unit/lkt.res
-+		${OUT_DIR}/unit/ln.res
-+		${OUT_DIR}/unit/lo.res
-+		${OUT_DIR}/unit/lrc.res
-+		${OUT_DIR}/unit/lt.res
-+		${OUT_DIR}/unit/lu.res
-+		${OUT_DIR}/unit/luo.res
-+		${OUT_DIR}/unit/luy.res
-+		${OUT_DIR}/unit/lv.res
-+		${OUT_DIR}/unit/mai.res
-+		${OUT_DIR}/unit/mas.res
-+		${OUT_DIR}/unit/mer.res
-+		${OUT_DIR}/unit/mfe.res
-+		${OUT_DIR}/unit/mg.res
-+		${OUT_DIR}/unit/mgh.res
-+		${OUT_DIR}/unit/mgo.res
-+		${OUT_DIR}/unit/mi.res
-+		${OUT_DIR}/unit/mk.res
-+		${OUT_DIR}/unit/ml.res
-+		${OUT_DIR}/unit/mn.res
-+		${OUT_DIR}/unit/mni.res
-+		${OUT_DIR}/unit/mni_Beng.res
-+		${OUT_DIR}/unit/mni_Beng_IN.res
-+		${OUT_DIR}/unit/mni_IN.res
-+		${OUT_DIR}/unit/mo.res
-+		${OUT_DIR}/unit/mr.res
-+		${OUT_DIR}/unit/ms.res
-+		${OUT_DIR}/unit/mt.res
-+		${OUT_DIR}/unit/mua.res
-+		${OUT_DIR}/unit/my.res
-+		${OUT_DIR}/unit/mzn.res
-+		${OUT_DIR}/unit/naq.res
-+		${OUT_DIR}/unit/nb.res
-+		${OUT_DIR}/unit/nb_NO.res
-+		${OUT_DIR}/unit/nd.res
-+		${OUT_DIR}/unit/nds.res
-+		${OUT_DIR}/unit/ne.res
-+		${OUT_DIR}/unit/nl.res
-+		${OUT_DIR}/unit/nmg.res
-+		${OUT_DIR}/unit/nn.res
-+		${OUT_DIR}/unit/nn_NO.res
-+		${OUT_DIR}/unit/nnh.res
-+		${OUT_DIR}/unit/no.res
-+		${OUT_DIR}/unit/no_NO.res
-+		${OUT_DIR}/unit/no_NO_NY.res
-+		${OUT_DIR}/unit/nus.res
-+		${OUT_DIR}/unit/nyn.res
-+		${OUT_DIR}/unit/om.res
-+		${OUT_DIR}/unit/or.res
-+		${OUT_DIR}/unit/os.res
-+		${OUT_DIR}/unit/pa.res
-+		${OUT_DIR}/unit/pa_Arab.res
-+		${OUT_DIR}/unit/pa_Arab_PK.res
-+		${OUT_DIR}/unit/pa_Guru.res
-+		${OUT_DIR}/unit/pa_Guru_IN.res
-+		${OUT_DIR}/unit/pa_IN.res
-+		${OUT_DIR}/unit/pa_PK.res
-+		${OUT_DIR}/unit/pcm.res
-+		${OUT_DIR}/unit/pl.res
-+		${OUT_DIR}/unit/pool.res
-+		${OUT_DIR}/unit/ps.res
-+		${OUT_DIR}/unit/ps_PK.res
-+		${OUT_DIR}/unit/pt.res
-+		${OUT_DIR}/unit/pt_AO.res
-+		${OUT_DIR}/unit/pt_CH.res
-+		${OUT_DIR}/unit/pt_CV.res
-+		${OUT_DIR}/unit/pt_GQ.res
-+		${OUT_DIR}/unit/pt_GW.res
-+		${OUT_DIR}/unit/pt_LU.res
-+		${OUT_DIR}/unit/pt_MO.res
-+		${OUT_DIR}/unit/pt_MZ.res
-+		${OUT_DIR}/unit/pt_PT.res
-+		${OUT_DIR}/unit/pt_ST.res
-+		${OUT_DIR}/unit/pt_TL.res
-+		${OUT_DIR}/unit/qu.res
-+		${OUT_DIR}/unit/rm.res
-+		${OUT_DIR}/unit/rn.res
-+		${OUT_DIR}/unit/ro.res
-+		${OUT_DIR}/unit/ro_MD.res
-+		${OUT_DIR}/unit/rof.res
-+		${OUT_DIR}/unit/root.res
-+		${OUT_DIR}/unit/ru.res
-+		${OUT_DIR}/unit/rw.res
-+		${OUT_DIR}/unit/rwk.res
-+		${OUT_DIR}/unit/sah.res
-+		${OUT_DIR}/unit/saq.res
-+		${OUT_DIR}/unit/sat.res
-+		${OUT_DIR}/unit/sat_IN.res
-+		${OUT_DIR}/unit/sat_Olck.res
-+		${OUT_DIR}/unit/sat_Olck_IN.res
-+		${OUT_DIR}/unit/sbp.res
-+		${OUT_DIR}/unit/sd.res
-+		${OUT_DIR}/unit/sd_Arab.res
-+		${OUT_DIR}/unit/sd_Arab_PK.res
-+		${OUT_DIR}/unit/sd_Deva.res
-+		${OUT_DIR}/unit/sd_PK.res
-+		${OUT_DIR}/unit/se.res
-+		${OUT_DIR}/unit/seh.res
-+		${OUT_DIR}/unit/ses.res
-+		${OUT_DIR}/unit/sg.res
-+		${OUT_DIR}/unit/sh.res
-+		${OUT_DIR}/unit/sh_BA.res
-+		${OUT_DIR}/unit/sh_CS.res
-+		${OUT_DIR}/unit/sh_YU.res
-+		${OUT_DIR}/unit/shi.res
-+		${OUT_DIR}/unit/shi_Latn.res
-+		${OUT_DIR}/unit/shi_MA.res
-+		${OUT_DIR}/unit/shi_Tfng.res
-+		${OUT_DIR}/unit/shi_Tfng_MA.res
-+		${OUT_DIR}/unit/si.res
-+		${OUT_DIR}/unit/sk.res
-+		${OUT_DIR}/unit/sl.res
-+		${OUT_DIR}/unit/smn.res
-+		${OUT_DIR}/unit/sn.res
-+		${OUT_DIR}/unit/so.res
-+		${OUT_DIR}/unit/sq.res
-+		${OUT_DIR}/unit/sr.res
-+		${OUT_DIR}/unit/sr_BA.res
-+		${OUT_DIR}/unit/sr_CS.res
-+		${OUT_DIR}/unit/sr_Cyrl.res
-+		${OUT_DIR}/unit/sr_Cyrl_BA.res
-+		${OUT_DIR}/unit/sr_Cyrl_CS.res
-+		${OUT_DIR}/unit/sr_Cyrl_RS.res
-+		${OUT_DIR}/unit/sr_Cyrl_XK.res
-+		${OUT_DIR}/unit/sr_Cyrl_YU.res
-+		${OUT_DIR}/unit/sr_Latn.res
-+		${OUT_DIR}/unit/sr_Latn_BA.res
-+		${OUT_DIR}/unit/sr_Latn_CS.res
-+		${OUT_DIR}/unit/sr_Latn_ME.res
-+		${OUT_DIR}/unit/sr_Latn_RS.res
-+		${OUT_DIR}/unit/sr_Latn_YU.res
-+		${OUT_DIR}/unit/sr_ME.res
-+		${OUT_DIR}/unit/sr_RS.res
-+		${OUT_DIR}/unit/sr_XK.res
-+		${OUT_DIR}/unit/sr_YU.res
-+		${OUT_DIR}/unit/su.res
-+		${OUT_DIR}/unit/su_ID.res
-+		${OUT_DIR}/unit/su_Latn.res
-+		${OUT_DIR}/unit/su_Latn_ID.res
-+		${OUT_DIR}/unit/sv.res
-+		${OUT_DIR}/unit/sv_FI.res
-+		${OUT_DIR}/unit/sw.res
-+		${OUT_DIR}/unit/sw_KE.res
-+		${OUT_DIR}/unit/ta.res
-+		${OUT_DIR}/unit/te.res
-+		${OUT_DIR}/unit/teo.res
-+		${OUT_DIR}/unit/tg.res
-+		${OUT_DIR}/unit/th.res
-+		${OUT_DIR}/unit/ti.res
-+		${OUT_DIR}/unit/tk.res
-+		${OUT_DIR}/unit/tl.res
-+		${OUT_DIR}/unit/tl_PH.res
-+		${OUT_DIR}/unit/to.res
-+		${OUT_DIR}/unit/tr.res
-+		${OUT_DIR}/unit/tt.res
-+		${OUT_DIR}/unit/twq.res
-+		${OUT_DIR}/unit/tzm.res
-+		${OUT_DIR}/unit/ug.res
-+		${OUT_DIR}/unit/uk.res
-+		${OUT_DIR}/unit/ur.res
-+		${OUT_DIR}/unit/ur_IN.res
-+		${OUT_DIR}/unit/uz.res
-+		${OUT_DIR}/unit/uz_AF.res
-+		${OUT_DIR}/unit/uz_Arab.res
-+		${OUT_DIR}/unit/uz_Arab_AF.res
-+		${OUT_DIR}/unit/uz_Cyrl.res
-+		${OUT_DIR}/unit/uz_Latn.res
-+		${OUT_DIR}/unit/uz_Latn_UZ.res
-+		${OUT_DIR}/unit/uz_UZ.res
-+		${OUT_DIR}/unit/vai.res
-+		${OUT_DIR}/unit/vai_LR.res
-+		${OUT_DIR}/unit/vai_Latn.res
-+		${OUT_DIR}/unit/vai_Vaii.res
-+		${OUT_DIR}/unit/vai_Vaii_LR.res
-+		${OUT_DIR}/unit/vi.res
-+		${OUT_DIR}/unit/vun.res
-+		${OUT_DIR}/unit/wae.res
-+		${OUT_DIR}/unit/wo.res
-+		${OUT_DIR}/unit/xh.res
-+		${OUT_DIR}/unit/xog.res
-+		${OUT_DIR}/unit/yav.res
-+		${OUT_DIR}/unit/yi.res
-+		${OUT_DIR}/unit/yo.res
-+		${OUT_DIR}/unit/yo_BJ.res
-+		${OUT_DIR}/unit/yue.res
-+		${OUT_DIR}/unit/yue_CN.res
-+		${OUT_DIR}/unit/yue_HK.res
-+		${OUT_DIR}/unit/yue_Hans.res
-+		${OUT_DIR}/unit/yue_Hans_CN.res
-+		${OUT_DIR}/unit/yue_Hant.res
-+		${OUT_DIR}/unit/yue_Hant_HK.res
-+		${OUT_DIR}/unit/zgh.res
-+		${OUT_DIR}/unit/zh.res
-+		${OUT_DIR}/unit/zh_CN.res
-+		${OUT_DIR}/unit/zh_HK.res
-+		${OUT_DIR}/unit/zh_Hans.res
-+		${OUT_DIR}/unit/zh_Hans_CN.res
-+		${OUT_DIR}/unit/zh_Hans_HK.res
-+		${OUT_DIR}/unit/zh_Hans_MO.res
-+		${OUT_DIR}/unit/zh_Hans_SG.res
-+		${OUT_DIR}/unit/zh_Hant.res
-+		${OUT_DIR}/unit/zh_Hant_HK.res
-+		${OUT_DIR}/unit/zh_Hant_MO.res
-+		${OUT_DIR}/unit/zh_Hant_TW.res
-+		${OUT_DIR}/unit/zh_MO.res
-+		${OUT_DIR}/unit/zh_SG.res
-+		${OUT_DIR}/unit/zh_TW.res
-+		${OUT_DIR}/unit/zu.res
-+		${OUT_DIR}/ur.res
-+		${OUT_DIR}/ur_IN.res
-+		${OUT_DIR}/ur_PK.res
-+		${OUT_DIR}/uts46.nrm
-+		${OUT_DIR}/uz.res
-+		${OUT_DIR}/uz_AF.res
-+		${OUT_DIR}/uz_Arab.res
-+		${OUT_DIR}/uz_Arab_AF.res
-+		${OUT_DIR}/uz_Cyrl.res
-+		${OUT_DIR}/uz_Cyrl_UZ.res
-+		${OUT_DIR}/uz_Latn.res
-+		${OUT_DIR}/uz_Latn_UZ.res
-+		${OUT_DIR}/uz_UZ.res
-+		${OUT_DIR}/vai.res
-+		${OUT_DIR}/vai_LR.res
-+		${OUT_DIR}/vai_Latn.res
-+		${OUT_DIR}/vai_Latn_LR.res
-+		${OUT_DIR}/vai_Vaii.res
-+		${OUT_DIR}/vai_Vaii_LR.res
-+		${OUT_DIR}/vi.res
-+		${OUT_DIR}/vi_VN.res
-+		${OUT_DIR}/vun.res
-+		${OUT_DIR}/vun_TZ.res
-+		${OUT_DIR}/wae.res
-+		${OUT_DIR}/wae_CH.res
-+		${OUT_DIR}/windows-874-2000.cnv
-+		${OUT_DIR}/windows-936-2000.cnv
-+		${OUT_DIR}/windows-949-2000.cnv
-+		${OUT_DIR}/windows-950-2000.cnv
-+		${OUT_DIR}/windowsZones.res
-+		${OUT_DIR}/wo.res
-+		${OUT_DIR}/wo_SN.res
-+		${OUT_DIR}/xh.res
-+		${OUT_DIR}/xh_ZA.res
-+		${OUT_DIR}/xog.res
-+		${OUT_DIR}/xog_UG.res
-+		${OUT_DIR}/yav.res
-+		${OUT_DIR}/yav_CM.res
-+		${OUT_DIR}/yi.res
-+		${OUT_DIR}/yi_001.res
-+		${OUT_DIR}/yo.res
-+		${OUT_DIR}/yo_BJ.res
-+		${OUT_DIR}/yo_NG.res
-+		${OUT_DIR}/yue.res
-+		${OUT_DIR}/yue_CN.res
-+		${OUT_DIR}/yue_HK.res
-+		${OUT_DIR}/yue_Hans.res
-+		${OUT_DIR}/yue_Hans_CN.res
-+		${OUT_DIR}/yue_Hant.res
-+		${OUT_DIR}/yue_Hant_HK.res
-+		${OUT_DIR}/zgh.res
-+		${OUT_DIR}/zgh_MA.res
-+		${OUT_DIR}/zh.res
-+		${OUT_DIR}/zh_CN.res
-+		${OUT_DIR}/zh_HK.res
-+		${OUT_DIR}/zh_Hans.res
-+		${OUT_DIR}/zh_Hans_CN.res
-+		${OUT_DIR}/zh_Hans_HK.res
-+		${OUT_DIR}/zh_Hans_MO.res
-+		${OUT_DIR}/zh_Hans_SG.res
-+		${OUT_DIR}/zh_Hant.res
-+		${OUT_DIR}/zh_Hant_HK.res
-+		${OUT_DIR}/zh_Hant_MO.res
-+		${OUT_DIR}/zh_Hant_TW.res
-+		${OUT_DIR}/zh_MO.res
-+		${OUT_DIR}/zh_SG.res
-+		${OUT_DIR}/zh_TW.res
-+		${OUT_DIR}/zone/${INDEX_NAME}.res
-+		${OUT_DIR}/zone/af.res
-+		${OUT_DIR}/zone/agq.res
-+		${OUT_DIR}/zone/ak.res
-+		${OUT_DIR}/zone/am.res
-+		${OUT_DIR}/zone/ar.res
-+		${OUT_DIR}/zone/ar_SA.res
-+		${OUT_DIR}/zone/ars.res
-+		${OUT_DIR}/zone/as.res
-+		${OUT_DIR}/zone/asa.res
-+		${OUT_DIR}/zone/ast.res
-+		${OUT_DIR}/zone/az.res
-+		${OUT_DIR}/zone/az_AZ.res
-+		${OUT_DIR}/zone/az_Cyrl.res
-+		${OUT_DIR}/zone/az_Latn.res
-+		${OUT_DIR}/zone/az_Latn_AZ.res
-+		${OUT_DIR}/zone/bas.res
-+		${OUT_DIR}/zone/be.res
-+		${OUT_DIR}/zone/bem.res
-+		${OUT_DIR}/zone/bez.res
-+		${OUT_DIR}/zone/bg.res
-+		${OUT_DIR}/zone/bm.res
-+		${OUT_DIR}/zone/bn.res
-+		${OUT_DIR}/zone/bo.res
-+		${OUT_DIR}/zone/br.res
-+		${OUT_DIR}/zone/brx.res
-+		${OUT_DIR}/zone/bs.res
-+		${OUT_DIR}/zone/bs_BA.res
-+		${OUT_DIR}/zone/bs_Cyrl.res
-+		${OUT_DIR}/zone/bs_Latn.res
-+		${OUT_DIR}/zone/bs_Latn_BA.res
-+		${OUT_DIR}/zone/ca.res
-+		${OUT_DIR}/zone/ccp.res
-+		${OUT_DIR}/zone/ce.res
-+		${OUT_DIR}/zone/ceb.res
-+		${OUT_DIR}/zone/cgg.res
-+		${OUT_DIR}/zone/chr.res
-+		${OUT_DIR}/zone/ckb.res
-+		${OUT_DIR}/zone/cs.res
-+		${OUT_DIR}/zone/cy.res
-+		${OUT_DIR}/zone/da.res
-+		${OUT_DIR}/zone/dav.res
-+		${OUT_DIR}/zone/de.res
-+		${OUT_DIR}/zone/de_CH.res
-+		${OUT_DIR}/zone/dje.res
-+		${OUT_DIR}/zone/dsb.res
-+		${OUT_DIR}/zone/dua.res
-+		${OUT_DIR}/zone/dyo.res
-+		${OUT_DIR}/zone/dz.res
-+		${OUT_DIR}/zone/ebu.res
-+		${OUT_DIR}/zone/ee.res
-+		${OUT_DIR}/zone/el.res
-+		${OUT_DIR}/zone/en.res
-+		${OUT_DIR}/zone/en_001.res
-+		${OUT_DIR}/zone/en_150.res
-+		${OUT_DIR}/zone/en_AE.res
-+		${OUT_DIR}/zone/en_AG.res
-+		${OUT_DIR}/zone/en_AI.res
-+		${OUT_DIR}/zone/en_AT.res
-+		${OUT_DIR}/zone/en_AU.res
-+		${OUT_DIR}/zone/en_BB.res
-+		${OUT_DIR}/zone/en_BE.res
-+		${OUT_DIR}/zone/en_BM.res
-+		${OUT_DIR}/zone/en_BS.res
-+		${OUT_DIR}/zone/en_BW.res
-+		${OUT_DIR}/zone/en_BZ.res
-+		${OUT_DIR}/zone/en_CA.res
-+		${OUT_DIR}/zone/en_CC.res
-+		${OUT_DIR}/zone/en_CH.res
-+		${OUT_DIR}/zone/en_CK.res
-+		${OUT_DIR}/zone/en_CM.res
-+		${OUT_DIR}/zone/en_CX.res
-+		${OUT_DIR}/zone/en_CY.res
-+		${OUT_DIR}/zone/en_DE.res
-+		${OUT_DIR}/zone/en_DG.res
-+		${OUT_DIR}/zone/en_DK.res
-+		${OUT_DIR}/zone/en_DM.res
-+		${OUT_DIR}/zone/en_ER.res
-+		${OUT_DIR}/zone/en_FI.res
-+		${OUT_DIR}/zone/en_FJ.res
-+		${OUT_DIR}/zone/en_FK.res
-+		${OUT_DIR}/zone/en_FM.res
-+		${OUT_DIR}/zone/en_GB.res
-+		${OUT_DIR}/zone/en_GD.res
-+		${OUT_DIR}/zone/en_GG.res
-+		${OUT_DIR}/zone/en_GH.res
-+		${OUT_DIR}/zone/en_GI.res
-+		${OUT_DIR}/zone/en_GM.res
-+		${OUT_DIR}/zone/en_GU.res
-+		${OUT_DIR}/zone/en_GY.res
-+		${OUT_DIR}/zone/en_HK.res
-+		${OUT_DIR}/zone/en_IE.res
-+		${OUT_DIR}/zone/en_IL.res
-+		${OUT_DIR}/zone/en_IM.res
-+		${OUT_DIR}/zone/en_IN.res
-+		${OUT_DIR}/zone/en_IO.res
-+		${OUT_DIR}/zone/en_JE.res
-+		${OUT_DIR}/zone/en_JM.res
-+		${OUT_DIR}/zone/en_KE.res
-+		${OUT_DIR}/zone/en_KI.res
-+		${OUT_DIR}/zone/en_KN.res
-+		${OUT_DIR}/zone/en_KY.res
-+		${OUT_DIR}/zone/en_LC.res
-+		${OUT_DIR}/zone/en_LR.res
-+		${OUT_DIR}/zone/en_LS.res
-+		${OUT_DIR}/zone/en_MG.res
-+		${OUT_DIR}/zone/en_MH.res
-+		${OUT_DIR}/zone/en_MO.res
-+		${OUT_DIR}/zone/en_MP.res
-+		${OUT_DIR}/zone/en_MS.res
-+		${OUT_DIR}/zone/en_MT.res
-+		${OUT_DIR}/zone/en_MU.res
-+		${OUT_DIR}/zone/en_MW.res
-+		${OUT_DIR}/zone/en_MY.res
-+		${OUT_DIR}/zone/en_NA.res
-+		${OUT_DIR}/zone/en_NF.res
-+		${OUT_DIR}/zone/en_NG.res
-+		${OUT_DIR}/zone/en_NH.res
-+		${OUT_DIR}/zone/en_NL.res
-+		${OUT_DIR}/zone/en_NR.res
-+		${OUT_DIR}/zone/en_NU.res
-+		${OUT_DIR}/zone/en_NZ.res
-+		${OUT_DIR}/zone/en_PG.res
-+		${OUT_DIR}/zone/en_PH.res
-+		${OUT_DIR}/zone/en_PK.res
-+		${OUT_DIR}/zone/en_PN.res
-+		${OUT_DIR}/zone/en_PW.res
-+		${OUT_DIR}/zone/en_RH.res
-+		${OUT_DIR}/zone/en_RW.res
-+		${OUT_DIR}/zone/en_SB.res
-+		${OUT_DIR}/zone/en_SC.res
-+		${OUT_DIR}/zone/en_SD.res
-+		${OUT_DIR}/zone/en_SE.res
-+		${OUT_DIR}/zone/en_SG.res
-+		${OUT_DIR}/zone/en_SH.res
-+		${OUT_DIR}/zone/en_SI.res
-+		${OUT_DIR}/zone/en_SL.res
-+		${OUT_DIR}/zone/en_SS.res
-+		${OUT_DIR}/zone/en_SX.res
-+		${OUT_DIR}/zone/en_SZ.res
-+		${OUT_DIR}/zone/en_TC.res
-+		${OUT_DIR}/zone/en_TK.res
-+		${OUT_DIR}/zone/en_TO.res
-+		${OUT_DIR}/zone/en_TT.res
-+		${OUT_DIR}/zone/en_TV.res
-+		${OUT_DIR}/zone/en_TZ.res
-+		${OUT_DIR}/zone/en_UG.res
-+		${OUT_DIR}/zone/en_VC.res
-+		${OUT_DIR}/zone/en_VG.res
-+		${OUT_DIR}/zone/en_VU.res
-+		${OUT_DIR}/zone/en_WS.res
-+		${OUT_DIR}/zone/en_ZA.res
-+		${OUT_DIR}/zone/en_ZM.res
-+		${OUT_DIR}/zone/en_ZW.res
-+		${OUT_DIR}/zone/eo.res
-+		${OUT_DIR}/zone/es.res
-+		${OUT_DIR}/zone/es_419.res
-+		${OUT_DIR}/zone/es_AR.res
-+		${OUT_DIR}/zone/es_BO.res
-+		${OUT_DIR}/zone/es_BR.res
-+		${OUT_DIR}/zone/es_BZ.res
-+		${OUT_DIR}/zone/es_CL.res
-+		${OUT_DIR}/zone/es_CO.res
-+		${OUT_DIR}/zone/es_CR.res
-+		${OUT_DIR}/zone/es_CU.res
-+		${OUT_DIR}/zone/es_DO.res
-+		${OUT_DIR}/zone/es_EC.res
-+		${OUT_DIR}/zone/es_GT.res
-+		${OUT_DIR}/zone/es_HN.res
-+		${OUT_DIR}/zone/es_MX.res
-+		${OUT_DIR}/zone/es_NI.res
-+		${OUT_DIR}/zone/es_PA.res
-+		${OUT_DIR}/zone/es_PE.res
-+		${OUT_DIR}/zone/es_PR.res
-+		${OUT_DIR}/zone/es_PY.res
-+		${OUT_DIR}/zone/es_SV.res
-+		${OUT_DIR}/zone/es_US.res
-+		${OUT_DIR}/zone/es_UY.res
-+		${OUT_DIR}/zone/es_VE.res
-+		${OUT_DIR}/zone/et.res
-+		${OUT_DIR}/zone/eu.res
-+		${OUT_DIR}/zone/ewo.res
-+		${OUT_DIR}/zone/fa.res
-+		${OUT_DIR}/zone/ff.res
-+		${OUT_DIR}/zone/ff_Adlm.res
-+		${OUT_DIR}/zone/ff_CM.res
-+		${OUT_DIR}/zone/ff_GN.res
-+		${OUT_DIR}/zone/ff_Latn.res
-+		${OUT_DIR}/zone/ff_Latn_CM.res
-+		${OUT_DIR}/zone/ff_Latn_GN.res
-+		${OUT_DIR}/zone/ff_Latn_MR.res
-+		${OUT_DIR}/zone/ff_Latn_SN.res
-+		${OUT_DIR}/zone/ff_MR.res
-+		${OUT_DIR}/zone/ff_SN.res
-+		${OUT_DIR}/zone/fi.res
-+		${OUT_DIR}/zone/fil.res
-+		${OUT_DIR}/zone/fil_PH.res
-+		${OUT_DIR}/zone/fo.res
-+		${OUT_DIR}/zone/fr.res
-+		${OUT_DIR}/zone/fr_CA.res
-+		${OUT_DIR}/zone/fr_GF.res
-+		${OUT_DIR}/zone/fur.res
-+		${OUT_DIR}/zone/fy.res
-+		${OUT_DIR}/zone/ga.res
-+		${OUT_DIR}/zone/gd.res
-+		${OUT_DIR}/zone/gl.res
-+		${OUT_DIR}/zone/gsw.res
-+		${OUT_DIR}/zone/gu.res
-+		${OUT_DIR}/zone/guz.res
-+		${OUT_DIR}/zone/gv.res
-+		${OUT_DIR}/zone/ha.res
-+		${OUT_DIR}/zone/haw.res
-+		${OUT_DIR}/zone/he.res
-+		${OUT_DIR}/zone/he_IL.res
-+		${OUT_DIR}/zone/hi.res
-+		${OUT_DIR}/zone/hr.res
-+		${OUT_DIR}/zone/hsb.res
-+		${OUT_DIR}/zone/hu.res
-+		${OUT_DIR}/zone/hy.res
-+		${OUT_DIR}/zone/ia.res
-+		${OUT_DIR}/zone/id.res
-+		${OUT_DIR}/zone/id_ID.res
-+		${OUT_DIR}/zone/ig.res
-+		${OUT_DIR}/zone/ii.res
-+		${OUT_DIR}/zone/in.res
-+		${OUT_DIR}/zone/in_ID.res
-+		${OUT_DIR}/zone/is.res
-+		${OUT_DIR}/zone/it.res
-+		${OUT_DIR}/zone/iw.res
-+		${OUT_DIR}/zone/iw_IL.res
-+		${OUT_DIR}/zone/ja.res
-+		${OUT_DIR}/zone/jgo.res
-+		${OUT_DIR}/zone/jmc.res
-+		${OUT_DIR}/zone/jv.res
-+		${OUT_DIR}/zone/ka.res
-+		${OUT_DIR}/zone/kab.res
-+		${OUT_DIR}/zone/kam.res
-+		${OUT_DIR}/zone/kde.res
-+		${OUT_DIR}/zone/kea.res
-+		${OUT_DIR}/zone/khq.res
-+		${OUT_DIR}/zone/ki.res
-+		${OUT_DIR}/zone/kk.res
-+		${OUT_DIR}/zone/kkj.res
-+		${OUT_DIR}/zone/kl.res
-+		${OUT_DIR}/zone/kln.res
-+		${OUT_DIR}/zone/km.res
-+		${OUT_DIR}/zone/kn.res
-+		${OUT_DIR}/zone/ko.res
-+		${OUT_DIR}/zone/ko_KP.res
-+		${OUT_DIR}/zone/kok.res
-+		${OUT_DIR}/zone/ks.res
-+		${OUT_DIR}/zone/ks_Arab.res
-+		${OUT_DIR}/zone/ks_Arab_IN.res
-+		${OUT_DIR}/zone/ks_IN.res
-+		${OUT_DIR}/zone/ksb.res
-+		${OUT_DIR}/zone/ksf.res
-+		${OUT_DIR}/zone/ksh.res
-+		${OUT_DIR}/zone/ku.res
-+		${OUT_DIR}/zone/kw.res
-+		${OUT_DIR}/zone/ky.res
-+		${OUT_DIR}/zone/lag.res
-+		${OUT_DIR}/zone/lb.res
-+		${OUT_DIR}/zone/lg.res
-+		${OUT_DIR}/zone/lkt.res
-+		${OUT_DIR}/zone/ln.res
-+		${OUT_DIR}/zone/lo.res
-+		${OUT_DIR}/zone/lrc.res
-+		${OUT_DIR}/zone/lt.res
-+		${OUT_DIR}/zone/lu.res
-+		${OUT_DIR}/zone/luo.res
-+		${OUT_DIR}/zone/luy.res
-+		${OUT_DIR}/zone/lv.res
-+		${OUT_DIR}/zone/mai.res
-+		${OUT_DIR}/zone/mas.res
-+		${OUT_DIR}/zone/mer.res
-+		${OUT_DIR}/zone/mfe.res
-+		${OUT_DIR}/zone/mg.res
-+		${OUT_DIR}/zone/mgh.res
-+		${OUT_DIR}/zone/mgo.res
-+		${OUT_DIR}/zone/mi.res
-+		${OUT_DIR}/zone/mk.res
-+		${OUT_DIR}/zone/ml.res
-+		${OUT_DIR}/zone/mn.res
-+		${OUT_DIR}/zone/mni.res
-+		${OUT_DIR}/zone/mni_Beng.res
-+		${OUT_DIR}/zone/mni_Beng_IN.res
-+		${OUT_DIR}/zone/mni_IN.res
-+		${OUT_DIR}/zone/mo.res
-+		${OUT_DIR}/zone/mr.res
-+		${OUT_DIR}/zone/ms.res
-+		${OUT_DIR}/zone/ms_ID.res
-+		${OUT_DIR}/zone/mt.res
-+		${OUT_DIR}/zone/mua.res
-+		${OUT_DIR}/zone/my.res
-+		${OUT_DIR}/zone/mzn.res
-+		${OUT_DIR}/zone/naq.res
-+		${OUT_DIR}/zone/nb.res
-+		${OUT_DIR}/zone/nb_NO.res
-+		${OUT_DIR}/zone/nd.res
-+		${OUT_DIR}/zone/nds.res
-+		${OUT_DIR}/zone/ne.res
-+		${OUT_DIR}/zone/ne_IN.res
-+		${OUT_DIR}/zone/nl.res
-+		${OUT_DIR}/zone/nl_SR.res
-+		${OUT_DIR}/zone/nmg.res
-+		${OUT_DIR}/zone/nn.res
-+		${OUT_DIR}/zone/nn_NO.res
-+		${OUT_DIR}/zone/nnh.res
-+		${OUT_DIR}/zone/no.res
-+		${OUT_DIR}/zone/no_NO.res
-+		${OUT_DIR}/zone/no_NO_NY.res
-+		${OUT_DIR}/zone/nus.res
-+		${OUT_DIR}/zone/nyn.res
-+		${OUT_DIR}/zone/om.res
-+		${OUT_DIR}/zone/or.res
-+		${OUT_DIR}/zone/os.res
-+		${OUT_DIR}/zone/pa.res
-+		${OUT_DIR}/zone/pa_Arab.res
-+		${OUT_DIR}/zone/pa_Arab_PK.res
-+		${OUT_DIR}/zone/pa_Guru.res
-+		${OUT_DIR}/zone/pa_Guru_IN.res
-+		${OUT_DIR}/zone/pa_IN.res
-+		${OUT_DIR}/zone/pa_PK.res
-+		${OUT_DIR}/zone/pcm.res
-+		${OUT_DIR}/zone/pl.res
-+		${OUT_DIR}/zone/pool.res
-+		${OUT_DIR}/zone/ps.res
-+		${OUT_DIR}/zone/ps_PK.res
-+		${OUT_DIR}/zone/pt.res
-+		${OUT_DIR}/zone/pt_AO.res
-+		${OUT_DIR}/zone/pt_CH.res
-+		${OUT_DIR}/zone/pt_CV.res
-+		${OUT_DIR}/zone/pt_GQ.res
-+		${OUT_DIR}/zone/pt_GW.res
-+		${OUT_DIR}/zone/pt_LU.res
-+		${OUT_DIR}/zone/pt_MO.res
-+		${OUT_DIR}/zone/pt_MZ.res
-+		${OUT_DIR}/zone/pt_PT.res
-+		${OUT_DIR}/zone/pt_ST.res
-+		${OUT_DIR}/zone/pt_TL.res
-+		${OUT_DIR}/zone/qu.res
-+		${OUT_DIR}/zone/qu_BO.res
-+		${OUT_DIR}/zone/qu_EC.res
-+		${OUT_DIR}/zone/rm.res
-+		${OUT_DIR}/zone/rn.res
-+		${OUT_DIR}/zone/ro.res
-+		${OUT_DIR}/zone/rof.res
-+		${OUT_DIR}/zone/root.res
-+		${OUT_DIR}/zone/ru.res
-+		${OUT_DIR}/zone/rw.res
-+		${OUT_DIR}/zone/rwk.res
-+		${OUT_DIR}/zone/sah.res
-+		${OUT_DIR}/zone/saq.res
-+		${OUT_DIR}/zone/sat.res
-+		${OUT_DIR}/zone/sat_IN.res
-+		${OUT_DIR}/zone/sat_Olck.res
-+		${OUT_DIR}/zone/sat_Olck_IN.res
-+		${OUT_DIR}/zone/sbp.res
-+		${OUT_DIR}/zone/sd.res
-+		${OUT_DIR}/zone/sd_Arab.res
-+		${OUT_DIR}/zone/sd_Arab_PK.res
-+		${OUT_DIR}/zone/sd_Deva.res
-+		${OUT_DIR}/zone/sd_PK.res
-+		${OUT_DIR}/zone/se.res
-+		${OUT_DIR}/zone/se_FI.res
-+		${OUT_DIR}/zone/seh.res
-+		${OUT_DIR}/zone/ses.res
-+		${OUT_DIR}/zone/sg.res
-+		${OUT_DIR}/zone/sh.res
-+		${OUT_DIR}/zone/sh_BA.res
-+		${OUT_DIR}/zone/sh_CS.res
-+		${OUT_DIR}/zone/sh_YU.res
-+		${OUT_DIR}/zone/shi.res
-+		${OUT_DIR}/zone/shi_Latn.res
-+		${OUT_DIR}/zone/shi_MA.res
-+		${OUT_DIR}/zone/shi_Tfng.res
-+		${OUT_DIR}/zone/shi_Tfng_MA.res
-+		${OUT_DIR}/zone/si.res
-+		${OUT_DIR}/zone/sk.res
-+		${OUT_DIR}/zone/sl.res
-+		${OUT_DIR}/zone/smn.res
-+		${OUT_DIR}/zone/sn.res
-+		${OUT_DIR}/zone/so.res
-+		${OUT_DIR}/zone/sq.res
-+		${OUT_DIR}/zone/sr.res
-+		${OUT_DIR}/zone/sr_BA.res
-+		${OUT_DIR}/zone/sr_CS.res
-+		${OUT_DIR}/zone/sr_Cyrl.res
-+		${OUT_DIR}/zone/sr_Cyrl_BA.res
-+		${OUT_DIR}/zone/sr_Cyrl_CS.res
-+		${OUT_DIR}/zone/sr_Cyrl_RS.res
-+		${OUT_DIR}/zone/sr_Cyrl_XK.res
-+		${OUT_DIR}/zone/sr_Cyrl_YU.res
-+		${OUT_DIR}/zone/sr_Latn.res
-+		${OUT_DIR}/zone/sr_Latn_BA.res
-+		${OUT_DIR}/zone/sr_Latn_CS.res
-+		${OUT_DIR}/zone/sr_Latn_ME.res
-+		${OUT_DIR}/zone/sr_Latn_RS.res
-+		${OUT_DIR}/zone/sr_Latn_YU.res
-+		${OUT_DIR}/zone/sr_ME.res
-+		${OUT_DIR}/zone/sr_RS.res
-+		${OUT_DIR}/zone/sr_XK.res
-+		${OUT_DIR}/zone/sr_YU.res
-+		${OUT_DIR}/zone/su.res
-+		${OUT_DIR}/zone/su_ID.res
-+		${OUT_DIR}/zone/su_Latn.res
-+		${OUT_DIR}/zone/su_Latn_ID.res
-+		${OUT_DIR}/zone/sv.res
-+		${OUT_DIR}/zone/sw.res
-+		${OUT_DIR}/zone/sw_KE.res
-+		${OUT_DIR}/zone/ta.res
-+		${OUT_DIR}/zone/ta_MY.res
-+		${OUT_DIR}/zone/ta_SG.res
-+		${OUT_DIR}/zone/te.res
-+		${OUT_DIR}/zone/teo.res
-+		${OUT_DIR}/zone/tg.res
-+		${OUT_DIR}/zone/th.res
-+		${OUT_DIR}/zone/ti.res
-+		${OUT_DIR}/zone/tk.res
-+		${OUT_DIR}/zone/tl.res
-+		${OUT_DIR}/zone/tl_PH.res
-+		${OUT_DIR}/zone/to.res
-+		${OUT_DIR}/zone/tr.res
-+		${OUT_DIR}/zone/tt.res
-+		${OUT_DIR}/zone/twq.res
-+		${OUT_DIR}/zone/tzdbNames.res
-+		${OUT_DIR}/zone/tzm.res
-+		${OUT_DIR}/zone/ug.res
-+		${OUT_DIR}/zone/uk.res
-+		${OUT_DIR}/zone/ur.res
-+		${OUT_DIR}/zone/ur_IN.res
-+		${OUT_DIR}/zone/uz.res
-+		${OUT_DIR}/zone/uz_AF.res
-+		${OUT_DIR}/zone/uz_Arab.res
-+		${OUT_DIR}/zone/uz_Arab_AF.res
-+		${OUT_DIR}/zone/uz_Cyrl.res
-+		${OUT_DIR}/zone/uz_Latn.res
-+		${OUT_DIR}/zone/uz_Latn_UZ.res
-+		${OUT_DIR}/zone/uz_UZ.res
-+		${OUT_DIR}/zone/vai.res
-+		${OUT_DIR}/zone/vai_LR.res
-+		${OUT_DIR}/zone/vai_Latn.res
-+		${OUT_DIR}/zone/vai_Vaii.res
-+		${OUT_DIR}/zone/vai_Vaii_LR.res
-+		${OUT_DIR}/zone/vi.res
-+		${OUT_DIR}/zone/vun.res
-+		${OUT_DIR}/zone/wae.res
-+		${OUT_DIR}/zone/wo.res
-+		${OUT_DIR}/zone/xh.res
-+		${OUT_DIR}/zone/xog.res
-+		${OUT_DIR}/zone/yav.res
-+		${OUT_DIR}/zone/yi.res
-+		${OUT_DIR}/zone/yo.res
-+		${OUT_DIR}/zone/yo_BJ.res
-+		${OUT_DIR}/zone/yue.res
-+		${OUT_DIR}/zone/yue_CN.res
-+		${OUT_DIR}/zone/yue_HK.res
-+		${OUT_DIR}/zone/yue_Hans.res
-+		${OUT_DIR}/zone/yue_Hans_CN.res
-+		${OUT_DIR}/zone/yue_Hant.res
-+		${OUT_DIR}/zone/yue_Hant_HK.res
-+		${OUT_DIR}/zone/zgh.res
-+		${OUT_DIR}/zone/zh.res
-+		${OUT_DIR}/zone/zh_CN.res
-+		${OUT_DIR}/zone/zh_HK.res
-+		${OUT_DIR}/zone/zh_Hans.res
-+		${OUT_DIR}/zone/zh_Hans_CN.res
-+		${OUT_DIR}/zone/zh_Hans_SG.res
-+		${OUT_DIR}/zone/zh_Hant.res
-+		${OUT_DIR}/zone/zh_Hant_HK.res
-+		${OUT_DIR}/zone/zh_Hant_MO.res
-+		${OUT_DIR}/zone/zh_Hant_TW.res
-+		${OUT_DIR}/zone/zh_MO.res
-+		${OUT_DIR}/zone/zh_SG.res
-+		${OUT_DIR}/zone/zh_TW.res
-+		${OUT_DIR}/zone/zu.res
-+		${OUT_DIR}/zoneinfo64.res
-+		${OUT_DIR}/zu.res
-+		${OUT_DIR}/zu_ZA.res
-+		${TMP_DIR}/icudata.lst
++    ${OUT_DIR}/${INDEX_NAME}.res
++    ${OUT_DIR}/af.res
++    ${OUT_DIR}/af_NA.res
++    ${OUT_DIR}/af_ZA.res
++    ${OUT_DIR}/agq.res
++    ${OUT_DIR}/agq_CM.res
++    ${OUT_DIR}/ak.res
++    ${OUT_DIR}/ak_GH.res
++    ${OUT_DIR}/am.res
++    ${OUT_DIR}/am_ET.res
++    ${OUT_DIR}/ar.res
++    ${OUT_DIR}/ar_001.res
++    ${OUT_DIR}/ar_AE.res
++    ${OUT_DIR}/ar_BH.res
++    ${OUT_DIR}/ar_DJ.res
++    ${OUT_DIR}/ar_DZ.res
++    ${OUT_DIR}/ar_EG.res
++    ${OUT_DIR}/ar_EH.res
++    ${OUT_DIR}/ar_ER.res
++    ${OUT_DIR}/ar_IL.res
++    ${OUT_DIR}/ar_IQ.res
++    ${OUT_DIR}/ar_JO.res
++    ${OUT_DIR}/ar_KM.res
++    ${OUT_DIR}/ar_KW.res
++    ${OUT_DIR}/ar_LB.res
++    ${OUT_DIR}/ar_LY.res
++    ${OUT_DIR}/ar_MA.res
++    ${OUT_DIR}/ar_MR.res
++    ${OUT_DIR}/ar_OM.res
++    ${OUT_DIR}/ar_PS.res
++    ${OUT_DIR}/ar_QA.res
++    ${OUT_DIR}/ar_SA.res
++    ${OUT_DIR}/ar_SD.res
++    ${OUT_DIR}/ar_SO.res
++    ${OUT_DIR}/ar_SS.res
++    ${OUT_DIR}/ar_SY.res
++    ${OUT_DIR}/ar_TD.res
++    ${OUT_DIR}/ar_TN.res
++    ${OUT_DIR}/ar_YE.res
++    ${OUT_DIR}/ars.res
++    ${OUT_DIR}/as.res
++    ${OUT_DIR}/as_IN.res
++    ${OUT_DIR}/asa.res
++    ${OUT_DIR}/asa_TZ.res
++    ${OUT_DIR}/ast.res
++    ${OUT_DIR}/ast_ES.res
++    ${OUT_DIR}/az.res
++    ${OUT_DIR}/az_AZ.res
++    ${OUT_DIR}/az_Cyrl.res
++    ${OUT_DIR}/az_Cyrl_AZ.res
++    ${OUT_DIR}/az_Latn.res
++    ${OUT_DIR}/az_Latn_AZ.res
++    ${OUT_DIR}/bas.res
++    ${OUT_DIR}/bas_CM.res
++    ${OUT_DIR}/be.res
++    ${OUT_DIR}/be_BY.res
++    ${OUT_DIR}/bem.res
++    ${OUT_DIR}/bem_ZM.res
++    ${OUT_DIR}/bez.res
++    ${OUT_DIR}/bez_TZ.res
++    ${OUT_DIR}/bg.res
++    ${OUT_DIR}/bg_BG.res
++    ${OUT_DIR}/bm.res
++    ${OUT_DIR}/bm_ML.res
++    ${OUT_DIR}/bn.res
++    ${OUT_DIR}/bn_BD.res
++    ${OUT_DIR}/bn_IN.res
++    ${OUT_DIR}/bo.res
++    ${OUT_DIR}/bo_CN.res
++    ${OUT_DIR}/bo_IN.res
++    ${OUT_DIR}/br.res
++    ${OUT_DIR}/br_FR.res
++    ${OUT_DIR}/brkitr/${INDEX_NAME}.res
++    ${OUT_DIR}/brkitr/burmesedict.dict
++    ${OUT_DIR}/brkitr/char.brk
++    ${OUT_DIR}/brkitr/cjdict.dict
++    ${OUT_DIR}/brkitr/de.res
++    ${OUT_DIR}/brkitr/el.res
++    ${OUT_DIR}/brkitr/en.res
++    ${OUT_DIR}/brkitr/en_US.res
++    ${OUT_DIR}/brkitr/en_US_POSIX.res
++    ${OUT_DIR}/brkitr/es.res
++    ${OUT_DIR}/brkitr/fr.res
++    ${OUT_DIR}/brkitr/it.res
++    ${OUT_DIR}/brkitr/ja.res
++    ${OUT_DIR}/brkitr/khmerdict.dict
++    ${OUT_DIR}/brkitr/laodict.dict
++    ${OUT_DIR}/brkitr/line.brk
++    ${OUT_DIR}/brkitr/line_cj.brk
++    ${OUT_DIR}/brkitr/line_loose.brk
++    ${OUT_DIR}/brkitr/line_loose_cj.brk
++    ${OUT_DIR}/brkitr/line_normal.brk
++    ${OUT_DIR}/brkitr/line_normal_cj.brk
++    ${OUT_DIR}/brkitr/pt.res
++    ${OUT_DIR}/brkitr/root.res
++    ${OUT_DIR}/brkitr/ru.res
++    ${OUT_DIR}/brkitr/sent.brk
++    ${OUT_DIR}/brkitr/sent_el.brk
++    ${OUT_DIR}/brkitr/thaidict.dict
++    ${OUT_DIR}/brkitr/title.brk
++    ${OUT_DIR}/brkitr/word.brk
++    ${OUT_DIR}/brkitr/word_POSIX.brk
++    ${OUT_DIR}/brkitr/zh.res
++    ${OUT_DIR}/brkitr/zh_Hant.res
++    ${OUT_DIR}/brx.res
++    ${OUT_DIR}/brx_IN.res
++    ${OUT_DIR}/bs.res
++    ${OUT_DIR}/bs_BA.res
++    ${OUT_DIR}/bs_Cyrl.res
++    ${OUT_DIR}/bs_Cyrl_BA.res
++    ${OUT_DIR}/bs_Latn.res
++    ${OUT_DIR}/bs_Latn_BA.res
++    ${OUT_DIR}/ca.res
++    ${OUT_DIR}/ca_AD.res
++    ${OUT_DIR}/ca_ES.res
++    ${OUT_DIR}/ca_FR.res
++    ${OUT_DIR}/ca_IT.res
++    ${OUT_DIR}/ccp.res
++    ${OUT_DIR}/ccp_BD.res
++    ${OUT_DIR}/ccp_IN.res
++    ${OUT_DIR}/ce.res
++    ${OUT_DIR}/ce_RU.res
++    ${OUT_DIR}/ceb.res
++    ${OUT_DIR}/ceb_PH.res
++    ${OUT_DIR}/cgg.res
++    ${OUT_DIR}/cgg_UG.res
++    ${OUT_DIR}/chr.res
++    ${OUT_DIR}/chr_US.res
++    ${OUT_DIR}/ckb.res
++    ${OUT_DIR}/ckb_IQ.res
++    ${OUT_DIR}/ckb_IR.res
++    ${OUT_DIR}/cns-11643-1992.cnv
++    ${OUT_DIR}/cnvalias.icu
++    ${OUT_DIR}/coll/${INDEX_NAME}.res
++    ${OUT_DIR}/coll/af.res
++    ${OUT_DIR}/coll/am.res
++    ${OUT_DIR}/coll/ar.res
++    ${OUT_DIR}/coll/ar_SA.res
++    ${OUT_DIR}/coll/ars.res
++    ${OUT_DIR}/coll/as.res
++    ${OUT_DIR}/coll/az.res
++    ${OUT_DIR}/coll/be.res
++    ${OUT_DIR}/coll/bg.res
++    ${OUT_DIR}/coll/bn.res
++    ${OUT_DIR}/coll/bo.res
++    ${OUT_DIR}/coll/bs.res
++    ${OUT_DIR}/coll/bs_Cyrl.res
++    ${OUT_DIR}/coll/ca.res
++    ${OUT_DIR}/coll/ceb.res
++    ${OUT_DIR}/coll/chr.res
++    ${OUT_DIR}/coll/cs.res
++    ${OUT_DIR}/coll/cy.res
++    ${OUT_DIR}/coll/da.res
++    ${OUT_DIR}/coll/de.res
++    ${OUT_DIR}/coll/de_.res
++    ${OUT_DIR}/coll/de_AT.res
++    ${OUT_DIR}/coll/de__PHONEBOOK.res
++    ${OUT_DIR}/coll/dsb.res
++    ${OUT_DIR}/coll/dz.res
++    ${OUT_DIR}/coll/ee.res
++    ${OUT_DIR}/coll/el.res
++    ${OUT_DIR}/coll/en.res
++    ${OUT_DIR}/coll/en_US.res
++    ${OUT_DIR}/coll/en_US_POSIX.res
++    ${OUT_DIR}/coll/eo.res
++    ${OUT_DIR}/coll/es.res
++    ${OUT_DIR}/coll/es_.res
++    ${OUT_DIR}/coll/es__TRADITIONAL.res
++    ${OUT_DIR}/coll/et.res
++    ${OUT_DIR}/coll/fa.res
++    ${OUT_DIR}/coll/fa_AF.res
++    ${OUT_DIR}/coll/ff.res
++    ${OUT_DIR}/coll/ff_Adlm.res
++    ${OUT_DIR}/coll/fi.res
++    ${OUT_DIR}/coll/fil.res
++    ${OUT_DIR}/coll/fo.res
++    ${OUT_DIR}/coll/fr.res
++    ${OUT_DIR}/coll/fr_CA.res
++    ${OUT_DIR}/coll/ga.res
++    ${OUT_DIR}/coll/gl.res
++    ${OUT_DIR}/coll/gu.res
++    ${OUT_DIR}/coll/ha.res
++    ${OUT_DIR}/coll/haw.res
++    ${OUT_DIR}/coll/he.res
++    ${OUT_DIR}/coll/he_IL.res
++    ${OUT_DIR}/coll/hi.res
++    ${OUT_DIR}/coll/hr.res
++    ${OUT_DIR}/coll/hsb.res
++    ${OUT_DIR}/coll/hu.res
++    ${OUT_DIR}/coll/hy.res
++    ${OUT_DIR}/coll/id.res
++    ${OUT_DIR}/coll/id_ID.res
++    ${OUT_DIR}/coll/ig.res
++    ${OUT_DIR}/coll/in.res
++    ${OUT_DIR}/coll/in_ID.res
++    ${OUT_DIR}/coll/is.res
++    ${OUT_DIR}/coll/it.res
++    ${OUT_DIR}/coll/iw.res
++    ${OUT_DIR}/coll/iw_IL.res
++    ${OUT_DIR}/coll/ja.res
++    ${OUT_DIR}/coll/ka.res
++    ${OUT_DIR}/coll/kk.res
++    ${OUT_DIR}/coll/kl.res
++    ${OUT_DIR}/coll/km.res
++    ${OUT_DIR}/coll/kn.res
++    ${OUT_DIR}/coll/ko.res
++    ${OUT_DIR}/coll/kok.res
++    ${OUT_DIR}/coll/ku.res
++    ${OUT_DIR}/coll/ky.res
++    ${OUT_DIR}/coll/lb.res
++    ${OUT_DIR}/coll/lkt.res
++    ${OUT_DIR}/coll/ln.res
++    ${OUT_DIR}/coll/lo.res
++    ${OUT_DIR}/coll/lt.res
++    ${OUT_DIR}/coll/lv.res
++    ${OUT_DIR}/coll/mk.res
++    ${OUT_DIR}/coll/ml.res
++    ${OUT_DIR}/coll/mn.res
++    ${OUT_DIR}/coll/mo.res
++    ${OUT_DIR}/coll/mr.res
++    ${OUT_DIR}/coll/ms.res
++    ${OUT_DIR}/coll/mt.res
++    ${OUT_DIR}/coll/my.res
++    ${OUT_DIR}/coll/nb.res
++    ${OUT_DIR}/coll/nb_NO.res
++    ${OUT_DIR}/coll/ne.res
++    ${OUT_DIR}/coll/nl.res
++    ${OUT_DIR}/coll/nn.res
++    ${OUT_DIR}/coll/no.res
++    ${OUT_DIR}/coll/no_NO.res
++    ${OUT_DIR}/coll/om.res
++    ${OUT_DIR}/coll/or.res
++    ${OUT_DIR}/coll/pa.res
++    ${OUT_DIR}/coll/pa_Guru.res
++    ${OUT_DIR}/coll/pa_Guru_IN.res
++    ${OUT_DIR}/coll/pa_IN.res
++    ${OUT_DIR}/coll/pl.res
++    ${OUT_DIR}/coll/ps.res
++    ${OUT_DIR}/coll/pt.res
++    ${OUT_DIR}/coll/ro.res
++    ${OUT_DIR}/coll/root.res
++    ${OUT_DIR}/coll/ru.res
++    ${OUT_DIR}/coll/se.res
++    ${OUT_DIR}/coll/sh.res
++    ${OUT_DIR}/coll/sh_BA.res
++    ${OUT_DIR}/coll/sh_CS.res
++    ${OUT_DIR}/coll/sh_YU.res
++    ${OUT_DIR}/coll/si.res
++    ${OUT_DIR}/coll/sk.res
++    ${OUT_DIR}/coll/sl.res
++    ${OUT_DIR}/coll/smn.res
++    ${OUT_DIR}/coll/sq.res
++    ${OUT_DIR}/coll/sr.res
++    ${OUT_DIR}/coll/sr_BA.res
++    ${OUT_DIR}/coll/sr_Cyrl.res
++    ${OUT_DIR}/coll/sr_Cyrl_BA.res
++    ${OUT_DIR}/coll/sr_Cyrl_ME.res
++    ${OUT_DIR}/coll/sr_Cyrl_RS.res
++    ${OUT_DIR}/coll/sr_Latn.res
++    ${OUT_DIR}/coll/sr_Latn_BA.res
++    ${OUT_DIR}/coll/sr_Latn_RS.res
++    ${OUT_DIR}/coll/sr_ME.res
++    ${OUT_DIR}/coll/sr_RS.res
++    ${OUT_DIR}/coll/sv.res
++    ${OUT_DIR}/coll/sw.res
++    ${OUT_DIR}/coll/ta.res
++    ${OUT_DIR}/coll/te.res
++    ${OUT_DIR}/coll/th.res
++    ${OUT_DIR}/coll/tk.res
++    ${OUT_DIR}/coll/to.res
++    ${OUT_DIR}/coll/tr.res
++    ${OUT_DIR}/coll/ucadata.icu
++    ${OUT_DIR}/coll/ug.res
++    ${OUT_DIR}/coll/uk.res
++    ${OUT_DIR}/coll/ur.res
++    ${OUT_DIR}/coll/uz.res
++    ${OUT_DIR}/coll/vi.res
++    ${OUT_DIR}/coll/wae.res
++    ${OUT_DIR}/coll/wo.res
++    ${OUT_DIR}/coll/xh.res
++    ${OUT_DIR}/coll/yi.res
++    ${OUT_DIR}/coll/yo.res
++    ${OUT_DIR}/coll/yue.res
++    ${OUT_DIR}/coll/yue_CN.res
++    ${OUT_DIR}/coll/yue_Hans.res
++    ${OUT_DIR}/coll/yue_Hans_CN.res
++    ${OUT_DIR}/coll/yue_Hant.res
++    ${OUT_DIR}/coll/zh.res
++    ${OUT_DIR}/coll/zh_CN.res
++    ${OUT_DIR}/coll/zh_HK.res
++    ${OUT_DIR}/coll/zh_Hans.res
++    ${OUT_DIR}/coll/zh_Hans_CN.res
++    ${OUT_DIR}/coll/zh_Hans_SG.res
++    ${OUT_DIR}/coll/zh_Hant.res
++    ${OUT_DIR}/coll/zh_Hant_HK.res
++    ${OUT_DIR}/coll/zh_Hant_MO.res
++    ${OUT_DIR}/coll/zh_Hant_TW.res
++    ${OUT_DIR}/coll/zh_MO.res
++    ${OUT_DIR}/coll/zh_SG.res
++    ${OUT_DIR}/coll/zh_TW.res
++    ${OUT_DIR}/coll/zu.res
++    ${OUT_DIR}/confusables.cfu
++    ${OUT_DIR}/cs.res
++    ${OUT_DIR}/cs_CZ.res
++    ${OUT_DIR}/curr/${INDEX_NAME}.res
++    ${OUT_DIR}/curr/af.res
++    ${OUT_DIR}/curr/af_NA.res
++    ${OUT_DIR}/curr/agq.res
++    ${OUT_DIR}/curr/ak.res
++    ${OUT_DIR}/curr/am.res
++    ${OUT_DIR}/curr/ar.res
++    ${OUT_DIR}/curr/ar_AE.res
++    ${OUT_DIR}/curr/ar_DJ.res
++    ${OUT_DIR}/curr/ar_ER.res
++    ${OUT_DIR}/curr/ar_KM.res
++    ${OUT_DIR}/curr/ar_LB.res
++    ${OUT_DIR}/curr/ar_SA.res
++    ${OUT_DIR}/curr/ar_SO.res
++    ${OUT_DIR}/curr/ar_SS.res
++    ${OUT_DIR}/curr/ars.res
++    ${OUT_DIR}/curr/as.res
++    ${OUT_DIR}/curr/asa.res
++    ${OUT_DIR}/curr/ast.res
++    ${OUT_DIR}/curr/az.res
++    ${OUT_DIR}/curr/az_AZ.res
++    ${OUT_DIR}/curr/az_Cyrl.res
++    ${OUT_DIR}/curr/az_Latn.res
++    ${OUT_DIR}/curr/az_Latn_AZ.res
++    ${OUT_DIR}/curr/bas.res
++    ${OUT_DIR}/curr/be.res
++    ${OUT_DIR}/curr/bem.res
++    ${OUT_DIR}/curr/bez.res
++    ${OUT_DIR}/curr/bg.res
++    ${OUT_DIR}/curr/bm.res
++    ${OUT_DIR}/curr/bn.res
++    ${OUT_DIR}/curr/bo.res
++    ${OUT_DIR}/curr/bo_IN.res
++    ${OUT_DIR}/curr/br.res
++    ${OUT_DIR}/curr/brx.res
++    ${OUT_DIR}/curr/bs.res
++    ${OUT_DIR}/curr/bs_BA.res
++    ${OUT_DIR}/curr/bs_Cyrl.res
++    ${OUT_DIR}/curr/bs_Latn.res
++    ${OUT_DIR}/curr/bs_Latn_BA.res
++    ${OUT_DIR}/curr/ca.res
++    ${OUT_DIR}/curr/ca_FR.res
++    ${OUT_DIR}/curr/ccp.res
++    ${OUT_DIR}/curr/ce.res
++    ${OUT_DIR}/curr/ceb.res
++    ${OUT_DIR}/curr/cgg.res
++    ${OUT_DIR}/curr/chr.res
++    ${OUT_DIR}/curr/ckb.res
++    ${OUT_DIR}/curr/cs.res
++    ${OUT_DIR}/curr/cy.res
++    ${OUT_DIR}/curr/da.res
++    ${OUT_DIR}/curr/dav.res
++    ${OUT_DIR}/curr/de.res
++    ${OUT_DIR}/curr/de_CH.res
++    ${OUT_DIR}/curr/de_LI.res
++    ${OUT_DIR}/curr/de_LU.res
++    ${OUT_DIR}/curr/dje.res
++    ${OUT_DIR}/curr/dsb.res
++    ${OUT_DIR}/curr/dua.res
++    ${OUT_DIR}/curr/dyo.res
++    ${OUT_DIR}/curr/dz.res
++    ${OUT_DIR}/curr/ebu.res
++    ${OUT_DIR}/curr/ee.res
++    ${OUT_DIR}/curr/el.res
++    ${OUT_DIR}/curr/en.res
++    ${OUT_DIR}/curr/en_001.res
++    ${OUT_DIR}/curr/en_150.res
++    ${OUT_DIR}/curr/en_AE.res
++    ${OUT_DIR}/curr/en_AG.res
++    ${OUT_DIR}/curr/en_AI.res
++    ${OUT_DIR}/curr/en_AT.res
++    ${OUT_DIR}/curr/en_AU.res
++    ${OUT_DIR}/curr/en_BB.res
++    ${OUT_DIR}/curr/en_BE.res
++    ${OUT_DIR}/curr/en_BI.res
++    ${OUT_DIR}/curr/en_BM.res
++    ${OUT_DIR}/curr/en_BS.res
++    ${OUT_DIR}/curr/en_BW.res
++    ${OUT_DIR}/curr/en_BZ.res
++    ${OUT_DIR}/curr/en_CA.res
++    ${OUT_DIR}/curr/en_CC.res
++    ${OUT_DIR}/curr/en_CH.res
++    ${OUT_DIR}/curr/en_CK.res
++    ${OUT_DIR}/curr/en_CM.res
++    ${OUT_DIR}/curr/en_CX.res
++    ${OUT_DIR}/curr/en_CY.res
++    ${OUT_DIR}/curr/en_DE.res
++    ${OUT_DIR}/curr/en_DG.res
++    ${OUT_DIR}/curr/en_DK.res
++    ${OUT_DIR}/curr/en_DM.res
++    ${OUT_DIR}/curr/en_ER.res
++    ${OUT_DIR}/curr/en_FI.res
++    ${OUT_DIR}/curr/en_FJ.res
++    ${OUT_DIR}/curr/en_FK.res
++    ${OUT_DIR}/curr/en_FM.res
++    ${OUT_DIR}/curr/en_GB.res
++    ${OUT_DIR}/curr/en_GD.res
++    ${OUT_DIR}/curr/en_GG.res
++    ${OUT_DIR}/curr/en_GH.res
++    ${OUT_DIR}/curr/en_GI.res
++    ${OUT_DIR}/curr/en_GM.res
++    ${OUT_DIR}/curr/en_GY.res
++    ${OUT_DIR}/curr/en_HK.res
++    ${OUT_DIR}/curr/en_IE.res
++    ${OUT_DIR}/curr/en_IL.res
++    ${OUT_DIR}/curr/en_IM.res
++    ${OUT_DIR}/curr/en_IN.res
++    ${OUT_DIR}/curr/en_IO.res
++    ${OUT_DIR}/curr/en_JE.res
++    ${OUT_DIR}/curr/en_JM.res
++    ${OUT_DIR}/curr/en_KE.res
++    ${OUT_DIR}/curr/en_KI.res
++    ${OUT_DIR}/curr/en_KN.res
++    ${OUT_DIR}/curr/en_KY.res
++    ${OUT_DIR}/curr/en_LC.res
++    ${OUT_DIR}/curr/en_LR.res
++    ${OUT_DIR}/curr/en_LS.res
++    ${OUT_DIR}/curr/en_MG.res
++    ${OUT_DIR}/curr/en_MO.res
++    ${OUT_DIR}/curr/en_MS.res
++    ${OUT_DIR}/curr/en_MT.res
++    ${OUT_DIR}/curr/en_MU.res
++    ${OUT_DIR}/curr/en_MW.res
++    ${OUT_DIR}/curr/en_MY.res
++    ${OUT_DIR}/curr/en_NA.res
++    ${OUT_DIR}/curr/en_NF.res
++    ${OUT_DIR}/curr/en_NG.res
++    ${OUT_DIR}/curr/en_NH.res
++    ${OUT_DIR}/curr/en_NL.res
++    ${OUT_DIR}/curr/en_NR.res
++    ${OUT_DIR}/curr/en_NU.res
++    ${OUT_DIR}/curr/en_NZ.res
++    ${OUT_DIR}/curr/en_PG.res
++    ${OUT_DIR}/curr/en_PH.res
++    ${OUT_DIR}/curr/en_PK.res
++    ${OUT_DIR}/curr/en_PN.res
++    ${OUT_DIR}/curr/en_PW.res
++    ${OUT_DIR}/curr/en_RH.res
++    ${OUT_DIR}/curr/en_RW.res
++    ${OUT_DIR}/curr/en_SB.res
++    ${OUT_DIR}/curr/en_SC.res
++    ${OUT_DIR}/curr/en_SD.res
++    ${OUT_DIR}/curr/en_SE.res
++    ${OUT_DIR}/curr/en_SG.res
++    ${OUT_DIR}/curr/en_SH.res
++    ${OUT_DIR}/curr/en_SI.res
++    ${OUT_DIR}/curr/en_SL.res
++    ${OUT_DIR}/curr/en_SS.res
++    ${OUT_DIR}/curr/en_SX.res
++    ${OUT_DIR}/curr/en_SZ.res
++    ${OUT_DIR}/curr/en_TC.res
++    ${OUT_DIR}/curr/en_TK.res
++    ${OUT_DIR}/curr/en_TO.res
++    ${OUT_DIR}/curr/en_TT.res
++    ${OUT_DIR}/curr/en_TV.res
++    ${OUT_DIR}/curr/en_TZ.res
++    ${OUT_DIR}/curr/en_UG.res
++    ${OUT_DIR}/curr/en_VC.res
++    ${OUT_DIR}/curr/en_VG.res
++    ${OUT_DIR}/curr/en_VU.res
++    ${OUT_DIR}/curr/en_WS.res
++    ${OUT_DIR}/curr/en_ZA.res
++    ${OUT_DIR}/curr/en_ZM.res
++    ${OUT_DIR}/curr/en_ZW.res
++    ${OUT_DIR}/curr/eo.res
++    ${OUT_DIR}/curr/es.res
++    ${OUT_DIR}/curr/es_419.res
++    ${OUT_DIR}/curr/es_AR.res
++    ${OUT_DIR}/curr/es_BO.res
++    ${OUT_DIR}/curr/es_BR.res
++    ${OUT_DIR}/curr/es_BZ.res
++    ${OUT_DIR}/curr/es_CL.res
++    ${OUT_DIR}/curr/es_CO.res
++    ${OUT_DIR}/curr/es_CR.res
++    ${OUT_DIR}/curr/es_CU.res
++    ${OUT_DIR}/curr/es_DO.res
++    ${OUT_DIR}/curr/es_EC.res
++    ${OUT_DIR}/curr/es_GQ.res
++    ${OUT_DIR}/curr/es_GT.res
++    ${OUT_DIR}/curr/es_HN.res
++    ${OUT_DIR}/curr/es_MX.res
++    ${OUT_DIR}/curr/es_NI.res
++    ${OUT_DIR}/curr/es_PA.res
++    ${OUT_DIR}/curr/es_PE.res
++    ${OUT_DIR}/curr/es_PH.res
++    ${OUT_DIR}/curr/es_PR.res
++    ${OUT_DIR}/curr/es_PY.res
++    ${OUT_DIR}/curr/es_SV.res
++    ${OUT_DIR}/curr/es_US.res
++    ${OUT_DIR}/curr/es_UY.res
++    ${OUT_DIR}/curr/es_VE.res
++    ${OUT_DIR}/curr/et.res
++    ${OUT_DIR}/curr/eu.res
++    ${OUT_DIR}/curr/ewo.res
++    ${OUT_DIR}/curr/fa.res
++    ${OUT_DIR}/curr/fa_AF.res
++    ${OUT_DIR}/curr/ff.res
++    ${OUT_DIR}/curr/ff_Adlm.res
++    ${OUT_DIR}/curr/ff_Adlm_BF.res
++    ${OUT_DIR}/curr/ff_Adlm_CM.res
++    ${OUT_DIR}/curr/ff_Adlm_GH.res
++    ${OUT_DIR}/curr/ff_Adlm_GM.res
++    ${OUT_DIR}/curr/ff_Adlm_GW.res
++    ${OUT_DIR}/curr/ff_Adlm_LR.res
++    ${OUT_DIR}/curr/ff_Adlm_MR.res
++    ${OUT_DIR}/curr/ff_Adlm_NE.res
++    ${OUT_DIR}/curr/ff_Adlm_NG.res
++    ${OUT_DIR}/curr/ff_Adlm_SL.res
++    ${OUT_DIR}/curr/ff_Adlm_SN.res
++    ${OUT_DIR}/curr/ff_CM.res
++    ${OUT_DIR}/curr/ff_GN.res
++    ${OUT_DIR}/curr/ff_Latn.res
++    ${OUT_DIR}/curr/ff_Latn_CM.res
++    ${OUT_DIR}/curr/ff_Latn_GH.res
++    ${OUT_DIR}/curr/ff_Latn_GM.res
++    ${OUT_DIR}/curr/ff_Latn_GN.res
++    ${OUT_DIR}/curr/ff_Latn_LR.res
++    ${OUT_DIR}/curr/ff_Latn_MR.res
++    ${OUT_DIR}/curr/ff_Latn_NG.res
++    ${OUT_DIR}/curr/ff_Latn_SL.res
++    ${OUT_DIR}/curr/ff_Latn_SN.res
++    ${OUT_DIR}/curr/ff_MR.res
++    ${OUT_DIR}/curr/ff_SN.res
++    ${OUT_DIR}/curr/fi.res
++    ${OUT_DIR}/curr/fil.res
++    ${OUT_DIR}/curr/fil_PH.res
++    ${OUT_DIR}/curr/fo.res
++    ${OUT_DIR}/curr/fo_DK.res
++    ${OUT_DIR}/curr/fr.res
++    ${OUT_DIR}/curr/fr_BI.res
++    ${OUT_DIR}/curr/fr_CA.res
++    ${OUT_DIR}/curr/fr_CD.res
++    ${OUT_DIR}/curr/fr_DJ.res
++    ${OUT_DIR}/curr/fr_DZ.res
++    ${OUT_DIR}/curr/fr_GN.res
++    ${OUT_DIR}/curr/fr_HT.res
++    ${OUT_DIR}/curr/fr_KM.res
++    ${OUT_DIR}/curr/fr_LU.res
++    ${OUT_DIR}/curr/fr_MG.res
++    ${OUT_DIR}/curr/fr_MR.res
++    ${OUT_DIR}/curr/fr_MU.res
++    ${OUT_DIR}/curr/fr_RW.res
++    ${OUT_DIR}/curr/fr_SC.res
++    ${OUT_DIR}/curr/fr_SY.res
++    ${OUT_DIR}/curr/fr_TN.res
++    ${OUT_DIR}/curr/fr_VU.res
++    ${OUT_DIR}/curr/fur.res
++    ${OUT_DIR}/curr/fy.res
++    ${OUT_DIR}/curr/ga.res
++    ${OUT_DIR}/curr/gd.res
++    ${OUT_DIR}/curr/gl.res
++    ${OUT_DIR}/curr/gsw.res
++    ${OUT_DIR}/curr/gu.res
++    ${OUT_DIR}/curr/guz.res
++    ${OUT_DIR}/curr/gv.res
++    ${OUT_DIR}/curr/ha.res
++    ${OUT_DIR}/curr/ha_GH.res
++    ${OUT_DIR}/curr/haw.res
++    ${OUT_DIR}/curr/he.res
++    ${OUT_DIR}/curr/he_IL.res
++    ${OUT_DIR}/curr/hi.res
++    ${OUT_DIR}/curr/hr.res
++    ${OUT_DIR}/curr/hr_BA.res
++    ${OUT_DIR}/curr/hsb.res
++    ${OUT_DIR}/curr/hu.res
++    ${OUT_DIR}/curr/hy.res
++    ${OUT_DIR}/curr/ia.res
++    ${OUT_DIR}/curr/id.res
++    ${OUT_DIR}/curr/id_ID.res
++    ${OUT_DIR}/curr/ig.res
++    ${OUT_DIR}/curr/ii.res
++    ${OUT_DIR}/curr/in.res
++    ${OUT_DIR}/curr/in_ID.res
++    ${OUT_DIR}/curr/is.res
++    ${OUT_DIR}/curr/it.res
++    ${OUT_DIR}/curr/iw.res
++    ${OUT_DIR}/curr/iw_IL.res
++    ${OUT_DIR}/curr/ja.res
++    ${OUT_DIR}/curr/jgo.res
++    ${OUT_DIR}/curr/jmc.res
++    ${OUT_DIR}/curr/jv.res
++    ${OUT_DIR}/curr/ka.res
++    ${OUT_DIR}/curr/kab.res
++    ${OUT_DIR}/curr/kam.res
++    ${OUT_DIR}/curr/kde.res
++    ${OUT_DIR}/curr/kea.res
++    ${OUT_DIR}/curr/khq.res
++    ${OUT_DIR}/curr/ki.res
++    ${OUT_DIR}/curr/kk.res
++    ${OUT_DIR}/curr/kkj.res
++    ${OUT_DIR}/curr/kl.res
++    ${OUT_DIR}/curr/kln.res
++    ${OUT_DIR}/curr/km.res
++    ${OUT_DIR}/curr/kn.res
++    ${OUT_DIR}/curr/ko.res
++    ${OUT_DIR}/curr/kok.res
++    ${OUT_DIR}/curr/ks.res
++    ${OUT_DIR}/curr/ks_Arab.res
++    ${OUT_DIR}/curr/ks_Arab_IN.res
++    ${OUT_DIR}/curr/ks_IN.res
++    ${OUT_DIR}/curr/ksb.res
++    ${OUT_DIR}/curr/ksf.res
++    ${OUT_DIR}/curr/ksh.res
++    ${OUT_DIR}/curr/ku.res
++    ${OUT_DIR}/curr/kw.res
++    ${OUT_DIR}/curr/ky.res
++    ${OUT_DIR}/curr/lag.res
++    ${OUT_DIR}/curr/lb.res
++    ${OUT_DIR}/curr/lg.res
++    ${OUT_DIR}/curr/lkt.res
++    ${OUT_DIR}/curr/ln.res
++    ${OUT_DIR}/curr/ln_AO.res
++    ${OUT_DIR}/curr/lo.res
++    ${OUT_DIR}/curr/lrc.res
++    ${OUT_DIR}/curr/lt.res
++    ${OUT_DIR}/curr/lu.res
++    ${OUT_DIR}/curr/luo.res
++    ${OUT_DIR}/curr/luy.res
++    ${OUT_DIR}/curr/lv.res
++    ${OUT_DIR}/curr/mai.res
++    ${OUT_DIR}/curr/mas.res
++    ${OUT_DIR}/curr/mas_TZ.res
++    ${OUT_DIR}/curr/mer.res
++    ${OUT_DIR}/curr/mfe.res
++    ${OUT_DIR}/curr/mg.res
++    ${OUT_DIR}/curr/mgh.res
++    ${OUT_DIR}/curr/mgo.res
++    ${OUT_DIR}/curr/mi.res
++    ${OUT_DIR}/curr/mk.res
++    ${OUT_DIR}/curr/ml.res
++    ${OUT_DIR}/curr/mn.res
++    ${OUT_DIR}/curr/mni.res
++    ${OUT_DIR}/curr/mni_Beng.res
++    ${OUT_DIR}/curr/mni_Beng_IN.res
++    ${OUT_DIR}/curr/mni_IN.res
++    ${OUT_DIR}/curr/mo.res
++    ${OUT_DIR}/curr/mr.res
++    ${OUT_DIR}/curr/ms.res
++    ${OUT_DIR}/curr/ms_BN.res
++    ${OUT_DIR}/curr/ms_ID.res
++    ${OUT_DIR}/curr/ms_SG.res
++    ${OUT_DIR}/curr/mt.res
++    ${OUT_DIR}/curr/mua.res
++    ${OUT_DIR}/curr/my.res
++    ${OUT_DIR}/curr/mzn.res
++    ${OUT_DIR}/curr/naq.res
++    ${OUT_DIR}/curr/nb.res
++    ${OUT_DIR}/curr/nb_NO.res
++    ${OUT_DIR}/curr/nd.res
++    ${OUT_DIR}/curr/nds.res
++    ${OUT_DIR}/curr/ne.res
++    ${OUT_DIR}/curr/nl.res
++    ${OUT_DIR}/curr/nl_AW.res
++    ${OUT_DIR}/curr/nl_BQ.res
++    ${OUT_DIR}/curr/nl_CW.res
++    ${OUT_DIR}/curr/nl_SR.res
++    ${OUT_DIR}/curr/nl_SX.res
++    ${OUT_DIR}/curr/nmg.res
++    ${OUT_DIR}/curr/nn.res
++    ${OUT_DIR}/curr/nn_NO.res
++    ${OUT_DIR}/curr/nnh.res
++    ${OUT_DIR}/curr/no.res
++    ${OUT_DIR}/curr/no_NO.res
++    ${OUT_DIR}/curr/no_NO_NY.res
++    ${OUT_DIR}/curr/nus.res
++    ${OUT_DIR}/curr/nyn.res
++    ${OUT_DIR}/curr/om.res
++    ${OUT_DIR}/curr/om_KE.res
++    ${OUT_DIR}/curr/or.res
++    ${OUT_DIR}/curr/os.res
++    ${OUT_DIR}/curr/os_RU.res
++    ${OUT_DIR}/curr/pa.res
++    ${OUT_DIR}/curr/pa_Arab.res
++    ${OUT_DIR}/curr/pa_Arab_PK.res
++    ${OUT_DIR}/curr/pa_Guru.res
++    ${OUT_DIR}/curr/pa_Guru_IN.res
++    ${OUT_DIR}/curr/pa_IN.res
++    ${OUT_DIR}/curr/pa_PK.res
++    ${OUT_DIR}/curr/pcm.res
++    ${OUT_DIR}/curr/pl.res
++    ${OUT_DIR}/curr/pool.res
++    ${OUT_DIR}/curr/ps.res
++    ${OUT_DIR}/curr/ps_PK.res
++    ${OUT_DIR}/curr/pt.res
++    ${OUT_DIR}/curr/pt_AO.res
++    ${OUT_DIR}/curr/pt_CH.res
++    ${OUT_DIR}/curr/pt_CV.res
++    ${OUT_DIR}/curr/pt_GQ.res
++    ${OUT_DIR}/curr/pt_GW.res
++    ${OUT_DIR}/curr/pt_LU.res
++    ${OUT_DIR}/curr/pt_MO.res
++    ${OUT_DIR}/curr/pt_MZ.res
++    ${OUT_DIR}/curr/pt_PT.res
++    ${OUT_DIR}/curr/pt_ST.res
++    ${OUT_DIR}/curr/pt_TL.res
++    ${OUT_DIR}/curr/qu.res
++    ${OUT_DIR}/curr/qu_BO.res
++    ${OUT_DIR}/curr/qu_EC.res
++    ${OUT_DIR}/curr/rm.res
++    ${OUT_DIR}/curr/rn.res
++    ${OUT_DIR}/curr/ro.res
++    ${OUT_DIR}/curr/ro_MD.res
++    ${OUT_DIR}/curr/rof.res
++    ${OUT_DIR}/curr/root.res
++    ${OUT_DIR}/curr/ru.res
++    ${OUT_DIR}/curr/ru_BY.res
++    ${OUT_DIR}/curr/ru_KG.res
++    ${OUT_DIR}/curr/ru_KZ.res
++    ${OUT_DIR}/curr/ru_MD.res
++    ${OUT_DIR}/curr/rw.res
++    ${OUT_DIR}/curr/rwk.res
++    ${OUT_DIR}/curr/sah.res
++    ${OUT_DIR}/curr/saq.res
++    ${OUT_DIR}/curr/sat.res
++    ${OUT_DIR}/curr/sat_IN.res
++    ${OUT_DIR}/curr/sat_Olck.res
++    ${OUT_DIR}/curr/sat_Olck_IN.res
++    ${OUT_DIR}/curr/sbp.res
++    ${OUT_DIR}/curr/sd.res
++    ${OUT_DIR}/curr/sd_Arab.res
++    ${OUT_DIR}/curr/sd_Arab_PK.res
++    ${OUT_DIR}/curr/sd_Deva.res
++    ${OUT_DIR}/curr/sd_PK.res
++    ${OUT_DIR}/curr/se.res
++    ${OUT_DIR}/curr/se_SE.res
++    ${OUT_DIR}/curr/seh.res
++    ${OUT_DIR}/curr/ses.res
++    ${OUT_DIR}/curr/sg.res
++    ${OUT_DIR}/curr/sh.res
++    ${OUT_DIR}/curr/sh_BA.res
++    ${OUT_DIR}/curr/sh_CS.res
++    ${OUT_DIR}/curr/sh_YU.res
++    ${OUT_DIR}/curr/shi.res
++    ${OUT_DIR}/curr/shi_Latn.res
++    ${OUT_DIR}/curr/shi_MA.res
++    ${OUT_DIR}/curr/shi_Tfng.res
++    ${OUT_DIR}/curr/shi_Tfng_MA.res
++    ${OUT_DIR}/curr/si.res
++    ${OUT_DIR}/curr/sk.res
++    ${OUT_DIR}/curr/sl.res
++    ${OUT_DIR}/curr/smn.res
++    ${OUT_DIR}/curr/sn.res
++    ${OUT_DIR}/curr/so.res
++    ${OUT_DIR}/curr/so_DJ.res
++    ${OUT_DIR}/curr/so_ET.res
++    ${OUT_DIR}/curr/so_KE.res
++    ${OUT_DIR}/curr/sq.res
++    ${OUT_DIR}/curr/sq_MK.res
++    ${OUT_DIR}/curr/sr.res
++    ${OUT_DIR}/curr/sr_BA.res
++    ${OUT_DIR}/curr/sr_CS.res
++    ${OUT_DIR}/curr/sr_Cyrl.res
++    ${OUT_DIR}/curr/sr_Cyrl_BA.res
++    ${OUT_DIR}/curr/sr_Cyrl_CS.res
++    ${OUT_DIR}/curr/sr_Cyrl_RS.res
++    ${OUT_DIR}/curr/sr_Cyrl_XK.res
++    ${OUT_DIR}/curr/sr_Cyrl_YU.res
++    ${OUT_DIR}/curr/sr_Latn.res
++    ${OUT_DIR}/curr/sr_Latn_BA.res
++    ${OUT_DIR}/curr/sr_Latn_CS.res
++    ${OUT_DIR}/curr/sr_Latn_ME.res
++    ${OUT_DIR}/curr/sr_Latn_RS.res
++    ${OUT_DIR}/curr/sr_Latn_YU.res
++    ${OUT_DIR}/curr/sr_ME.res
++    ${OUT_DIR}/curr/sr_RS.res
++    ${OUT_DIR}/curr/sr_XK.res
++    ${OUT_DIR}/curr/sr_YU.res
++    ${OUT_DIR}/curr/su.res
++    ${OUT_DIR}/curr/su_ID.res
++    ${OUT_DIR}/curr/su_Latn.res
++    ${OUT_DIR}/curr/su_Latn_ID.res
++    ${OUT_DIR}/curr/supplementalData.res
++    ${OUT_DIR}/curr/sv.res
++    ${OUT_DIR}/curr/sw.res
++    ${OUT_DIR}/curr/sw_CD.res
++    ${OUT_DIR}/curr/sw_KE.res
++    ${OUT_DIR}/curr/sw_UG.res
++    ${OUT_DIR}/curr/ta.res
++    ${OUT_DIR}/curr/ta_LK.res
++    ${OUT_DIR}/curr/ta_MY.res
++    ${OUT_DIR}/curr/ta_SG.res
++    ${OUT_DIR}/curr/te.res
++    ${OUT_DIR}/curr/teo.res
++    ${OUT_DIR}/curr/teo_KE.res
++    ${OUT_DIR}/curr/tg.res
++    ${OUT_DIR}/curr/th.res
++    ${OUT_DIR}/curr/ti.res
++    ${OUT_DIR}/curr/ti_ER.res
++    ${OUT_DIR}/curr/tk.res
++    ${OUT_DIR}/curr/tl.res
++    ${OUT_DIR}/curr/tl_PH.res
++    ${OUT_DIR}/curr/to.res
++    ${OUT_DIR}/curr/tr.res
++    ${OUT_DIR}/curr/tt.res
++    ${OUT_DIR}/curr/twq.res
++    ${OUT_DIR}/curr/tzm.res
++    ${OUT_DIR}/curr/ug.res
++    ${OUT_DIR}/curr/uk.res
++    ${OUT_DIR}/curr/ur.res
++    ${OUT_DIR}/curr/ur_IN.res
++    ${OUT_DIR}/curr/uz.res
++    ${OUT_DIR}/curr/uz_AF.res
++    ${OUT_DIR}/curr/uz_Arab.res
++    ${OUT_DIR}/curr/uz_Arab_AF.res
++    ${OUT_DIR}/curr/uz_Cyrl.res
++    ${OUT_DIR}/curr/uz_Latn.res
++    ${OUT_DIR}/curr/uz_Latn_UZ.res
++    ${OUT_DIR}/curr/uz_UZ.res
++    ${OUT_DIR}/curr/vai.res
++    ${OUT_DIR}/curr/vai_LR.res
++    ${OUT_DIR}/curr/vai_Latn.res
++    ${OUT_DIR}/curr/vai_Vaii.res
++    ${OUT_DIR}/curr/vai_Vaii_LR.res
++    ${OUT_DIR}/curr/vi.res
++    ${OUT_DIR}/curr/vun.res
++    ${OUT_DIR}/curr/wae.res
++    ${OUT_DIR}/curr/wo.res
++    ${OUT_DIR}/curr/xh.res
++    ${OUT_DIR}/curr/xog.res
++    ${OUT_DIR}/curr/yav.res
++    ${OUT_DIR}/curr/yi.res
++    ${OUT_DIR}/curr/yo.res
++    ${OUT_DIR}/curr/yo_BJ.res
++    ${OUT_DIR}/curr/yue.res
++    ${OUT_DIR}/curr/yue_CN.res
++    ${OUT_DIR}/curr/yue_HK.res
++    ${OUT_DIR}/curr/yue_Hans.res
++    ${OUT_DIR}/curr/yue_Hans_CN.res
++    ${OUT_DIR}/curr/yue_Hant.res
++    ${OUT_DIR}/curr/yue_Hant_HK.res
++    ${OUT_DIR}/curr/zgh.res
++    ${OUT_DIR}/curr/zh.res
++    ${OUT_DIR}/curr/zh_CN.res
++    ${OUT_DIR}/curr/zh_HK.res
++    ${OUT_DIR}/curr/zh_Hans.res
++    ${OUT_DIR}/curr/zh_Hans_CN.res
++    ${OUT_DIR}/curr/zh_Hans_HK.res
++    ${OUT_DIR}/curr/zh_Hans_MO.res
++    ${OUT_DIR}/curr/zh_Hans_SG.res
++    ${OUT_DIR}/curr/zh_Hant.res
++    ${OUT_DIR}/curr/zh_Hant_HK.res
++    ${OUT_DIR}/curr/zh_Hant_MO.res
++    ${OUT_DIR}/curr/zh_Hant_TW.res
++    ${OUT_DIR}/curr/zh_MO.res
++    ${OUT_DIR}/curr/zh_SG.res
++    ${OUT_DIR}/curr/zh_TW.res
++    ${OUT_DIR}/curr/zu.res
++    ${OUT_DIR}/currencyNumericCodes.res
++    ${OUT_DIR}/cy.res
++    ${OUT_DIR}/cy_GB.res
++    ${OUT_DIR}/da.res
++    ${OUT_DIR}/da_DK.res
++    ${OUT_DIR}/da_GL.res
++    ${OUT_DIR}/dav.res
++    ${OUT_DIR}/dav_KE.res
++    ${OUT_DIR}/dayPeriods.res
++    ${OUT_DIR}/de.res
++    ${OUT_DIR}/de_AT.res
++    ${OUT_DIR}/de_BE.res
++    ${OUT_DIR}/de_CH.res
++    ${OUT_DIR}/de_DE.res
++    ${OUT_DIR}/de_IT.res
++    ${OUT_DIR}/de_LI.res
++    ${OUT_DIR}/de_LU.res
++    ${OUT_DIR}/dje.res
++    ${OUT_DIR}/dje_NE.res
++    ${OUT_DIR}/dsb.res
++    ${OUT_DIR}/dsb_DE.res
++    ${OUT_DIR}/dua.res
++    ${OUT_DIR}/dua_CM.res
++    ${OUT_DIR}/dyo.res
++    ${OUT_DIR}/dyo_SN.res
++    ${OUT_DIR}/dz.res
++    ${OUT_DIR}/dz_BT.res
++    ${OUT_DIR}/ebcdic-xml-us.cnv
++    ${OUT_DIR}/ebu.res
++    ${OUT_DIR}/ebu_KE.res
++    ${OUT_DIR}/ee.res
++    ${OUT_DIR}/ee_GH.res
++    ${OUT_DIR}/ee_TG.res
++    ${OUT_DIR}/el.res
++    ${OUT_DIR}/el_CY.res
++    ${OUT_DIR}/el_GR.res
++    ${OUT_DIR}/en.res
++    ${OUT_DIR}/en_001.res
++    ${OUT_DIR}/en_150.res
++    ${OUT_DIR}/en_AE.res
++    ${OUT_DIR}/en_AG.res
++    ${OUT_DIR}/en_AI.res
++    ${OUT_DIR}/en_AS.res
++    ${OUT_DIR}/en_AT.res
++    ${OUT_DIR}/en_AU.res
++    ${OUT_DIR}/en_BB.res
++    ${OUT_DIR}/en_BE.res
++    ${OUT_DIR}/en_BI.res
++    ${OUT_DIR}/en_BM.res
++    ${OUT_DIR}/en_BS.res
++    ${OUT_DIR}/en_BW.res
++    ${OUT_DIR}/en_BZ.res
++    ${OUT_DIR}/en_CA.res
++    ${OUT_DIR}/en_CC.res
++    ${OUT_DIR}/en_CH.res
++    ${OUT_DIR}/en_CK.res
++    ${OUT_DIR}/en_CM.res
++    ${OUT_DIR}/en_CX.res
++    ${OUT_DIR}/en_CY.res
++    ${OUT_DIR}/en_DE.res
++    ${OUT_DIR}/en_DG.res
++    ${OUT_DIR}/en_DK.res
++    ${OUT_DIR}/en_DM.res
++    ${OUT_DIR}/en_ER.res
++    ${OUT_DIR}/en_FI.res
++    ${OUT_DIR}/en_FJ.res
++    ${OUT_DIR}/en_FK.res
++    ${OUT_DIR}/en_FM.res
++    ${OUT_DIR}/en_GB.res
++    ${OUT_DIR}/en_GD.res
++    ${OUT_DIR}/en_GG.res
++    ${OUT_DIR}/en_GH.res
++    ${OUT_DIR}/en_GI.res
++    ${OUT_DIR}/en_GM.res
++    ${OUT_DIR}/en_GU.res
++    ${OUT_DIR}/en_GY.res
++    ${OUT_DIR}/en_HK.res
++    ${OUT_DIR}/en_IE.res
++    ${OUT_DIR}/en_IL.res
++    ${OUT_DIR}/en_IM.res
++    ${OUT_DIR}/en_IN.res
++    ${OUT_DIR}/en_IO.res
++    ${OUT_DIR}/en_JE.res
++    ${OUT_DIR}/en_JM.res
++    ${OUT_DIR}/en_KE.res
++    ${OUT_DIR}/en_KI.res
++    ${OUT_DIR}/en_KN.res
++    ${OUT_DIR}/en_KY.res
++    ${OUT_DIR}/en_LC.res
++    ${OUT_DIR}/en_LR.res
++    ${OUT_DIR}/en_LS.res
++    ${OUT_DIR}/en_MG.res
++    ${OUT_DIR}/en_MH.res
++    ${OUT_DIR}/en_MO.res
++    ${OUT_DIR}/en_MP.res
++    ${OUT_DIR}/en_MS.res
++    ${OUT_DIR}/en_MT.res
++    ${OUT_DIR}/en_MU.res
++    ${OUT_DIR}/en_MW.res
++    ${OUT_DIR}/en_MY.res
++    ${OUT_DIR}/en_NA.res
++    ${OUT_DIR}/en_NF.res
++    ${OUT_DIR}/en_NG.res
++    ${OUT_DIR}/en_NH.res
++    ${OUT_DIR}/en_NL.res
++    ${OUT_DIR}/en_NR.res
++    ${OUT_DIR}/en_NU.res
++    ${OUT_DIR}/en_NZ.res
++    ${OUT_DIR}/en_PG.res
++    ${OUT_DIR}/en_PH.res
++    ${OUT_DIR}/en_PK.res
++    ${OUT_DIR}/en_PN.res
++    ${OUT_DIR}/en_PR.res
++    ${OUT_DIR}/en_PW.res
++    ${OUT_DIR}/en_RH.res
++    ${OUT_DIR}/en_RW.res
++    ${OUT_DIR}/en_SB.res
++    ${OUT_DIR}/en_SC.res
++    ${OUT_DIR}/en_SD.res
++    ${OUT_DIR}/en_SE.res
++    ${OUT_DIR}/en_SG.res
++    ${OUT_DIR}/en_SH.res
++    ${OUT_DIR}/en_SI.res
++    ${OUT_DIR}/en_SL.res
++    ${OUT_DIR}/en_SS.res
++    ${OUT_DIR}/en_SX.res
++    ${OUT_DIR}/en_SZ.res
++    ${OUT_DIR}/en_TC.res
++    ${OUT_DIR}/en_TK.res
++    ${OUT_DIR}/en_TO.res
++    ${OUT_DIR}/en_TT.res
++    ${OUT_DIR}/en_TV.res
++    ${OUT_DIR}/en_TZ.res
++    ${OUT_DIR}/en_UG.res
++    ${OUT_DIR}/en_UM.res
++    ${OUT_DIR}/en_US.res
++    ${OUT_DIR}/en_US_POSIX.res
++    ${OUT_DIR}/en_VC.res
++    ${OUT_DIR}/en_VG.res
++    ${OUT_DIR}/en_VI.res
++    ${OUT_DIR}/en_VU.res
++    ${OUT_DIR}/en_WS.res
++    ${OUT_DIR}/en_ZA.res
++    ${OUT_DIR}/en_ZM.res
++    ${OUT_DIR}/en_ZW.res
++    ${OUT_DIR}/eo.res
++    ${OUT_DIR}/eo_001.res
++    ${OUT_DIR}/es.res
++    ${OUT_DIR}/es_419.res
++    ${OUT_DIR}/es_AR.res
++    ${OUT_DIR}/es_BO.res
++    ${OUT_DIR}/es_BR.res
++    ${OUT_DIR}/es_BZ.res
++    ${OUT_DIR}/es_CL.res
++    ${OUT_DIR}/es_CO.res
++    ${OUT_DIR}/es_CR.res
++    ${OUT_DIR}/es_CU.res
++    ${OUT_DIR}/es_DO.res
++    ${OUT_DIR}/es_EA.res
++    ${OUT_DIR}/es_EC.res
++    ${OUT_DIR}/es_ES.res
++    ${OUT_DIR}/es_GQ.res
++    ${OUT_DIR}/es_GT.res
++    ${OUT_DIR}/es_HN.res
++    ${OUT_DIR}/es_IC.res
++    ${OUT_DIR}/es_MX.res
++    ${OUT_DIR}/es_NI.res
++    ${OUT_DIR}/es_PA.res
++    ${OUT_DIR}/es_PE.res
++    ${OUT_DIR}/es_PH.res
++    ${OUT_DIR}/es_PR.res
++    ${OUT_DIR}/es_PY.res
++    ${OUT_DIR}/es_SV.res
++    ${OUT_DIR}/es_US.res
++    ${OUT_DIR}/es_UY.res
++    ${OUT_DIR}/es_VE.res
++    ${OUT_DIR}/et.res
++    ${OUT_DIR}/et_EE.res
++    ${OUT_DIR}/eu.res
++    ${OUT_DIR}/eu_ES.res
++    ${OUT_DIR}/euc-jp-2007.cnv
++    ${OUT_DIR}/euc-tw-2014.cnv
++    ${OUT_DIR}/ewo.res
++    ${OUT_DIR}/ewo_CM.res
++    ${OUT_DIR}/fa.res
++    ${OUT_DIR}/fa_AF.res
++    ${OUT_DIR}/fa_IR.res
++    ${OUT_DIR}/ff.res
++    ${OUT_DIR}/ff_Adlm.res
++    ${OUT_DIR}/ff_Adlm_BF.res
++    ${OUT_DIR}/ff_Adlm_CM.res
++    ${OUT_DIR}/ff_Adlm_GH.res
++    ${OUT_DIR}/ff_Adlm_GM.res
++    ${OUT_DIR}/ff_Adlm_GN.res
++    ${OUT_DIR}/ff_Adlm_GW.res
++    ${OUT_DIR}/ff_Adlm_LR.res
++    ${OUT_DIR}/ff_Adlm_MR.res
++    ${OUT_DIR}/ff_Adlm_NE.res
++    ${OUT_DIR}/ff_Adlm_NG.res
++    ${OUT_DIR}/ff_Adlm_SL.res
++    ${OUT_DIR}/ff_Adlm_SN.res
++    ${OUT_DIR}/ff_CM.res
++    ${OUT_DIR}/ff_GN.res
++    ${OUT_DIR}/ff_Latn.res
++    ${OUT_DIR}/ff_Latn_BF.res
++    ${OUT_DIR}/ff_Latn_CM.res
++    ${OUT_DIR}/ff_Latn_GH.res
++    ${OUT_DIR}/ff_Latn_GM.res
++    ${OUT_DIR}/ff_Latn_GN.res
++    ${OUT_DIR}/ff_Latn_GW.res
++    ${OUT_DIR}/ff_Latn_LR.res
++    ${OUT_DIR}/ff_Latn_MR.res
++    ${OUT_DIR}/ff_Latn_NE.res
++    ${OUT_DIR}/ff_Latn_NG.res
++    ${OUT_DIR}/ff_Latn_SL.res
++    ${OUT_DIR}/ff_Latn_SN.res
++    ${OUT_DIR}/ff_MR.res
++    ${OUT_DIR}/ff_SN.res
++    ${OUT_DIR}/fi.res
++    ${OUT_DIR}/fi_FI.res
++    ${OUT_DIR}/fil.res
++    ${OUT_DIR}/fil_PH.res
++    ${OUT_DIR}/fo.res
++    ${OUT_DIR}/fo_DK.res
++    ${OUT_DIR}/fo_FO.res
++    ${OUT_DIR}/fr.res
++    ${OUT_DIR}/fr_BE.res
++    ${OUT_DIR}/fr_BF.res
++    ${OUT_DIR}/fr_BI.res
++    ${OUT_DIR}/fr_BJ.res
++    ${OUT_DIR}/fr_BL.res
++    ${OUT_DIR}/fr_CA.res
++    ${OUT_DIR}/fr_CD.res
++    ${OUT_DIR}/fr_CF.res
++    ${OUT_DIR}/fr_CG.res
++    ${OUT_DIR}/fr_CH.res
++    ${OUT_DIR}/fr_CI.res
++    ${OUT_DIR}/fr_CM.res
++    ${OUT_DIR}/fr_DJ.res
++    ${OUT_DIR}/fr_DZ.res
++    ${OUT_DIR}/fr_FR.res
++    ${OUT_DIR}/fr_GA.res
++    ${OUT_DIR}/fr_GF.res
++    ${OUT_DIR}/fr_GN.res
++    ${OUT_DIR}/fr_GP.res
++    ${OUT_DIR}/fr_GQ.res
++    ${OUT_DIR}/fr_HT.res
++    ${OUT_DIR}/fr_KM.res
++    ${OUT_DIR}/fr_LU.res
++    ${OUT_DIR}/fr_MA.res
++    ${OUT_DIR}/fr_MC.res
++    ${OUT_DIR}/fr_MF.res
++    ${OUT_DIR}/fr_MG.res
++    ${OUT_DIR}/fr_ML.res
++    ${OUT_DIR}/fr_MQ.res
++    ${OUT_DIR}/fr_MR.res
++    ${OUT_DIR}/fr_MU.res
++    ${OUT_DIR}/fr_NC.res
++    ${OUT_DIR}/fr_NE.res
++    ${OUT_DIR}/fr_PF.res
++    ${OUT_DIR}/fr_PM.res
++    ${OUT_DIR}/fr_RE.res
++    ${OUT_DIR}/fr_RW.res
++    ${OUT_DIR}/fr_SC.res
++    ${OUT_DIR}/fr_SN.res
++    ${OUT_DIR}/fr_SY.res
++    ${OUT_DIR}/fr_TD.res
++    ${OUT_DIR}/fr_TG.res
++    ${OUT_DIR}/fr_TN.res
++    ${OUT_DIR}/fr_VU.res
++    ${OUT_DIR}/fr_WF.res
++    ${OUT_DIR}/fr_YT.res
++    ${OUT_DIR}/fur.res
++    ${OUT_DIR}/fur_IT.res
++    ${OUT_DIR}/fy.res
++    ${OUT_DIR}/fy_NL.res
++    ${OUT_DIR}/ga.res
++    ${OUT_DIR}/ga_GB.res
++    ${OUT_DIR}/ga_IE.res
++    ${OUT_DIR}/gb18030.cnv
++    ${OUT_DIR}/gd.res
++    ${OUT_DIR}/gd_GB.res
++    ${OUT_DIR}/genderList.res
++    ${OUT_DIR}/gl.res
++    ${OUT_DIR}/gl_ES.res
++    ${OUT_DIR}/gsm-03.38-2009.cnv
++    ${OUT_DIR}/gsw.res
++    ${OUT_DIR}/gsw_CH.res
++    ${OUT_DIR}/gsw_FR.res
++    ${OUT_DIR}/gsw_LI.res
++    ${OUT_DIR}/gu.res
++    ${OUT_DIR}/gu_IN.res
++    ${OUT_DIR}/guz.res
++    ${OUT_DIR}/guz_KE.res
++    ${OUT_DIR}/gv.res
++    ${OUT_DIR}/gv_IM.res
++    ${OUT_DIR}/ha.res
++    ${OUT_DIR}/ha_GH.res
++    ${OUT_DIR}/ha_NE.res
++    ${OUT_DIR}/ha_NG.res
++    ${OUT_DIR}/haw.res
++    ${OUT_DIR}/haw_US.res
++    ${OUT_DIR}/he.res
++    ${OUT_DIR}/he_IL.res
++    ${OUT_DIR}/hi.res
++    ${OUT_DIR}/hi_IN.res
++    ${OUT_DIR}/hr.res
++    ${OUT_DIR}/hr_BA.res
++    ${OUT_DIR}/hr_HR.res
++    ${OUT_DIR}/hsb.res
++    ${OUT_DIR}/hsb_DE.res
++    ${OUT_DIR}/hu.res
++    ${OUT_DIR}/hu_HU.res
++    ${OUT_DIR}/hy.res
++    ${OUT_DIR}/hy_AM.res
++    ${OUT_DIR}/ia.res
++    ${OUT_DIR}/ia_001.res
++    ${OUT_DIR}/ibm-1006_P100-1995.cnv
++    ${OUT_DIR}/ibm-1025_P100-1995.cnv
++    ${OUT_DIR}/ibm-1026_P100-1995.cnv
++    ${OUT_DIR}/ibm-1047_P100-1995.cnv
++    ${OUT_DIR}/ibm-1051_P100-1995.cnv
++    ${OUT_DIR}/ibm-1089_P100-1995.cnv
++    ${OUT_DIR}/ibm-1097_P100-1995.cnv
++    ${OUT_DIR}/ibm-1098_P100-1995.cnv
++    ${OUT_DIR}/ibm-1112_P100-1995.cnv
++    ${OUT_DIR}/ibm-1122_P100-1999.cnv
++    ${OUT_DIR}/ibm-1123_P100-1995.cnv
++    ${OUT_DIR}/ibm-1124_P100-1996.cnv
++    ${OUT_DIR}/ibm-1125_P100-1997.cnv
++    ${OUT_DIR}/ibm-1129_P100-1997.cnv
++    ${OUT_DIR}/ibm-1130_P100-1997.cnv
++    ${OUT_DIR}/ibm-1131_P100-1997.cnv
++    ${OUT_DIR}/ibm-1132_P100-1998.cnv
++    ${OUT_DIR}/ibm-1133_P100-1997.cnv
++    ${OUT_DIR}/ibm-1137_P100-1999.cnv
++    ${OUT_DIR}/ibm-1140_P100-1997.cnv
++    ${OUT_DIR}/ibm-1141_P100-1997.cnv
++    ${OUT_DIR}/ibm-1142_P100-1997.cnv
++    ${OUT_DIR}/ibm-1143_P100-1997.cnv
++    ${OUT_DIR}/ibm-1144_P100-1997.cnv
++    ${OUT_DIR}/ibm-1145_P100-1997.cnv
++    ${OUT_DIR}/ibm-1146_P100-1997.cnv
++    ${OUT_DIR}/ibm-1147_P100-1997.cnv
++    ${OUT_DIR}/ibm-1148_P100-1997.cnv
++    ${OUT_DIR}/ibm-1149_P100-1997.cnv
++    ${OUT_DIR}/ibm-1153_P100-1999.cnv
++    ${OUT_DIR}/ibm-1154_P100-1999.cnv
++    ${OUT_DIR}/ibm-1155_P100-1999.cnv
++    ${OUT_DIR}/ibm-1156_P100-1999.cnv
++    ${OUT_DIR}/ibm-1157_P100-1999.cnv
++    ${OUT_DIR}/ibm-1158_P100-1999.cnv
++    ${OUT_DIR}/ibm-1160_P100-1999.cnv
++    ${OUT_DIR}/ibm-1162_P100-1999.cnv
++    ${OUT_DIR}/ibm-1164_P100-1999.cnv
++    ${OUT_DIR}/ibm-1168_P100-2002.cnv
++    ${OUT_DIR}/ibm-1250_P100-1995.cnv
++    ${OUT_DIR}/ibm-1251_P100-1995.cnv
++    ${OUT_DIR}/ibm-1252_P100-2000.cnv
++    ${OUT_DIR}/ibm-1253_P100-1995.cnv
++    ${OUT_DIR}/ibm-1254_P100-1995.cnv
++    ${OUT_DIR}/ibm-1255_P100-1995.cnv
++    ${OUT_DIR}/ibm-1256_P110-1997.cnv
++    ${OUT_DIR}/ibm-1257_P100-1995.cnv
++    ${OUT_DIR}/ibm-1258_P100-1997.cnv
++    ${OUT_DIR}/ibm-12712_P100-1998.cnv
++    ${OUT_DIR}/ibm-1276_P100-1995.cnv
++    ${OUT_DIR}/ibm-1363_P110-1997.cnv
++    ${OUT_DIR}/ibm-1363_P11B-1998.cnv
++    ${OUT_DIR}/ibm-1364_P110-2007.cnv
++    ${OUT_DIR}/ibm-1371_P100-1999.cnv
++    ${OUT_DIR}/ibm-1373_P100-2002.cnv
++    ${OUT_DIR}/ibm-1375_P100-2008.cnv
++    ${OUT_DIR}/ibm-1383_P110-1999.cnv
++    ${OUT_DIR}/ibm-1386_P100-2001.cnv
++    ${OUT_DIR}/ibm-1388_P103-2001.cnv
++    ${OUT_DIR}/ibm-1390_P110-2003.cnv
++    ${OUT_DIR}/ibm-1399_P110-2003.cnv
++    ${OUT_DIR}/ibm-16684_P110-2003.cnv
++    ${OUT_DIR}/ibm-16804_X110-1999.cnv
++    ${OUT_DIR}/ibm-273_P100-1995.cnv
++    ${OUT_DIR}/ibm-277_P100-1995.cnv
++    ${OUT_DIR}/ibm-278_P100-1995.cnv
++    ${OUT_DIR}/ibm-280_P100-1995.cnv
++    ${OUT_DIR}/ibm-284_P100-1995.cnv
++    ${OUT_DIR}/ibm-285_P100-1995.cnv
++    ${OUT_DIR}/ibm-290_P100-1995.cnv
++    ${OUT_DIR}/ibm-297_P100-1995.cnv
++    ${OUT_DIR}/ibm-33722_P120-1999.cnv
++    ${OUT_DIR}/ibm-33722_P12A_P12A-2004_U2.cnv
++    ${OUT_DIR}/ibm-33722_P12A_P12A-2009_U2.cnv
++    ${OUT_DIR}/ibm-37_P100-1995.cnv
++    ${OUT_DIR}/ibm-420_X120-1999.cnv
++    ${OUT_DIR}/ibm-424_P100-1995.cnv
++    ${OUT_DIR}/ibm-437_P100-1995.cnv
++    ${OUT_DIR}/ibm-4517_P100-2005.cnv
++    ${OUT_DIR}/ibm-4899_P100-1998.cnv
++    ${OUT_DIR}/ibm-4909_P100-1999.cnv
++    ${OUT_DIR}/ibm-4971_P100-1999.cnv
++    ${OUT_DIR}/ibm-500_P100-1995.cnv
++    ${OUT_DIR}/ibm-5012_P100-1999.cnv
++    ${OUT_DIR}/ibm-5123_P100-1999.cnv
++    ${OUT_DIR}/ibm-5346_P100-1998.cnv
++    ${OUT_DIR}/ibm-5347_P100-1998.cnv
++    ${OUT_DIR}/ibm-5348_P100-1997.cnv
++    ${OUT_DIR}/ibm-5349_P100-1998.cnv
++    ${OUT_DIR}/ibm-5350_P100-1998.cnv
++    ${OUT_DIR}/ibm-5351_P100-1998.cnv
++    ${OUT_DIR}/ibm-5352_P100-1998.cnv
++    ${OUT_DIR}/ibm-5353_P100-1998.cnv
++    ${OUT_DIR}/ibm-5354_P100-1998.cnv
++    ${OUT_DIR}/ibm-5471_P100-2006.cnv
++    ${OUT_DIR}/ibm-5478_P100-1995.cnv
++    ${OUT_DIR}/ibm-720_P100-1997.cnv
++    ${OUT_DIR}/ibm-737_P100-1997.cnv
++    ${OUT_DIR}/ibm-775_P100-1996.cnv
++    ${OUT_DIR}/ibm-803_P100-1999.cnv
++    ${OUT_DIR}/ibm-813_P100-1995.cnv
++    ${OUT_DIR}/ibm-838_P100-1995.cnv
++    ${OUT_DIR}/ibm-8482_P100-1999.cnv
++    ${OUT_DIR}/ibm-850_P100-1995.cnv
++    ${OUT_DIR}/ibm-851_P100-1995.cnv
++    ${OUT_DIR}/ibm-852_P100-1995.cnv
++    ${OUT_DIR}/ibm-855_P100-1995.cnv
++    ${OUT_DIR}/ibm-856_P100-1995.cnv
++    ${OUT_DIR}/ibm-857_P100-1995.cnv
++    ${OUT_DIR}/ibm-858_P100-1997.cnv
++    ${OUT_DIR}/ibm-860_P100-1995.cnv
++    ${OUT_DIR}/ibm-861_P100-1995.cnv
++    ${OUT_DIR}/ibm-862_P100-1995.cnv
++    ${OUT_DIR}/ibm-863_P100-1995.cnv
++    ${OUT_DIR}/ibm-864_X110-1999.cnv
++    ${OUT_DIR}/ibm-865_P100-1995.cnv
++    ${OUT_DIR}/ibm-866_P100-1995.cnv
++    ${OUT_DIR}/ibm-867_P100-1998.cnv
++    ${OUT_DIR}/ibm-868_P100-1995.cnv
++    ${OUT_DIR}/ibm-869_P100-1995.cnv
++    ${OUT_DIR}/ibm-870_P100-1995.cnv
++    ${OUT_DIR}/ibm-871_P100-1995.cnv
++    ${OUT_DIR}/ibm-874_P100-1995.cnv
++    ${OUT_DIR}/ibm-875_P100-1995.cnv
++    ${OUT_DIR}/ibm-878_P100-1996.cnv
++    ${OUT_DIR}/ibm-9005_X110-2007.cnv
++    ${OUT_DIR}/ibm-901_P100-1999.cnv
++    ${OUT_DIR}/ibm-902_P100-1999.cnv
++    ${OUT_DIR}/ibm-9067_X100-2005.cnv
++    ${OUT_DIR}/ibm-912_P100-1995.cnv
++    ${OUT_DIR}/ibm-913_P100-2000.cnv
++    ${OUT_DIR}/ibm-914_P100-1995.cnv
++    ${OUT_DIR}/ibm-915_P100-1995.cnv
++    ${OUT_DIR}/ibm-916_P100-1995.cnv
++    ${OUT_DIR}/ibm-918_P100-1995.cnv
++    ${OUT_DIR}/ibm-920_P100-1995.cnv
++    ${OUT_DIR}/ibm-921_P100-1995.cnv
++    ${OUT_DIR}/ibm-922_P100-1999.cnv
++    ${OUT_DIR}/ibm-923_P100-1998.cnv
++    ${OUT_DIR}/ibm-930_P120-1999.cnv
++    ${OUT_DIR}/ibm-933_P110-1995.cnv
++    ${OUT_DIR}/ibm-935_P110-1999.cnv
++    ${OUT_DIR}/ibm-937_P110-1999.cnv
++    ${OUT_DIR}/ibm-939_P120-1999.cnv
++    ${OUT_DIR}/ibm-942_P12A-1999.cnv
++    ${OUT_DIR}/ibm-943_P130-1999.cnv
++    ${OUT_DIR}/ibm-943_P15A-2003.cnv
++    ${OUT_DIR}/ibm-9447_P100-2002.cnv
++    ${OUT_DIR}/ibm-9448_X100-2005.cnv
++    ${OUT_DIR}/ibm-9449_P100-2002.cnv
++    ${OUT_DIR}/ibm-949_P110-1999.cnv
++    ${OUT_DIR}/ibm-949_P11A-1999.cnv
++    ${OUT_DIR}/ibm-950_P110-1999.cnv
++    ${OUT_DIR}/ibm-954_P101-2007.cnv
++    ${OUT_DIR}/ibm-964_P110-1999.cnv
++    ${OUT_DIR}/ibm-970_P110_P110-2006_U2.cnv
++    ${OUT_DIR}/ibm-971_P100-1995.cnv
++    ${OUT_DIR}/icu-internal-25546.cnv
++    ${OUT_DIR}/icu-internal-compound-d1.cnv
++    ${OUT_DIR}/icu-internal-compound-d2.cnv
++    ${OUT_DIR}/icu-internal-compound-d3.cnv
++    ${OUT_DIR}/icu-internal-compound-d4.cnv
++    ${OUT_DIR}/icu-internal-compound-d5.cnv
++    ${OUT_DIR}/icu-internal-compound-d6.cnv
++    ${OUT_DIR}/icu-internal-compound-d7.cnv
++    ${OUT_DIR}/icu-internal-compound-s1.cnv
++    ${OUT_DIR}/icu-internal-compound-s2.cnv
++    ${OUT_DIR}/icu-internal-compound-s3.cnv
++    ${OUT_DIR}/icu-internal-compound-t.cnv
++    ${OUT_DIR}/icustd.res
++    ${OUT_DIR}/icuver.res
++    ${OUT_DIR}/id.res
++    ${OUT_DIR}/id_ID.res
++    ${OUT_DIR}/ig.res
++    ${OUT_DIR}/ig_NG.res
++    ${OUT_DIR}/ii.res
++    ${OUT_DIR}/ii_CN.res
++    ${OUT_DIR}/in.res
++    ${OUT_DIR}/in_ID.res
++    ${OUT_DIR}/is.res
++    ${OUT_DIR}/is_IS.res
++    ${OUT_DIR}/iso-8859_10-1998.cnv
++    ${OUT_DIR}/iso-8859_11-2001.cnv
++    ${OUT_DIR}/iso-8859_14-1998.cnv
++    ${OUT_DIR}/iso-ir-165.cnv
++    ${OUT_DIR}/it.res
++    ${OUT_DIR}/it_CH.res
++    ${OUT_DIR}/it_IT.res
++    ${OUT_DIR}/it_SM.res
++    ${OUT_DIR}/it_VA.res
++    ${OUT_DIR}/iw.res
++    ${OUT_DIR}/iw_IL.res
++    ${OUT_DIR}/ja.res
++    ${OUT_DIR}/ja_JP.res
++    ${OUT_DIR}/ja_JP_TRADITIONAL.res
++    ${OUT_DIR}/jgo.res
++    ${OUT_DIR}/jgo_CM.res
++    ${OUT_DIR}/jisx-212.cnv
++    ${OUT_DIR}/jmc.res
++    ${OUT_DIR}/jmc_TZ.res
++    ${OUT_DIR}/jv.res
++    ${OUT_DIR}/jv_ID.res
++    ${OUT_DIR}/ka.res
++    ${OUT_DIR}/ka_GE.res
++    ${OUT_DIR}/kab.res
++    ${OUT_DIR}/kab_DZ.res
++    ${OUT_DIR}/kam.res
++    ${OUT_DIR}/kam_KE.res
++    ${OUT_DIR}/kde.res
++    ${OUT_DIR}/kde_TZ.res
++    ${OUT_DIR}/kea.res
++    ${OUT_DIR}/kea_CV.res
++    ${OUT_DIR}/keyTypeData.res
++    ${OUT_DIR}/khq.res
++    ${OUT_DIR}/khq_ML.res
++    ${OUT_DIR}/ki.res
++    ${OUT_DIR}/ki_KE.res
++    ${OUT_DIR}/kk.res
++    ${OUT_DIR}/kk_KZ.res
++    ${OUT_DIR}/kkj.res
++    ${OUT_DIR}/kkj_CM.res
++    ${OUT_DIR}/kl.res
++    ${OUT_DIR}/kl_GL.res
++    ${OUT_DIR}/kln.res
++    ${OUT_DIR}/kln_KE.res
++    ${OUT_DIR}/km.res
++    ${OUT_DIR}/km_KH.res
++    ${OUT_DIR}/kn.res
++    ${OUT_DIR}/kn_IN.res
++    ${OUT_DIR}/ko.res
++    ${OUT_DIR}/ko_KP.res
++    ${OUT_DIR}/ko_KR.res
++    ${OUT_DIR}/kok.res
++    ${OUT_DIR}/kok_IN.res
++    ${OUT_DIR}/ks.res
++    ${OUT_DIR}/ks_Arab.res
++    ${OUT_DIR}/ks_Arab_IN.res
++    ${OUT_DIR}/ks_IN.res
++    ${OUT_DIR}/ksb.res
++    ${OUT_DIR}/ksb_TZ.res
++    ${OUT_DIR}/ksf.res
++    ${OUT_DIR}/ksf_CM.res
++    ${OUT_DIR}/ksh.res
++    ${OUT_DIR}/ksh_DE.res
++    ${OUT_DIR}/ku.res
++    ${OUT_DIR}/ku_TR.res
++    ${OUT_DIR}/kw.res
++    ${OUT_DIR}/kw_GB.res
++    ${OUT_DIR}/ky.res
++    ${OUT_DIR}/ky_KG.res
++    ${OUT_DIR}/lag.res
++    ${OUT_DIR}/lag_TZ.res
++    ${OUT_DIR}/lang/${INDEX_NAME}.res
++    ${OUT_DIR}/lang/af.res
++    ${OUT_DIR}/lang/agq.res
++    ${OUT_DIR}/lang/ak.res
++    ${OUT_DIR}/lang/am.res
++    ${OUT_DIR}/lang/ar.res
++    ${OUT_DIR}/lang/ar_EG.res
++    ${OUT_DIR}/lang/ar_LY.res
++    ${OUT_DIR}/lang/ar_SA.res
++    ${OUT_DIR}/lang/ars.res
++    ${OUT_DIR}/lang/as.res
++    ${OUT_DIR}/lang/asa.res
++    ${OUT_DIR}/lang/ast.res
++    ${OUT_DIR}/lang/az.res
++    ${OUT_DIR}/lang/az_AZ.res
++    ${OUT_DIR}/lang/az_Cyrl.res
++    ${OUT_DIR}/lang/az_Latn.res
++    ${OUT_DIR}/lang/az_Latn_AZ.res
++    ${OUT_DIR}/lang/bas.res
++    ${OUT_DIR}/lang/be.res
++    ${OUT_DIR}/lang/bem.res
++    ${OUT_DIR}/lang/bez.res
++    ${OUT_DIR}/lang/bg.res
++    ${OUT_DIR}/lang/bm.res
++    ${OUT_DIR}/lang/bn.res
++    ${OUT_DIR}/lang/bn_IN.res
++    ${OUT_DIR}/lang/bo.res
++    ${OUT_DIR}/lang/br.res
++    ${OUT_DIR}/lang/brx.res
++    ${OUT_DIR}/lang/bs.res
++    ${OUT_DIR}/lang/bs_BA.res
++    ${OUT_DIR}/lang/bs_Cyrl.res
++    ${OUT_DIR}/lang/bs_Latn.res
++    ${OUT_DIR}/lang/bs_Latn_BA.res
++    ${OUT_DIR}/lang/ca.res
++    ${OUT_DIR}/lang/ccp.res
++    ${OUT_DIR}/lang/ce.res
++    ${OUT_DIR}/lang/ceb.res
++    ${OUT_DIR}/lang/cgg.res
++    ${OUT_DIR}/lang/chr.res
++    ${OUT_DIR}/lang/ckb.res
++    ${OUT_DIR}/lang/cs.res
++    ${OUT_DIR}/lang/cy.res
++    ${OUT_DIR}/lang/da.res
++    ${OUT_DIR}/lang/dav.res
++    ${OUT_DIR}/lang/de.res
++    ${OUT_DIR}/lang/de_AT.res
++    ${OUT_DIR}/lang/de_CH.res
++    ${OUT_DIR}/lang/de_LU.res
++    ${OUT_DIR}/lang/dje.res
++    ${OUT_DIR}/lang/dsb.res
++    ${OUT_DIR}/lang/dua.res
++    ${OUT_DIR}/lang/dyo.res
++    ${OUT_DIR}/lang/dz.res
++    ${OUT_DIR}/lang/ebu.res
++    ${OUT_DIR}/lang/ee.res
++    ${OUT_DIR}/lang/el.res
++    ${OUT_DIR}/lang/en.res
++    ${OUT_DIR}/lang/en_001.res
++    ${OUT_DIR}/lang/en_150.res
++    ${OUT_DIR}/lang/en_AG.res
++    ${OUT_DIR}/lang/en_AI.res
++    ${OUT_DIR}/lang/en_AT.res
++    ${OUT_DIR}/lang/en_AU.res
++    ${OUT_DIR}/lang/en_BB.res
++    ${OUT_DIR}/lang/en_BE.res
++    ${OUT_DIR}/lang/en_BM.res
++    ${OUT_DIR}/lang/en_BS.res
++    ${OUT_DIR}/lang/en_BW.res
++    ${OUT_DIR}/lang/en_BZ.res
++    ${OUT_DIR}/lang/en_CA.res
++    ${OUT_DIR}/lang/en_CC.res
++    ${OUT_DIR}/lang/en_CH.res
++    ${OUT_DIR}/lang/en_CK.res
++    ${OUT_DIR}/lang/en_CM.res
++    ${OUT_DIR}/lang/en_CX.res
++    ${OUT_DIR}/lang/en_CY.res
++    ${OUT_DIR}/lang/en_DE.res
++    ${OUT_DIR}/lang/en_DG.res
++    ${OUT_DIR}/lang/en_DK.res
++    ${OUT_DIR}/lang/en_DM.res
++    ${OUT_DIR}/lang/en_ER.res
++    ${OUT_DIR}/lang/en_FI.res
++    ${OUT_DIR}/lang/en_FJ.res
++    ${OUT_DIR}/lang/en_FK.res
++    ${OUT_DIR}/lang/en_FM.res
++    ${OUT_DIR}/lang/en_GB.res
++    ${OUT_DIR}/lang/en_GD.res
++    ${OUT_DIR}/lang/en_GG.res
++    ${OUT_DIR}/lang/en_GH.res
++    ${OUT_DIR}/lang/en_GI.res
++    ${OUT_DIR}/lang/en_GM.res
++    ${OUT_DIR}/lang/en_GY.res
++    ${OUT_DIR}/lang/en_HK.res
++    ${OUT_DIR}/lang/en_IE.res
++    ${OUT_DIR}/lang/en_IL.res
++    ${OUT_DIR}/lang/en_IM.res
++    ${OUT_DIR}/lang/en_IN.res
++    ${OUT_DIR}/lang/en_IO.res
++    ${OUT_DIR}/lang/en_JE.res
++    ${OUT_DIR}/lang/en_JM.res
++    ${OUT_DIR}/lang/en_KE.res
++    ${OUT_DIR}/lang/en_KI.res
++    ${OUT_DIR}/lang/en_KN.res
++    ${OUT_DIR}/lang/en_KY.res
++    ${OUT_DIR}/lang/en_LC.res
++    ${OUT_DIR}/lang/en_LR.res
++    ${OUT_DIR}/lang/en_LS.res
++    ${OUT_DIR}/lang/en_MG.res
++    ${OUT_DIR}/lang/en_MO.res
++    ${OUT_DIR}/lang/en_MS.res
++    ${OUT_DIR}/lang/en_MT.res
++    ${OUT_DIR}/lang/en_MU.res
++    ${OUT_DIR}/lang/en_MW.res
++    ${OUT_DIR}/lang/en_MY.res
++    ${OUT_DIR}/lang/en_NA.res
++    ${OUT_DIR}/lang/en_NF.res
++    ${OUT_DIR}/lang/en_NG.res
++    ${OUT_DIR}/lang/en_NH.res
++    ${OUT_DIR}/lang/en_NL.res
++    ${OUT_DIR}/lang/en_NR.res
++    ${OUT_DIR}/lang/en_NU.res
++    ${OUT_DIR}/lang/en_NZ.res
++    ${OUT_DIR}/lang/en_PG.res
++    ${OUT_DIR}/lang/en_PH.res
++    ${OUT_DIR}/lang/en_PK.res
++    ${OUT_DIR}/lang/en_PN.res
++    ${OUT_DIR}/lang/en_PW.res
++    ${OUT_DIR}/lang/en_RH.res
++    ${OUT_DIR}/lang/en_RW.res
++    ${OUT_DIR}/lang/en_SB.res
++    ${OUT_DIR}/lang/en_SC.res
++    ${OUT_DIR}/lang/en_SD.res
++    ${OUT_DIR}/lang/en_SE.res
++    ${OUT_DIR}/lang/en_SG.res
++    ${OUT_DIR}/lang/en_SH.res
++    ${OUT_DIR}/lang/en_SI.res
++    ${OUT_DIR}/lang/en_SL.res
++    ${OUT_DIR}/lang/en_SS.res
++    ${OUT_DIR}/lang/en_SX.res
++    ${OUT_DIR}/lang/en_SZ.res
++    ${OUT_DIR}/lang/en_TC.res
++    ${OUT_DIR}/lang/en_TK.res
++    ${OUT_DIR}/lang/en_TO.res
++    ${OUT_DIR}/lang/en_TT.res
++    ${OUT_DIR}/lang/en_TV.res
++    ${OUT_DIR}/lang/en_TZ.res
++    ${OUT_DIR}/lang/en_UG.res
++    ${OUT_DIR}/lang/en_VC.res
++    ${OUT_DIR}/lang/en_VG.res
++    ${OUT_DIR}/lang/en_VU.res
++    ${OUT_DIR}/lang/en_WS.res
++    ${OUT_DIR}/lang/en_ZA.res
++    ${OUT_DIR}/lang/en_ZM.res
++    ${OUT_DIR}/lang/en_ZW.res
++    ${OUT_DIR}/lang/eo.res
++    ${OUT_DIR}/lang/es.res
++    ${OUT_DIR}/lang/es_419.res
++    ${OUT_DIR}/lang/es_AR.res
++    ${OUT_DIR}/lang/es_BO.res
++    ${OUT_DIR}/lang/es_BR.res
++    ${OUT_DIR}/lang/es_BZ.res
++    ${OUT_DIR}/lang/es_CL.res
++    ${OUT_DIR}/lang/es_CO.res
++    ${OUT_DIR}/lang/es_CR.res
++    ${OUT_DIR}/lang/es_CU.res
++    ${OUT_DIR}/lang/es_DO.res
++    ${OUT_DIR}/lang/es_EC.res
++    ${OUT_DIR}/lang/es_GT.res
++    ${OUT_DIR}/lang/es_HN.res
++    ${OUT_DIR}/lang/es_MX.res
++    ${OUT_DIR}/lang/es_NI.res
++    ${OUT_DIR}/lang/es_PA.res
++    ${OUT_DIR}/lang/es_PE.res
++    ${OUT_DIR}/lang/es_PR.res
++    ${OUT_DIR}/lang/es_PY.res
++    ${OUT_DIR}/lang/es_SV.res
++    ${OUT_DIR}/lang/es_US.res
++    ${OUT_DIR}/lang/es_UY.res
++    ${OUT_DIR}/lang/es_VE.res
++    ${OUT_DIR}/lang/et.res
++    ${OUT_DIR}/lang/eu.res
++    ${OUT_DIR}/lang/ewo.res
++    ${OUT_DIR}/lang/fa.res
++    ${OUT_DIR}/lang/fa_AF.res
++    ${OUT_DIR}/lang/ff.res
++    ${OUT_DIR}/lang/ff_Adlm.res
++    ${OUT_DIR}/lang/ff_CM.res
++    ${OUT_DIR}/lang/ff_GN.res
++    ${OUT_DIR}/lang/ff_Latn.res
++    ${OUT_DIR}/lang/ff_Latn_CM.res
++    ${OUT_DIR}/lang/ff_Latn_GN.res
++    ${OUT_DIR}/lang/ff_Latn_MR.res
++    ${OUT_DIR}/lang/ff_Latn_SN.res
++    ${OUT_DIR}/lang/ff_MR.res
++    ${OUT_DIR}/lang/ff_SN.res
++    ${OUT_DIR}/lang/fi.res
++    ${OUT_DIR}/lang/fil.res
++    ${OUT_DIR}/lang/fil_PH.res
++    ${OUT_DIR}/lang/fo.res
++    ${OUT_DIR}/lang/fr.res
++    ${OUT_DIR}/lang/fr_BE.res
++    ${OUT_DIR}/lang/fr_CA.res
++    ${OUT_DIR}/lang/fr_CH.res
++    ${OUT_DIR}/lang/fur.res
++    ${OUT_DIR}/lang/fy.res
++    ${OUT_DIR}/lang/ga.res
++    ${OUT_DIR}/lang/gd.res
++    ${OUT_DIR}/lang/gl.res
++    ${OUT_DIR}/lang/gsw.res
++    ${OUT_DIR}/lang/gu.res
++    ${OUT_DIR}/lang/guz.res
++    ${OUT_DIR}/lang/gv.res
++    ${OUT_DIR}/lang/ha.res
++    ${OUT_DIR}/lang/ha_NE.res
++    ${OUT_DIR}/lang/haw.res
++    ${OUT_DIR}/lang/he.res
++    ${OUT_DIR}/lang/he_IL.res
++    ${OUT_DIR}/lang/hi.res
++    ${OUT_DIR}/lang/hr.res
++    ${OUT_DIR}/lang/hsb.res
++    ${OUT_DIR}/lang/hu.res
++    ${OUT_DIR}/lang/hy.res
++    ${OUT_DIR}/lang/ia.res
++    ${OUT_DIR}/lang/id.res
++    ${OUT_DIR}/lang/id_ID.res
++    ${OUT_DIR}/lang/ig.res
++    ${OUT_DIR}/lang/ii.res
++    ${OUT_DIR}/lang/in.res
++    ${OUT_DIR}/lang/in_ID.res
++    ${OUT_DIR}/lang/is.res
++    ${OUT_DIR}/lang/it.res
++    ${OUT_DIR}/lang/iw.res
++    ${OUT_DIR}/lang/iw_IL.res
++    ${OUT_DIR}/lang/ja.res
++    ${OUT_DIR}/lang/jgo.res
++    ${OUT_DIR}/lang/jmc.res
++    ${OUT_DIR}/lang/jv.res
++    ${OUT_DIR}/lang/ka.res
++    ${OUT_DIR}/lang/kab.res
++    ${OUT_DIR}/lang/kam.res
++    ${OUT_DIR}/lang/kde.res
++    ${OUT_DIR}/lang/kea.res
++    ${OUT_DIR}/lang/khq.res
++    ${OUT_DIR}/lang/ki.res
++    ${OUT_DIR}/lang/kk.res
++    ${OUT_DIR}/lang/kkj.res
++    ${OUT_DIR}/lang/kl.res
++    ${OUT_DIR}/lang/kln.res
++    ${OUT_DIR}/lang/km.res
++    ${OUT_DIR}/lang/kn.res
++    ${OUT_DIR}/lang/ko.res
++    ${OUT_DIR}/lang/kok.res
++    ${OUT_DIR}/lang/ks.res
++    ${OUT_DIR}/lang/ks_Arab.res
++    ${OUT_DIR}/lang/ks_Arab_IN.res
++    ${OUT_DIR}/lang/ks_IN.res
++    ${OUT_DIR}/lang/ksb.res
++    ${OUT_DIR}/lang/ksf.res
++    ${OUT_DIR}/lang/ksh.res
++    ${OUT_DIR}/lang/ku.res
++    ${OUT_DIR}/lang/kw.res
++    ${OUT_DIR}/lang/ky.res
++    ${OUT_DIR}/lang/lag.res
++    ${OUT_DIR}/lang/lb.res
++    ${OUT_DIR}/lang/lg.res
++    ${OUT_DIR}/lang/lkt.res
++    ${OUT_DIR}/lang/ln.res
++    ${OUT_DIR}/lang/lo.res
++    ${OUT_DIR}/lang/lrc.res
++    ${OUT_DIR}/lang/lt.res
++    ${OUT_DIR}/lang/lu.res
++    ${OUT_DIR}/lang/luo.res
++    ${OUT_DIR}/lang/luy.res
++    ${OUT_DIR}/lang/lv.res
++    ${OUT_DIR}/lang/mai.res
++    ${OUT_DIR}/lang/mas.res
++    ${OUT_DIR}/lang/mer.res
++    ${OUT_DIR}/lang/mfe.res
++    ${OUT_DIR}/lang/mg.res
++    ${OUT_DIR}/lang/mgh.res
++    ${OUT_DIR}/lang/mgo.res
++    ${OUT_DIR}/lang/mi.res
++    ${OUT_DIR}/lang/mk.res
++    ${OUT_DIR}/lang/ml.res
++    ${OUT_DIR}/lang/mn.res
++    ${OUT_DIR}/lang/mni.res
++    ${OUT_DIR}/lang/mni_Beng.res
++    ${OUT_DIR}/lang/mni_Beng_IN.res
++    ${OUT_DIR}/lang/mni_IN.res
++    ${OUT_DIR}/lang/mo.res
++    ${OUT_DIR}/lang/mr.res
++    ${OUT_DIR}/lang/ms.res
++    ${OUT_DIR}/lang/mt.res
++    ${OUT_DIR}/lang/mua.res
++    ${OUT_DIR}/lang/my.res
++    ${OUT_DIR}/lang/mzn.res
++    ${OUT_DIR}/lang/naq.res
++    ${OUT_DIR}/lang/nb.res
++    ${OUT_DIR}/lang/nb_NO.res
++    ${OUT_DIR}/lang/nd.res
++    ${OUT_DIR}/lang/nds.res
++    ${OUT_DIR}/lang/ne.res
++    ${OUT_DIR}/lang/nl.res
++    ${OUT_DIR}/lang/nmg.res
++    ${OUT_DIR}/lang/nn.res
++    ${OUT_DIR}/lang/nn_NO.res
++    ${OUT_DIR}/lang/nnh.res
++    ${OUT_DIR}/lang/no.res
++    ${OUT_DIR}/lang/no_NO.res
++    ${OUT_DIR}/lang/no_NO_NY.res
++    ${OUT_DIR}/lang/nus.res
++    ${OUT_DIR}/lang/nyn.res
++    ${OUT_DIR}/lang/om.res
++    ${OUT_DIR}/lang/or.res
++    ${OUT_DIR}/lang/os.res
++    ${OUT_DIR}/lang/pa.res
++    ${OUT_DIR}/lang/pa_Arab.res
++    ${OUT_DIR}/lang/pa_Arab_PK.res
++    ${OUT_DIR}/lang/pa_Guru.res
++    ${OUT_DIR}/lang/pa_Guru_IN.res
++    ${OUT_DIR}/lang/pa_IN.res
++    ${OUT_DIR}/lang/pa_PK.res
++    ${OUT_DIR}/lang/pcm.res
++    ${OUT_DIR}/lang/pl.res
++    ${OUT_DIR}/lang/pool.res
++    ${OUT_DIR}/lang/ps.res
++    ${OUT_DIR}/lang/ps_PK.res
++    ${OUT_DIR}/lang/pt.res
++    ${OUT_DIR}/lang/pt_AO.res
++    ${OUT_DIR}/lang/pt_CH.res
++    ${OUT_DIR}/lang/pt_CV.res
++    ${OUT_DIR}/lang/pt_GQ.res
++    ${OUT_DIR}/lang/pt_GW.res
++    ${OUT_DIR}/lang/pt_LU.res
++    ${OUT_DIR}/lang/pt_MO.res
++    ${OUT_DIR}/lang/pt_MZ.res
++    ${OUT_DIR}/lang/pt_PT.res
++    ${OUT_DIR}/lang/pt_ST.res
++    ${OUT_DIR}/lang/pt_TL.res
++    ${OUT_DIR}/lang/qu.res
++    ${OUT_DIR}/lang/rm.res
++    ${OUT_DIR}/lang/rn.res
++    ${OUT_DIR}/lang/ro.res
++    ${OUT_DIR}/lang/ro_MD.res
++    ${OUT_DIR}/lang/rof.res
++    ${OUT_DIR}/lang/root.res
++    ${OUT_DIR}/lang/ru.res
++    ${OUT_DIR}/lang/rw.res
++    ${OUT_DIR}/lang/rwk.res
++    ${OUT_DIR}/lang/sah.res
++    ${OUT_DIR}/lang/saq.res
++    ${OUT_DIR}/lang/sat.res
++    ${OUT_DIR}/lang/sat_IN.res
++    ${OUT_DIR}/lang/sat_Olck.res
++    ${OUT_DIR}/lang/sat_Olck_IN.res
++    ${OUT_DIR}/lang/sbp.res
++    ${OUT_DIR}/lang/sd.res
++    ${OUT_DIR}/lang/sd_Arab.res
++    ${OUT_DIR}/lang/sd_Arab_PK.res
++    ${OUT_DIR}/lang/sd_Deva.res
++    ${OUT_DIR}/lang/sd_PK.res
++    ${OUT_DIR}/lang/se.res
++    ${OUT_DIR}/lang/se_FI.res
++    ${OUT_DIR}/lang/seh.res
++    ${OUT_DIR}/lang/ses.res
++    ${OUT_DIR}/lang/sg.res
++    ${OUT_DIR}/lang/sh.res
++    ${OUT_DIR}/lang/sh_BA.res
++    ${OUT_DIR}/lang/sh_CS.res
++    ${OUT_DIR}/lang/sh_YU.res
++    ${OUT_DIR}/lang/shi.res
++    ${OUT_DIR}/lang/shi_Latn.res
++    ${OUT_DIR}/lang/shi_MA.res
++    ${OUT_DIR}/lang/shi_Tfng.res
++    ${OUT_DIR}/lang/shi_Tfng_MA.res
++    ${OUT_DIR}/lang/si.res
++    ${OUT_DIR}/lang/sk.res
++    ${OUT_DIR}/lang/sl.res
++    ${OUT_DIR}/lang/smn.res
++    ${OUT_DIR}/lang/sn.res
++    ${OUT_DIR}/lang/so.res
++    ${OUT_DIR}/lang/sq.res
++    ${OUT_DIR}/lang/sr.res
++    ${OUT_DIR}/lang/sr_BA.res
++    ${OUT_DIR}/lang/sr_CS.res
++    ${OUT_DIR}/lang/sr_Cyrl.res
++    ${OUT_DIR}/lang/sr_Cyrl_BA.res
++    ${OUT_DIR}/lang/sr_Cyrl_CS.res
++    ${OUT_DIR}/lang/sr_Cyrl_ME.res
++    ${OUT_DIR}/lang/sr_Cyrl_RS.res
++    ${OUT_DIR}/lang/sr_Cyrl_XK.res
++    ${OUT_DIR}/lang/sr_Cyrl_YU.res
++    ${OUT_DIR}/lang/sr_Latn.res
++    ${OUT_DIR}/lang/sr_Latn_BA.res
++    ${OUT_DIR}/lang/sr_Latn_CS.res
++    ${OUT_DIR}/lang/sr_Latn_ME.res
++    ${OUT_DIR}/lang/sr_Latn_RS.res
++    ${OUT_DIR}/lang/sr_Latn_XK.res
++    ${OUT_DIR}/lang/sr_Latn_YU.res
++    ${OUT_DIR}/lang/sr_ME.res
++    ${OUT_DIR}/lang/sr_RS.res
++    ${OUT_DIR}/lang/sr_XK.res
++    ${OUT_DIR}/lang/sr_YU.res
++    ${OUT_DIR}/lang/su.res
++    ${OUT_DIR}/lang/su_ID.res
++    ${OUT_DIR}/lang/su_Latn.res
++    ${OUT_DIR}/lang/su_Latn_ID.res
++    ${OUT_DIR}/lang/sv.res
++    ${OUT_DIR}/lang/sv_FI.res
++    ${OUT_DIR}/lang/sw.res
++    ${OUT_DIR}/lang/sw_CD.res
++    ${OUT_DIR}/lang/sw_KE.res
++    ${OUT_DIR}/lang/ta.res
++    ${OUT_DIR}/lang/te.res
++    ${OUT_DIR}/lang/teo.res
++    ${OUT_DIR}/lang/tg.res
++    ${OUT_DIR}/lang/th.res
++    ${OUT_DIR}/lang/ti.res
++    ${OUT_DIR}/lang/tk.res
++    ${OUT_DIR}/lang/tl.res
++    ${OUT_DIR}/lang/tl_PH.res
++    ${OUT_DIR}/lang/to.res
++    ${OUT_DIR}/lang/tr.res
++    ${OUT_DIR}/lang/tt.res
++    ${OUT_DIR}/lang/twq.res
++    ${OUT_DIR}/lang/tzm.res
++    ${OUT_DIR}/lang/ug.res
++    ${OUT_DIR}/lang/uk.res
++    ${OUT_DIR}/lang/ur.res
++    ${OUT_DIR}/lang/ur_IN.res
++    ${OUT_DIR}/lang/uz.res
++    ${OUT_DIR}/lang/uz_AF.res
++    ${OUT_DIR}/lang/uz_Arab.res
++    ${OUT_DIR}/lang/uz_Arab_AF.res
++    ${OUT_DIR}/lang/uz_Cyrl.res
++    ${OUT_DIR}/lang/uz_Latn.res
++    ${OUT_DIR}/lang/uz_Latn_UZ.res
++    ${OUT_DIR}/lang/uz_UZ.res
++    ${OUT_DIR}/lang/vai.res
++    ${OUT_DIR}/lang/vai_LR.res
++    ${OUT_DIR}/lang/vai_Latn.res
++    ${OUT_DIR}/lang/vai_Vaii.res
++    ${OUT_DIR}/lang/vai_Vaii_LR.res
++    ${OUT_DIR}/lang/vi.res
++    ${OUT_DIR}/lang/vun.res
++    ${OUT_DIR}/lang/wae.res
++    ${OUT_DIR}/lang/wo.res
++    ${OUT_DIR}/lang/xh.res
++    ${OUT_DIR}/lang/xog.res
++    ${OUT_DIR}/lang/yav.res
++    ${OUT_DIR}/lang/yi.res
++    ${OUT_DIR}/lang/yo.res
++    ${OUT_DIR}/lang/yo_BJ.res
++    ${OUT_DIR}/lang/yue.res
++    ${OUT_DIR}/lang/yue_CN.res
++    ${OUT_DIR}/lang/yue_HK.res
++    ${OUT_DIR}/lang/yue_Hans.res
++    ${OUT_DIR}/lang/yue_Hans_CN.res
++    ${OUT_DIR}/lang/yue_Hant.res
++    ${OUT_DIR}/lang/yue_Hant_HK.res
++    ${OUT_DIR}/lang/zgh.res
++    ${OUT_DIR}/lang/zh.res
++    ${OUT_DIR}/lang/zh_CN.res
++    ${OUT_DIR}/lang/zh_HK.res
++    ${OUT_DIR}/lang/zh_Hans.res
++    ${OUT_DIR}/lang/zh_Hans_CN.res
++    ${OUT_DIR}/lang/zh_Hans_SG.res
++    ${OUT_DIR}/lang/zh_Hant.res
++    ${OUT_DIR}/lang/zh_Hant_HK.res
++    ${OUT_DIR}/lang/zh_Hant_MO.res
++    ${OUT_DIR}/lang/zh_Hant_TW.res
++    ${OUT_DIR}/lang/zh_MO.res
++    ${OUT_DIR}/lang/zh_SG.res
++    ${OUT_DIR}/lang/zh_TW.res
++    ${OUT_DIR}/lang/zu.res
++    ${OUT_DIR}/langInfo.res
++    ${OUT_DIR}/lb.res
++    ${OUT_DIR}/lb_LU.res
++    ${OUT_DIR}/lg.res
++    ${OUT_DIR}/lg_UG.res
++    ${OUT_DIR}/likelySubtags.res
++    ${OUT_DIR}/lkt.res
++    ${OUT_DIR}/lkt_US.res
++    ${OUT_DIR}/lmb-excp.cnv
++    ${OUT_DIR}/ln.res
++    ${OUT_DIR}/ln_AO.res
++    ${OUT_DIR}/ln_CD.res
++    ${OUT_DIR}/ln_CF.res
++    ${OUT_DIR}/ln_CG.res
++    ${OUT_DIR}/lo.res
++    ${OUT_DIR}/lo_LA.res
++    ${OUT_DIR}/lrc.res
++    ${OUT_DIR}/lrc_IQ.res
++    ${OUT_DIR}/lrc_IR.res
++    ${OUT_DIR}/lt.res
++    ${OUT_DIR}/lt_LT.res
++    ${OUT_DIR}/lu.res
++    ${OUT_DIR}/lu_CD.res
++    ${OUT_DIR}/luo.res
++    ${OUT_DIR}/luo_KE.res
++    ${OUT_DIR}/luy.res
++    ${OUT_DIR}/luy_KE.res
++    ${OUT_DIR}/lv.res
++    ${OUT_DIR}/lv_LV.res
++    ${OUT_DIR}/macos-0_2-10.2.cnv
++    ${OUT_DIR}/macos-29-10.2.cnv
++    ${OUT_DIR}/macos-35-10.2.cnv
++    ${OUT_DIR}/macos-6_2-10.4.cnv
++    ${OUT_DIR}/macos-7_3-10.2.cnv
++    ${OUT_DIR}/mai.res
++    ${OUT_DIR}/mai_IN.res
++    ${OUT_DIR}/mas.res
++    ${OUT_DIR}/mas_KE.res
++    ${OUT_DIR}/mas_TZ.res
++    ${OUT_DIR}/mer.res
++    ${OUT_DIR}/mer_KE.res
++    ${OUT_DIR}/metaZones.res
++    ${OUT_DIR}/metadata.res
++    ${OUT_DIR}/mfe.res
++    ${OUT_DIR}/mfe_MU.res
++    ${OUT_DIR}/mg.res
++    ${OUT_DIR}/mg_MG.res
++    ${OUT_DIR}/mgh.res
++    ${OUT_DIR}/mgh_MZ.res
++    ${OUT_DIR}/mgo.res
++    ${OUT_DIR}/mgo_CM.res
++    ${OUT_DIR}/mi.res
++    ${OUT_DIR}/mi_NZ.res
++    ${OUT_DIR}/mk.res
++    ${OUT_DIR}/mk_MK.res
++    ${OUT_DIR}/ml.res
++    ${OUT_DIR}/ml_IN.res
++    ${OUT_DIR}/mn.res
++    ${OUT_DIR}/mn_MN.res
++    ${OUT_DIR}/mni.res
++    ${OUT_DIR}/mni_Beng.res
++    ${OUT_DIR}/mni_Beng_IN.res
++    ${OUT_DIR}/mni_IN.res
++    ${OUT_DIR}/mo.res
++    ${OUT_DIR}/mr.res
++    ${OUT_DIR}/mr_IN.res
++    ${OUT_DIR}/ms.res
++    ${OUT_DIR}/ms_BN.res
++    ${OUT_DIR}/ms_ID.res
++    ${OUT_DIR}/ms_MY.res
++    ${OUT_DIR}/ms_SG.res
++    ${OUT_DIR}/mt.res
++    ${OUT_DIR}/mt_MT.res
++    ${OUT_DIR}/mua.res
++    ${OUT_DIR}/mua_CM.res
++    ${OUT_DIR}/my.res
++    ${OUT_DIR}/my_MM.res
++    ${OUT_DIR}/mzn.res
++    ${OUT_DIR}/mzn_IR.res
++    ${OUT_DIR}/naq.res
++    ${OUT_DIR}/naq_NA.res
++    ${OUT_DIR}/nb.res
++    ${OUT_DIR}/nb_NO.res
++    ${OUT_DIR}/nb_SJ.res
++    ${OUT_DIR}/nd.res
++    ${OUT_DIR}/nd_ZW.res
++    ${OUT_DIR}/nds.res
++    ${OUT_DIR}/nds_DE.res
++    ${OUT_DIR}/nds_NL.res
++    ${OUT_DIR}/ne.res
++    ${OUT_DIR}/ne_IN.res
++    ${OUT_DIR}/ne_NP.res
++    ${OUT_DIR}/nfkc.nrm
++    ${OUT_DIR}/nfkc_cf.nrm
++    ${OUT_DIR}/nl.res
++    ${OUT_DIR}/nl_AW.res
++    ${OUT_DIR}/nl_BE.res
++    ${OUT_DIR}/nl_BQ.res
++    ${OUT_DIR}/nl_CW.res
++    ${OUT_DIR}/nl_NL.res
++    ${OUT_DIR}/nl_SR.res
++    ${OUT_DIR}/nl_SX.res
++    ${OUT_DIR}/nmg.res
++    ${OUT_DIR}/nmg_CM.res
++    ${OUT_DIR}/nn.res
++    ${OUT_DIR}/nn_NO.res
++    ${OUT_DIR}/nnh.res
++    ${OUT_DIR}/nnh_CM.res
++    ${OUT_DIR}/no.res
++    ${OUT_DIR}/no_NO.res
++    ${OUT_DIR}/no_NO_NY.res
++    ${OUT_DIR}/numberingSystems.res
++    ${OUT_DIR}/nus.res
++    ${OUT_DIR}/nus_SS.res
++    ${OUT_DIR}/nyn.res
++    ${OUT_DIR}/nyn_UG.res
++    ${OUT_DIR}/om.res
++    ${OUT_DIR}/om_ET.res
++    ${OUT_DIR}/om_KE.res
++    ${OUT_DIR}/or.res
++    ${OUT_DIR}/or_IN.res
++    ${OUT_DIR}/os.res
++    ${OUT_DIR}/os_GE.res
++    ${OUT_DIR}/os_RU.res
++    ${OUT_DIR}/pa.res
++    ${OUT_DIR}/pa_Arab.res
++    ${OUT_DIR}/pa_Arab_PK.res
++    ${OUT_DIR}/pa_Guru.res
++    ${OUT_DIR}/pa_Guru_IN.res
++    ${OUT_DIR}/pa_IN.res
++    ${OUT_DIR}/pa_PK.res
++    ${OUT_DIR}/pcm.res
++    ${OUT_DIR}/pcm_NG.res
++    ${OUT_DIR}/pl.res
++    ${OUT_DIR}/pl_PL.res
++    ${OUT_DIR}/pluralRanges.res
++    ${OUT_DIR}/plurals.res
++    ${OUT_DIR}/pool.res
++    ${OUT_DIR}/ps.res
++    ${OUT_DIR}/ps_AF.res
++    ${OUT_DIR}/ps_PK.res
++    ${OUT_DIR}/pt.res
++    ${OUT_DIR}/pt_AO.res
++    ${OUT_DIR}/pt_BR.res
++    ${OUT_DIR}/pt_CH.res
++    ${OUT_DIR}/pt_CV.res
++    ${OUT_DIR}/pt_GQ.res
++    ${OUT_DIR}/pt_GW.res
++    ${OUT_DIR}/pt_LU.res
++    ${OUT_DIR}/pt_MO.res
++    ${OUT_DIR}/pt_MZ.res
++    ${OUT_DIR}/pt_PT.res
++    ${OUT_DIR}/pt_ST.res
++    ${OUT_DIR}/pt_TL.res
++    ${OUT_DIR}/qu.res
++    ${OUT_DIR}/qu_BO.res
++    ${OUT_DIR}/qu_EC.res
++    ${OUT_DIR}/qu_PE.res
++    ${OUT_DIR}/rbnf/${INDEX_NAME}.res
++    ${OUT_DIR}/rbnf/af.res
++    ${OUT_DIR}/rbnf/ak.res
++    ${OUT_DIR}/rbnf/am.res
++    ${OUT_DIR}/rbnf/ar.res
++    ${OUT_DIR}/rbnf/ar_SA.res
++    ${OUT_DIR}/rbnf/ars.res
++    ${OUT_DIR}/rbnf/az.res
++    ${OUT_DIR}/rbnf/be.res
++    ${OUT_DIR}/rbnf/bg.res
++    ${OUT_DIR}/rbnf/bs.res
++    ${OUT_DIR}/rbnf/ca.res
++    ${OUT_DIR}/rbnf/ccp.res
++    ${OUT_DIR}/rbnf/chr.res
++    ${OUT_DIR}/rbnf/cs.res
++    ${OUT_DIR}/rbnf/cy.res
++    ${OUT_DIR}/rbnf/da.res
++    ${OUT_DIR}/rbnf/de.res
++    ${OUT_DIR}/rbnf/de_CH.res
++    ${OUT_DIR}/rbnf/ee.res
++    ${OUT_DIR}/rbnf/el.res
++    ${OUT_DIR}/rbnf/en.res
++    ${OUT_DIR}/rbnf/en_001.res
++    ${OUT_DIR}/rbnf/en_IN.res
++    ${OUT_DIR}/rbnf/eo.res
++    ${OUT_DIR}/rbnf/es.res
++    ${OUT_DIR}/rbnf/es_419.res
++    ${OUT_DIR}/rbnf/es_DO.res
++    ${OUT_DIR}/rbnf/es_GT.res
++    ${OUT_DIR}/rbnf/es_HN.res
++    ${OUT_DIR}/rbnf/es_MX.res
++    ${OUT_DIR}/rbnf/es_NI.res
++    ${OUT_DIR}/rbnf/es_PA.res
++    ${OUT_DIR}/rbnf/es_PR.res
++    ${OUT_DIR}/rbnf/es_SV.res
++    ${OUT_DIR}/rbnf/es_US.res
++    ${OUT_DIR}/rbnf/et.res
++    ${OUT_DIR}/rbnf/fa.res
++    ${OUT_DIR}/rbnf/fa_AF.res
++    ${OUT_DIR}/rbnf/ff.res
++    ${OUT_DIR}/rbnf/fi.res
++    ${OUT_DIR}/rbnf/fil.res
++    ${OUT_DIR}/rbnf/fo.res
++    ${OUT_DIR}/rbnf/fr.res
++    ${OUT_DIR}/rbnf/fr_BE.res
++    ${OUT_DIR}/rbnf/fr_CH.res
++    ${OUT_DIR}/rbnf/ga.res
++    ${OUT_DIR}/rbnf/he.res
++    ${OUT_DIR}/rbnf/hi.res
++    ${OUT_DIR}/rbnf/hr.res
++    ${OUT_DIR}/rbnf/hu.res
++    ${OUT_DIR}/rbnf/hy.res
++    ${OUT_DIR}/rbnf/id.res
++    ${OUT_DIR}/rbnf/in.res
++    ${OUT_DIR}/rbnf/is.res
++    ${OUT_DIR}/rbnf/it.res
++    ${OUT_DIR}/rbnf/iw.res
++    ${OUT_DIR}/rbnf/ja.res
++    ${OUT_DIR}/rbnf/ka.res
++    ${OUT_DIR}/rbnf/kl.res
++    ${OUT_DIR}/rbnf/km.res
++    ${OUT_DIR}/rbnf/ko.res
++    ${OUT_DIR}/rbnf/ky.res
++    ${OUT_DIR}/rbnf/lb.res
++    ${OUT_DIR}/rbnf/lo.res
++    ${OUT_DIR}/rbnf/lrc.res
++    ${OUT_DIR}/rbnf/lt.res
++    ${OUT_DIR}/rbnf/lv.res
++    ${OUT_DIR}/rbnf/mk.res
++    ${OUT_DIR}/rbnf/ms.res
++    ${OUT_DIR}/rbnf/mt.res
++    ${OUT_DIR}/rbnf/my.res
++    ${OUT_DIR}/rbnf/nb.res
++    ${OUT_DIR}/rbnf/nl.res
++    ${OUT_DIR}/rbnf/nn.res
++    ${OUT_DIR}/rbnf/no.res
++    ${OUT_DIR}/rbnf/pl.res
++    ${OUT_DIR}/rbnf/pt.res
++    ${OUT_DIR}/rbnf/pt_PT.res
++    ${OUT_DIR}/rbnf/qu.res
++    ${OUT_DIR}/rbnf/ro.res
++    ${OUT_DIR}/rbnf/root.res
++    ${OUT_DIR}/rbnf/ru.res
++    ${OUT_DIR}/rbnf/se.res
++    ${OUT_DIR}/rbnf/sh.res
++    ${OUT_DIR}/rbnf/sk.res
++    ${OUT_DIR}/rbnf/sl.res
++    ${OUT_DIR}/rbnf/sq.res
++    ${OUT_DIR}/rbnf/sr.res
++    ${OUT_DIR}/rbnf/sr_Latn.res
++    ${OUT_DIR}/rbnf/su.res
++    ${OUT_DIR}/rbnf/sv.res
++    ${OUT_DIR}/rbnf/sw.res
++    ${OUT_DIR}/rbnf/ta.res
++    ${OUT_DIR}/rbnf/th.res
++    ${OUT_DIR}/rbnf/tr.res
++    ${OUT_DIR}/rbnf/uk.res
++    ${OUT_DIR}/rbnf/vi.res
++    ${OUT_DIR}/rbnf/yue.res
++    ${OUT_DIR}/rbnf/yue_Hans.res
++    ${OUT_DIR}/rbnf/zh.res
++    ${OUT_DIR}/rbnf/zh_HK.res
++    ${OUT_DIR}/rbnf/zh_Hant.res
++    ${OUT_DIR}/rbnf/zh_Hant_HK.res
++    ${OUT_DIR}/rbnf/zh_Hant_MO.res
++    ${OUT_DIR}/rbnf/zh_Hant_TW.res
++    ${OUT_DIR}/rbnf/zh_MO.res
++    ${OUT_DIR}/rbnf/zh_TW.res
++    ${OUT_DIR}/region/${INDEX_NAME}.res
++    ${OUT_DIR}/region/af.res
++    ${OUT_DIR}/region/agq.res
++    ${OUT_DIR}/region/ak.res
++    ${OUT_DIR}/region/am.res
++    ${OUT_DIR}/region/ar.res
++    ${OUT_DIR}/region/ar_AE.res
++    ${OUT_DIR}/region/ar_LY.res
++    ${OUT_DIR}/region/ar_SA.res
++    ${OUT_DIR}/region/ars.res
++    ${OUT_DIR}/region/as.res
++    ${OUT_DIR}/region/asa.res
++    ${OUT_DIR}/region/ast.res
++    ${OUT_DIR}/region/az.res
++    ${OUT_DIR}/region/az_AZ.res
++    ${OUT_DIR}/region/az_Cyrl.res
++    ${OUT_DIR}/region/az_Latn.res
++    ${OUT_DIR}/region/az_Latn_AZ.res
++    ${OUT_DIR}/region/bas.res
++    ${OUT_DIR}/region/be.res
++    ${OUT_DIR}/region/bem.res
++    ${OUT_DIR}/region/bez.res
++    ${OUT_DIR}/region/bg.res
++    ${OUT_DIR}/region/bm.res
++    ${OUT_DIR}/region/bn.res
++    ${OUT_DIR}/region/bn_IN.res
++    ${OUT_DIR}/region/bo.res
++    ${OUT_DIR}/region/bo_IN.res
++    ${OUT_DIR}/region/br.res
++    ${OUT_DIR}/region/brx.res
++    ${OUT_DIR}/region/bs.res
++    ${OUT_DIR}/region/bs_BA.res
++    ${OUT_DIR}/region/bs_Cyrl.res
++    ${OUT_DIR}/region/bs_Latn.res
++    ${OUT_DIR}/region/bs_Latn_BA.res
++    ${OUT_DIR}/region/ca.res
++    ${OUT_DIR}/region/ccp.res
++    ${OUT_DIR}/region/ce.res
++    ${OUT_DIR}/region/ceb.res
++    ${OUT_DIR}/region/cgg.res
++    ${OUT_DIR}/region/chr.res
++    ${OUT_DIR}/region/ckb.res
++    ${OUT_DIR}/region/cs.res
++    ${OUT_DIR}/region/cy.res
++    ${OUT_DIR}/region/da.res
++    ${OUT_DIR}/region/dav.res
++    ${OUT_DIR}/region/de.res
++    ${OUT_DIR}/region/de_AT.res
++    ${OUT_DIR}/region/de_CH.res
++    ${OUT_DIR}/region/dje.res
++    ${OUT_DIR}/region/dsb.res
++    ${OUT_DIR}/region/dua.res
++    ${OUT_DIR}/region/dyo.res
++    ${OUT_DIR}/region/dz.res
++    ${OUT_DIR}/region/ebu.res
++    ${OUT_DIR}/region/ee.res
++    ${OUT_DIR}/region/el.res
++    ${OUT_DIR}/region/en.res
++    ${OUT_DIR}/region/en_001.res
++    ${OUT_DIR}/region/en_150.res
++    ${OUT_DIR}/region/en_AG.res
++    ${OUT_DIR}/region/en_AI.res
++    ${OUT_DIR}/region/en_AT.res
++    ${OUT_DIR}/region/en_AU.res
++    ${OUT_DIR}/region/en_BB.res
++    ${OUT_DIR}/region/en_BE.res
++    ${OUT_DIR}/region/en_BM.res
++    ${OUT_DIR}/region/en_BS.res
++    ${OUT_DIR}/region/en_BW.res
++    ${OUT_DIR}/region/en_BZ.res
++    ${OUT_DIR}/region/en_CA.res
++    ${OUT_DIR}/region/en_CC.res
++    ${OUT_DIR}/region/en_CH.res
++    ${OUT_DIR}/region/en_CK.res
++    ${OUT_DIR}/region/en_CM.res
++    ${OUT_DIR}/region/en_CX.res
++    ${OUT_DIR}/region/en_CY.res
++    ${OUT_DIR}/region/en_DE.res
++    ${OUT_DIR}/region/en_DG.res
++    ${OUT_DIR}/region/en_DK.res
++    ${OUT_DIR}/region/en_DM.res
++    ${OUT_DIR}/region/en_ER.res
++    ${OUT_DIR}/region/en_FI.res
++    ${OUT_DIR}/region/en_FJ.res
++    ${OUT_DIR}/region/en_FK.res
++    ${OUT_DIR}/region/en_FM.res
++    ${OUT_DIR}/region/en_GB.res
++    ${OUT_DIR}/region/en_GD.res
++    ${OUT_DIR}/region/en_GG.res
++    ${OUT_DIR}/region/en_GH.res
++    ${OUT_DIR}/region/en_GI.res
++    ${OUT_DIR}/region/en_GM.res
++    ${OUT_DIR}/region/en_GY.res
++    ${OUT_DIR}/region/en_HK.res
++    ${OUT_DIR}/region/en_IE.res
++    ${OUT_DIR}/region/en_IL.res
++    ${OUT_DIR}/region/en_IM.res
++    ${OUT_DIR}/region/en_IN.res
++    ${OUT_DIR}/region/en_IO.res
++    ${OUT_DIR}/region/en_JE.res
++    ${OUT_DIR}/region/en_JM.res
++    ${OUT_DIR}/region/en_KE.res
++    ${OUT_DIR}/region/en_KI.res
++    ${OUT_DIR}/region/en_KN.res
++    ${OUT_DIR}/region/en_KY.res
++    ${OUT_DIR}/region/en_LC.res
++    ${OUT_DIR}/region/en_LR.res
++    ${OUT_DIR}/region/en_LS.res
++    ${OUT_DIR}/region/en_MG.res
++    ${OUT_DIR}/region/en_MO.res
++    ${OUT_DIR}/region/en_MS.res
++    ${OUT_DIR}/region/en_MT.res
++    ${OUT_DIR}/region/en_MU.res
++    ${OUT_DIR}/region/en_MW.res
++    ${OUT_DIR}/region/en_MY.res
++    ${OUT_DIR}/region/en_NA.res
++    ${OUT_DIR}/region/en_NF.res
++    ${OUT_DIR}/region/en_NG.res
++    ${OUT_DIR}/region/en_NH.res
++    ${OUT_DIR}/region/en_NL.res
++    ${OUT_DIR}/region/en_NR.res
++    ${OUT_DIR}/region/en_NU.res
++    ${OUT_DIR}/region/en_NZ.res
++    ${OUT_DIR}/region/en_PG.res
++    ${OUT_DIR}/region/en_PH.res
++    ${OUT_DIR}/region/en_PK.res
++    ${OUT_DIR}/region/en_PN.res
++    ${OUT_DIR}/region/en_PW.res
++    ${OUT_DIR}/region/en_RH.res
++    ${OUT_DIR}/region/en_RW.res
++    ${OUT_DIR}/region/en_SB.res
++    ${OUT_DIR}/region/en_SC.res
++    ${OUT_DIR}/region/en_SD.res
++    ${OUT_DIR}/region/en_SE.res
++    ${OUT_DIR}/region/en_SG.res
++    ${OUT_DIR}/region/en_SH.res
++    ${OUT_DIR}/region/en_SI.res
++    ${OUT_DIR}/region/en_SL.res
++    ${OUT_DIR}/region/en_SS.res
++    ${OUT_DIR}/region/en_SX.res
++    ${OUT_DIR}/region/en_SZ.res
++    ${OUT_DIR}/region/en_TC.res
++    ${OUT_DIR}/region/en_TK.res
++    ${OUT_DIR}/region/en_TO.res
++    ${OUT_DIR}/region/en_TT.res
++    ${OUT_DIR}/region/en_TV.res
++    ${OUT_DIR}/region/en_TZ.res
++    ${OUT_DIR}/region/en_UG.res
++    ${OUT_DIR}/region/en_VC.res
++    ${OUT_DIR}/region/en_VG.res
++    ${OUT_DIR}/region/en_VU.res
++    ${OUT_DIR}/region/en_WS.res
++    ${OUT_DIR}/region/en_ZA.res
++    ${OUT_DIR}/region/en_ZM.res
++    ${OUT_DIR}/region/en_ZW.res
++    ${OUT_DIR}/region/eo.res
++    ${OUT_DIR}/region/es.res
++    ${OUT_DIR}/region/es_419.res
++    ${OUT_DIR}/region/es_AR.res
++    ${OUT_DIR}/region/es_BO.res
++    ${OUT_DIR}/region/es_BR.res
++    ${OUT_DIR}/region/es_BZ.res
++    ${OUT_DIR}/region/es_CL.res
++    ${OUT_DIR}/region/es_CO.res
++    ${OUT_DIR}/region/es_CR.res
++    ${OUT_DIR}/region/es_CU.res
++    ${OUT_DIR}/region/es_DO.res
++    ${OUT_DIR}/region/es_EC.res
++    ${OUT_DIR}/region/es_GT.res
++    ${OUT_DIR}/region/es_HN.res
++    ${OUT_DIR}/region/es_MX.res
++    ${OUT_DIR}/region/es_NI.res
++    ${OUT_DIR}/region/es_PA.res
++    ${OUT_DIR}/region/es_PE.res
++    ${OUT_DIR}/region/es_PR.res
++    ${OUT_DIR}/region/es_PY.res
++    ${OUT_DIR}/region/es_SV.res
++    ${OUT_DIR}/region/es_US.res
++    ${OUT_DIR}/region/es_UY.res
++    ${OUT_DIR}/region/es_VE.res
++    ${OUT_DIR}/region/et.res
++    ${OUT_DIR}/region/eu.res
++    ${OUT_DIR}/region/ewo.res
++    ${OUT_DIR}/region/fa.res
++    ${OUT_DIR}/region/fa_AF.res
++    ${OUT_DIR}/region/ff.res
++    ${OUT_DIR}/region/ff_Adlm.res
++    ${OUT_DIR}/region/ff_CM.res
++    ${OUT_DIR}/region/ff_GN.res
++    ${OUT_DIR}/region/ff_Latn.res
++    ${OUT_DIR}/region/ff_Latn_CM.res
++    ${OUT_DIR}/region/ff_Latn_GN.res
++    ${OUT_DIR}/region/ff_Latn_MR.res
++    ${OUT_DIR}/region/ff_Latn_SN.res
++    ${OUT_DIR}/region/ff_MR.res
++    ${OUT_DIR}/region/ff_SN.res
++    ${OUT_DIR}/region/fi.res
++    ${OUT_DIR}/region/fil.res
++    ${OUT_DIR}/region/fil_PH.res
++    ${OUT_DIR}/region/fo.res
++    ${OUT_DIR}/region/fr.res
++    ${OUT_DIR}/region/fr_BE.res
++    ${OUT_DIR}/region/fr_CA.res
++    ${OUT_DIR}/region/fur.res
++    ${OUT_DIR}/region/fy.res
++    ${OUT_DIR}/region/ga.res
++    ${OUT_DIR}/region/gd.res
++    ${OUT_DIR}/region/gl.res
++    ${OUT_DIR}/region/gsw.res
++    ${OUT_DIR}/region/gu.res
++    ${OUT_DIR}/region/guz.res
++    ${OUT_DIR}/region/gv.res
++    ${OUT_DIR}/region/ha.res
++    ${OUT_DIR}/region/haw.res
++    ${OUT_DIR}/region/he.res
++    ${OUT_DIR}/region/he_IL.res
++    ${OUT_DIR}/region/hi.res
++    ${OUT_DIR}/region/hr.res
++    ${OUT_DIR}/region/hsb.res
++    ${OUT_DIR}/region/hu.res
++    ${OUT_DIR}/region/hy.res
++    ${OUT_DIR}/region/ia.res
++    ${OUT_DIR}/region/id.res
++    ${OUT_DIR}/region/id_ID.res
++    ${OUT_DIR}/region/ig.res
++    ${OUT_DIR}/region/ii.res
++    ${OUT_DIR}/region/in.res
++    ${OUT_DIR}/region/in_ID.res
++    ${OUT_DIR}/region/is.res
++    ${OUT_DIR}/region/it.res
++    ${OUT_DIR}/region/iw.res
++    ${OUT_DIR}/region/iw_IL.res
++    ${OUT_DIR}/region/ja.res
++    ${OUT_DIR}/region/jgo.res
++    ${OUT_DIR}/region/jmc.res
++    ${OUT_DIR}/region/jv.res
++    ${OUT_DIR}/region/ka.res
++    ${OUT_DIR}/region/kab.res
++    ${OUT_DIR}/region/kam.res
++    ${OUT_DIR}/region/kde.res
++    ${OUT_DIR}/region/kea.res
++    ${OUT_DIR}/region/khq.res
++    ${OUT_DIR}/region/ki.res
++    ${OUT_DIR}/region/kk.res
++    ${OUT_DIR}/region/kkj.res
++    ${OUT_DIR}/region/kl.res
++    ${OUT_DIR}/region/kln.res
++    ${OUT_DIR}/region/km.res
++    ${OUT_DIR}/region/kn.res
++    ${OUT_DIR}/region/ko.res
++    ${OUT_DIR}/region/ko_KP.res
++    ${OUT_DIR}/region/kok.res
++    ${OUT_DIR}/region/ks.res
++    ${OUT_DIR}/region/ks_Arab.res
++    ${OUT_DIR}/region/ks_Arab_IN.res
++    ${OUT_DIR}/region/ks_IN.res
++    ${OUT_DIR}/region/ksb.res
++    ${OUT_DIR}/region/ksf.res
++    ${OUT_DIR}/region/ksh.res
++    ${OUT_DIR}/region/ku.res
++    ${OUT_DIR}/region/kw.res
++    ${OUT_DIR}/region/ky.res
++    ${OUT_DIR}/region/lag.res
++    ${OUT_DIR}/region/lb.res
++    ${OUT_DIR}/region/lg.res
++    ${OUT_DIR}/region/lkt.res
++    ${OUT_DIR}/region/ln.res
++    ${OUT_DIR}/region/lo.res
++    ${OUT_DIR}/region/lrc.res
++    ${OUT_DIR}/region/lt.res
++    ${OUT_DIR}/region/lu.res
++    ${OUT_DIR}/region/luo.res
++    ${OUT_DIR}/region/luy.res
++    ${OUT_DIR}/region/lv.res
++    ${OUT_DIR}/region/mai.res
++    ${OUT_DIR}/region/mas.res
++    ${OUT_DIR}/region/mer.res
++    ${OUT_DIR}/region/mfe.res
++    ${OUT_DIR}/region/mg.res
++    ${OUT_DIR}/region/mgh.res
++    ${OUT_DIR}/region/mgo.res
++    ${OUT_DIR}/region/mi.res
++    ${OUT_DIR}/region/mk.res
++    ${OUT_DIR}/region/ml.res
++    ${OUT_DIR}/region/mn.res
++    ${OUT_DIR}/region/mni.res
++    ${OUT_DIR}/region/mni_Beng.res
++    ${OUT_DIR}/region/mni_Beng_IN.res
++    ${OUT_DIR}/region/mni_IN.res
++    ${OUT_DIR}/region/mo.res
++    ${OUT_DIR}/region/mr.res
++    ${OUT_DIR}/region/ms.res
++    ${OUT_DIR}/region/mt.res
++    ${OUT_DIR}/region/mua.res
++    ${OUT_DIR}/region/my.res
++    ${OUT_DIR}/region/mzn.res
++    ${OUT_DIR}/region/naq.res
++    ${OUT_DIR}/region/nb.res
++    ${OUT_DIR}/region/nb_NO.res
++    ${OUT_DIR}/region/nd.res
++    ${OUT_DIR}/region/nds.res
++    ${OUT_DIR}/region/ne.res
++    ${OUT_DIR}/region/nl.res
++    ${OUT_DIR}/region/nmg.res
++    ${OUT_DIR}/region/nn.res
++    ${OUT_DIR}/region/nn_NO.res
++    ${OUT_DIR}/region/nnh.res
++    ${OUT_DIR}/region/no.res
++    ${OUT_DIR}/region/no_NO.res
++    ${OUT_DIR}/region/no_NO_NY.res
++    ${OUT_DIR}/region/nus.res
++    ${OUT_DIR}/region/nyn.res
++    ${OUT_DIR}/region/om.res
++    ${OUT_DIR}/region/or.res
++    ${OUT_DIR}/region/os.res
++    ${OUT_DIR}/region/pa.res
++    ${OUT_DIR}/region/pa_Arab.res
++    ${OUT_DIR}/region/pa_Arab_PK.res
++    ${OUT_DIR}/region/pa_Guru.res
++    ${OUT_DIR}/region/pa_Guru_IN.res
++    ${OUT_DIR}/region/pa_IN.res
++    ${OUT_DIR}/region/pa_PK.res
++    ${OUT_DIR}/region/pcm.res
++    ${OUT_DIR}/region/pl.res
++    ${OUT_DIR}/region/pool.res
++    ${OUT_DIR}/region/ps.res
++    ${OUT_DIR}/region/ps_PK.res
++    ${OUT_DIR}/region/pt.res
++    ${OUT_DIR}/region/pt_AO.res
++    ${OUT_DIR}/region/pt_CH.res
++    ${OUT_DIR}/region/pt_CV.res
++    ${OUT_DIR}/region/pt_GQ.res
++    ${OUT_DIR}/region/pt_GW.res
++    ${OUT_DIR}/region/pt_LU.res
++    ${OUT_DIR}/region/pt_MO.res
++    ${OUT_DIR}/region/pt_MZ.res
++    ${OUT_DIR}/region/pt_PT.res
++    ${OUT_DIR}/region/pt_ST.res
++    ${OUT_DIR}/region/pt_TL.res
++    ${OUT_DIR}/region/qu.res
++    ${OUT_DIR}/region/rm.res
++    ${OUT_DIR}/region/rn.res
++    ${OUT_DIR}/region/ro.res
++    ${OUT_DIR}/region/ro_MD.res
++    ${OUT_DIR}/region/rof.res
++    ${OUT_DIR}/region/root.res
++    ${OUT_DIR}/region/ru.res
++    ${OUT_DIR}/region/ru_UA.res
++    ${OUT_DIR}/region/rw.res
++    ${OUT_DIR}/region/rwk.res
++    ${OUT_DIR}/region/sah.res
++    ${OUT_DIR}/region/saq.res
++    ${OUT_DIR}/region/sat.res
++    ${OUT_DIR}/region/sat_IN.res
++    ${OUT_DIR}/region/sat_Olck.res
++    ${OUT_DIR}/region/sat_Olck_IN.res
++    ${OUT_DIR}/region/sbp.res
++    ${OUT_DIR}/region/sd.res
++    ${OUT_DIR}/region/sd_Arab.res
++    ${OUT_DIR}/region/sd_Arab_PK.res
++    ${OUT_DIR}/region/sd_Deva.res
++    ${OUT_DIR}/region/sd_PK.res
++    ${OUT_DIR}/region/se.res
++    ${OUT_DIR}/region/se_FI.res
++    ${OUT_DIR}/region/seh.res
++    ${OUT_DIR}/region/ses.res
++    ${OUT_DIR}/region/sg.res
++    ${OUT_DIR}/region/sh.res
++    ${OUT_DIR}/region/sh_BA.res
++    ${OUT_DIR}/region/sh_CS.res
++    ${OUT_DIR}/region/sh_YU.res
++    ${OUT_DIR}/region/shi.res
++    ${OUT_DIR}/region/shi_Latn.res
++    ${OUT_DIR}/region/shi_MA.res
++    ${OUT_DIR}/region/shi_Tfng.res
++    ${OUT_DIR}/region/shi_Tfng_MA.res
++    ${OUT_DIR}/region/si.res
++    ${OUT_DIR}/region/sk.res
++    ${OUT_DIR}/region/sl.res
++    ${OUT_DIR}/region/smn.res
++    ${OUT_DIR}/region/sn.res
++    ${OUT_DIR}/region/so.res
++    ${OUT_DIR}/region/sq.res
++    ${OUT_DIR}/region/sr.res
++    ${OUT_DIR}/region/sr_BA.res
++    ${OUT_DIR}/region/sr_CS.res
++    ${OUT_DIR}/region/sr_Cyrl.res
++    ${OUT_DIR}/region/sr_Cyrl_BA.res
++    ${OUT_DIR}/region/sr_Cyrl_CS.res
++    ${OUT_DIR}/region/sr_Cyrl_ME.res
++    ${OUT_DIR}/region/sr_Cyrl_RS.res
++    ${OUT_DIR}/region/sr_Cyrl_XK.res
++    ${OUT_DIR}/region/sr_Cyrl_YU.res
++    ${OUT_DIR}/region/sr_Latn.res
++    ${OUT_DIR}/region/sr_Latn_BA.res
++    ${OUT_DIR}/region/sr_Latn_CS.res
++    ${OUT_DIR}/region/sr_Latn_ME.res
++    ${OUT_DIR}/region/sr_Latn_RS.res
++    ${OUT_DIR}/region/sr_Latn_XK.res
++    ${OUT_DIR}/region/sr_Latn_YU.res
++    ${OUT_DIR}/region/sr_ME.res
++    ${OUT_DIR}/region/sr_RS.res
++    ${OUT_DIR}/region/sr_XK.res
++    ${OUT_DIR}/region/sr_YU.res
++    ${OUT_DIR}/region/su.res
++    ${OUT_DIR}/region/su_ID.res
++    ${OUT_DIR}/region/su_Latn.res
++    ${OUT_DIR}/region/su_Latn_ID.res
++    ${OUT_DIR}/region/sv.res
++    ${OUT_DIR}/region/sw.res
++    ${OUT_DIR}/region/sw_CD.res
++    ${OUT_DIR}/region/sw_KE.res
++    ${OUT_DIR}/region/ta.res
++    ${OUT_DIR}/region/te.res
++    ${OUT_DIR}/region/teo.res
++    ${OUT_DIR}/region/tg.res
++    ${OUT_DIR}/region/th.res
++    ${OUT_DIR}/region/ti.res
++    ${OUT_DIR}/region/tk.res
++    ${OUT_DIR}/region/tl.res
++    ${OUT_DIR}/region/tl_PH.res
++    ${OUT_DIR}/region/to.res
++    ${OUT_DIR}/region/tr.res
++    ${OUT_DIR}/region/tt.res
++    ${OUT_DIR}/region/twq.res
++    ${OUT_DIR}/region/tzm.res
++    ${OUT_DIR}/region/ug.res
++    ${OUT_DIR}/region/uk.res
++    ${OUT_DIR}/region/ur.res
++    ${OUT_DIR}/region/ur_IN.res
++    ${OUT_DIR}/region/uz.res
++    ${OUT_DIR}/region/uz_AF.res
++    ${OUT_DIR}/region/uz_Arab.res
++    ${OUT_DIR}/region/uz_Arab_AF.res
++    ${OUT_DIR}/region/uz_Cyrl.res
++    ${OUT_DIR}/region/uz_Latn.res
++    ${OUT_DIR}/region/uz_Latn_UZ.res
++    ${OUT_DIR}/region/uz_UZ.res
++    ${OUT_DIR}/region/vai.res
++    ${OUT_DIR}/region/vai_LR.res
++    ${OUT_DIR}/region/vai_Latn.res
++    ${OUT_DIR}/region/vai_Vaii.res
++    ${OUT_DIR}/region/vai_Vaii_LR.res
++    ${OUT_DIR}/region/vi.res
++    ${OUT_DIR}/region/vun.res
++    ${OUT_DIR}/region/wae.res
++    ${OUT_DIR}/region/wo.res
++    ${OUT_DIR}/region/xh.res
++    ${OUT_DIR}/region/xog.res
++    ${OUT_DIR}/region/yav.res
++    ${OUT_DIR}/region/yi.res
++    ${OUT_DIR}/region/yo.res
++    ${OUT_DIR}/region/yo_BJ.res
++    ${OUT_DIR}/region/yue.res
++    ${OUT_DIR}/region/yue_CN.res
++    ${OUT_DIR}/region/yue_HK.res
++    ${OUT_DIR}/region/yue_Hans.res
++    ${OUT_DIR}/region/yue_Hans_CN.res
++    ${OUT_DIR}/region/yue_Hant.res
++    ${OUT_DIR}/region/yue_Hant_HK.res
++    ${OUT_DIR}/region/zgh.res
++    ${OUT_DIR}/region/zh.res
++    ${OUT_DIR}/region/zh_CN.res
++    ${OUT_DIR}/region/zh_HK.res
++    ${OUT_DIR}/region/zh_Hans.res
++    ${OUT_DIR}/region/zh_Hans_CN.res
++    ${OUT_DIR}/region/zh_Hans_SG.res
++    ${OUT_DIR}/region/zh_Hant.res
++    ${OUT_DIR}/region/zh_Hant_HK.res
++    ${OUT_DIR}/region/zh_Hant_MO.res
++    ${OUT_DIR}/region/zh_Hant_TW.res
++    ${OUT_DIR}/region/zh_MO.res
++    ${OUT_DIR}/region/zh_SG.res
++    ${OUT_DIR}/region/zh_TW.res
++    ${OUT_DIR}/region/zu.res
++    ${OUT_DIR}/rfc3491.spp
++    ${OUT_DIR}/rfc3530cs.spp
++    ${OUT_DIR}/rfc3530csci.spp
++    ${OUT_DIR}/rfc3530mixp.spp
++    ${OUT_DIR}/rfc3722.spp
++    ${OUT_DIR}/rfc3920node.spp
++    ${OUT_DIR}/rfc3920res.spp
++    ${OUT_DIR}/rfc4011.spp
++    ${OUT_DIR}/rfc4013.spp
++    ${OUT_DIR}/rfc4505.spp
++    ${OUT_DIR}/rfc4518.spp
++    ${OUT_DIR}/rfc4518ci.spp
++    ${OUT_DIR}/rm.res
++    ${OUT_DIR}/rm_CH.res
++    ${OUT_DIR}/rn.res
++    ${OUT_DIR}/rn_BI.res
++    ${OUT_DIR}/ro.res
++    ${OUT_DIR}/ro_MD.res
++    ${OUT_DIR}/ro_RO.res
++    ${OUT_DIR}/rof.res
++    ${OUT_DIR}/rof_TZ.res
++    ${OUT_DIR}/root.res
++    ${OUT_DIR}/ru.res
++    ${OUT_DIR}/ru_BY.res
++    ${OUT_DIR}/ru_KG.res
++    ${OUT_DIR}/ru_KZ.res
++    ${OUT_DIR}/ru_MD.res
++    ${OUT_DIR}/ru_RU.res
++    ${OUT_DIR}/ru_UA.res
++    ${OUT_DIR}/rw.res
++    ${OUT_DIR}/rw_RW.res
++    ${OUT_DIR}/rwk.res
++    ${OUT_DIR}/rwk_TZ.res
++    ${OUT_DIR}/sah.res
++    ${OUT_DIR}/sah_RU.res
++    ${OUT_DIR}/saq.res
++    ${OUT_DIR}/saq_KE.res
++    ${OUT_DIR}/sat.res
++    ${OUT_DIR}/sat_IN.res
++    ${OUT_DIR}/sat_Olck.res
++    ${OUT_DIR}/sat_Olck_IN.res
++    ${OUT_DIR}/sbp.res
++    ${OUT_DIR}/sbp_TZ.res
++    ${OUT_DIR}/sd.res
++    ${OUT_DIR}/sd_Arab.res
++    ${OUT_DIR}/sd_Arab_PK.res
++    ${OUT_DIR}/sd_Deva.res
++    ${OUT_DIR}/sd_Deva_IN.res
++    ${OUT_DIR}/sd_PK.res
++    ${OUT_DIR}/se.res
++    ${OUT_DIR}/se_FI.res
++    ${OUT_DIR}/se_NO.res
++    ${OUT_DIR}/se_SE.res
++    ${OUT_DIR}/seh.res
++    ${OUT_DIR}/seh_MZ.res
++    ${OUT_DIR}/ses.res
++    ${OUT_DIR}/ses_ML.res
++    ${OUT_DIR}/sg.res
++    ${OUT_DIR}/sg_CF.res
++    ${OUT_DIR}/sh.res
++    ${OUT_DIR}/sh_BA.res
++    ${OUT_DIR}/sh_CS.res
++    ${OUT_DIR}/sh_YU.res
++    ${OUT_DIR}/shi.res
++    ${OUT_DIR}/shi_Latn.res
++    ${OUT_DIR}/shi_Latn_MA.res
++    ${OUT_DIR}/shi_MA.res
++    ${OUT_DIR}/shi_Tfng.res
++    ${OUT_DIR}/shi_Tfng_MA.res
++    ${OUT_DIR}/si.res
++    ${OUT_DIR}/si_LK.res
++    ${OUT_DIR}/sk.res
++    ${OUT_DIR}/sk_SK.res
++    ${OUT_DIR}/sl.res
++    ${OUT_DIR}/sl_SI.res
++    ${OUT_DIR}/smn.res
++    ${OUT_DIR}/smn_FI.res
++    ${OUT_DIR}/sn.res
++    ${OUT_DIR}/sn_ZW.res
++    ${OUT_DIR}/so.res
++    ${OUT_DIR}/so_DJ.res
++    ${OUT_DIR}/so_ET.res
++    ${OUT_DIR}/so_KE.res
++    ${OUT_DIR}/so_SO.res
++    ${OUT_DIR}/sq.res
++    ${OUT_DIR}/sq_AL.res
++    ${OUT_DIR}/sq_MK.res
++    ${OUT_DIR}/sq_XK.res
++    ${OUT_DIR}/sr.res
++    ${OUT_DIR}/sr_BA.res
++    ${OUT_DIR}/sr_CS.res
++    ${OUT_DIR}/sr_Cyrl.res
++    ${OUT_DIR}/sr_Cyrl_BA.res
++    ${OUT_DIR}/sr_Cyrl_CS.res
++    ${OUT_DIR}/sr_Cyrl_ME.res
++    ${OUT_DIR}/sr_Cyrl_RS.res
++    ${OUT_DIR}/sr_Cyrl_XK.res
++    ${OUT_DIR}/sr_Cyrl_YU.res
++    ${OUT_DIR}/sr_Latn.res
++    ${OUT_DIR}/sr_Latn_BA.res
++    ${OUT_DIR}/sr_Latn_CS.res
++    ${OUT_DIR}/sr_Latn_ME.res
++    ${OUT_DIR}/sr_Latn_RS.res
++    ${OUT_DIR}/sr_Latn_XK.res
++    ${OUT_DIR}/sr_Latn_YU.res
++    ${OUT_DIR}/sr_ME.res
++    ${OUT_DIR}/sr_RS.res
++    ${OUT_DIR}/sr_XK.res
++    ${OUT_DIR}/sr_YU.res
++    ${OUT_DIR}/su.res
++    ${OUT_DIR}/su_ID.res
++    ${OUT_DIR}/su_Latn.res
++    ${OUT_DIR}/su_Latn_ID.res
++    ${OUT_DIR}/supplementalData.res
++    ${OUT_DIR}/sv.res
++    ${OUT_DIR}/sv_AX.res
++    ${OUT_DIR}/sv_FI.res
++    ${OUT_DIR}/sv_SE.res
++    ${OUT_DIR}/sw.res
++    ${OUT_DIR}/sw_CD.res
++    ${OUT_DIR}/sw_KE.res
++    ${OUT_DIR}/sw_TZ.res
++    ${OUT_DIR}/sw_UG.res
++    ${OUT_DIR}/ta.res
++    ${OUT_DIR}/ta_IN.res
++    ${OUT_DIR}/ta_LK.res
++    ${OUT_DIR}/ta_MY.res
++    ${OUT_DIR}/ta_SG.res
++    ${OUT_DIR}/te.res
++    ${OUT_DIR}/te_IN.res
++    ${OUT_DIR}/teo.res
++    ${OUT_DIR}/teo_KE.res
++    ${OUT_DIR}/teo_UG.res
++    ${OUT_DIR}/tg.res
++    ${OUT_DIR}/tg_TJ.res
++    ${OUT_DIR}/th.res
++    ${OUT_DIR}/th_TH.res
++    ${OUT_DIR}/th_TH_TRADITIONAL.res
++    ${OUT_DIR}/ti.res
++    ${OUT_DIR}/ti_ER.res
++    ${OUT_DIR}/ti_ET.res
++    ${OUT_DIR}/timezoneTypes.res
++    ${OUT_DIR}/tk.res
++    ${OUT_DIR}/tk_TM.res
++    ${OUT_DIR}/tl.res
++    ${OUT_DIR}/tl_PH.res
++    ${OUT_DIR}/to.res
++    ${OUT_DIR}/to_TO.res
++    ${OUT_DIR}/tr.res
++    ${OUT_DIR}/tr_CY.res
++    ${OUT_DIR}/tr_TR.res
++    ${OUT_DIR}/translit/el.res
++    ${OUT_DIR}/translit/en.res
++    ${OUT_DIR}/translit/root.res
++    ${OUT_DIR}/tt.res
++    ${OUT_DIR}/tt_RU.res
++    ${OUT_DIR}/twq.res
++    ${OUT_DIR}/twq_NE.res
++    ${OUT_DIR}/tzm.res
++    ${OUT_DIR}/tzm_MA.res
++    ${OUT_DIR}/ug.res
++    ${OUT_DIR}/ug_CN.res
++    ${OUT_DIR}/uk.res
++    ${OUT_DIR}/uk_UA.res
++    ${OUT_DIR}/ulayout.icu
++    ${OUT_DIR}/unames.icu
++    ${OUT_DIR}/unit/${INDEX_NAME}.res
++    ${OUT_DIR}/unit/af.res
++    ${OUT_DIR}/unit/agq.res
++    ${OUT_DIR}/unit/ak.res
++    ${OUT_DIR}/unit/am.res
++    ${OUT_DIR}/unit/ar.res
++    ${OUT_DIR}/unit/ar_SA.res
++    ${OUT_DIR}/unit/ars.res
++    ${OUT_DIR}/unit/as.res
++    ${OUT_DIR}/unit/asa.res
++    ${OUT_DIR}/unit/ast.res
++    ${OUT_DIR}/unit/az.res
++    ${OUT_DIR}/unit/az_AZ.res
++    ${OUT_DIR}/unit/az_Cyrl.res
++    ${OUT_DIR}/unit/az_Latn.res
++    ${OUT_DIR}/unit/az_Latn_AZ.res
++    ${OUT_DIR}/unit/bas.res
++    ${OUT_DIR}/unit/be.res
++    ${OUT_DIR}/unit/bem.res
++    ${OUT_DIR}/unit/bez.res
++    ${OUT_DIR}/unit/bg.res
++    ${OUT_DIR}/unit/bm.res
++    ${OUT_DIR}/unit/bn.res
++    ${OUT_DIR}/unit/bo.res
++    ${OUT_DIR}/unit/br.res
++    ${OUT_DIR}/unit/brx.res
++    ${OUT_DIR}/unit/bs.res
++    ${OUT_DIR}/unit/bs_BA.res
++    ${OUT_DIR}/unit/bs_Cyrl.res
++    ${OUT_DIR}/unit/bs_Latn.res
++    ${OUT_DIR}/unit/bs_Latn_BA.res
++    ${OUT_DIR}/unit/ca.res
++    ${OUT_DIR}/unit/ccp.res
++    ${OUT_DIR}/unit/ce.res
++    ${OUT_DIR}/unit/ceb.res
++    ${OUT_DIR}/unit/cgg.res
++    ${OUT_DIR}/unit/chr.res
++    ${OUT_DIR}/unit/ckb.res
++    ${OUT_DIR}/unit/cs.res
++    ${OUT_DIR}/unit/cy.res
++    ${OUT_DIR}/unit/da.res
++    ${OUT_DIR}/unit/dav.res
++    ${OUT_DIR}/unit/de.res
++    ${OUT_DIR}/unit/de_CH.res
++    ${OUT_DIR}/unit/dje.res
++    ${OUT_DIR}/unit/dsb.res
++    ${OUT_DIR}/unit/dua.res
++    ${OUT_DIR}/unit/dyo.res
++    ${OUT_DIR}/unit/dz.res
++    ${OUT_DIR}/unit/ebu.res
++    ${OUT_DIR}/unit/ee.res
++    ${OUT_DIR}/unit/el.res
++    ${OUT_DIR}/unit/en.res
++    ${OUT_DIR}/unit/en_001.res
++    ${OUT_DIR}/unit/en_150.res
++    ${OUT_DIR}/unit/en_AG.res
++    ${OUT_DIR}/unit/en_AI.res
++    ${OUT_DIR}/unit/en_AT.res
++    ${OUT_DIR}/unit/en_AU.res
++    ${OUT_DIR}/unit/en_BB.res
++    ${OUT_DIR}/unit/en_BE.res
++    ${OUT_DIR}/unit/en_BM.res
++    ${OUT_DIR}/unit/en_BS.res
++    ${OUT_DIR}/unit/en_BW.res
++    ${OUT_DIR}/unit/en_BZ.res
++    ${OUT_DIR}/unit/en_CA.res
++    ${OUT_DIR}/unit/en_CC.res
++    ${OUT_DIR}/unit/en_CH.res
++    ${OUT_DIR}/unit/en_CK.res
++    ${OUT_DIR}/unit/en_CM.res
++    ${OUT_DIR}/unit/en_CX.res
++    ${OUT_DIR}/unit/en_CY.res
++    ${OUT_DIR}/unit/en_DE.res
++    ${OUT_DIR}/unit/en_DG.res
++    ${OUT_DIR}/unit/en_DK.res
++    ${OUT_DIR}/unit/en_DM.res
++    ${OUT_DIR}/unit/en_ER.res
++    ${OUT_DIR}/unit/en_FI.res
++    ${OUT_DIR}/unit/en_FJ.res
++    ${OUT_DIR}/unit/en_FK.res
++    ${OUT_DIR}/unit/en_FM.res
++    ${OUT_DIR}/unit/en_GB.res
++    ${OUT_DIR}/unit/en_GD.res
++    ${OUT_DIR}/unit/en_GG.res
++    ${OUT_DIR}/unit/en_GH.res
++    ${OUT_DIR}/unit/en_GI.res
++    ${OUT_DIR}/unit/en_GM.res
++    ${OUT_DIR}/unit/en_GY.res
++    ${OUT_DIR}/unit/en_HK.res
++    ${OUT_DIR}/unit/en_IE.res
++    ${OUT_DIR}/unit/en_IL.res
++    ${OUT_DIR}/unit/en_IM.res
++    ${OUT_DIR}/unit/en_IN.res
++    ${OUT_DIR}/unit/en_IO.res
++    ${OUT_DIR}/unit/en_JE.res
++    ${OUT_DIR}/unit/en_JM.res
++    ${OUT_DIR}/unit/en_KE.res
++    ${OUT_DIR}/unit/en_KI.res
++    ${OUT_DIR}/unit/en_KN.res
++    ${OUT_DIR}/unit/en_KY.res
++    ${OUT_DIR}/unit/en_LC.res
++    ${OUT_DIR}/unit/en_LR.res
++    ${OUT_DIR}/unit/en_LS.res
++    ${OUT_DIR}/unit/en_MG.res
++    ${OUT_DIR}/unit/en_MO.res
++    ${OUT_DIR}/unit/en_MS.res
++    ${OUT_DIR}/unit/en_MT.res
++    ${OUT_DIR}/unit/en_MU.res
++    ${OUT_DIR}/unit/en_MW.res
++    ${OUT_DIR}/unit/en_MY.res
++    ${OUT_DIR}/unit/en_NA.res
++    ${OUT_DIR}/unit/en_NF.res
++    ${OUT_DIR}/unit/en_NG.res
++    ${OUT_DIR}/unit/en_NH.res
++    ${OUT_DIR}/unit/en_NL.res
++    ${OUT_DIR}/unit/en_NR.res
++    ${OUT_DIR}/unit/en_NU.res
++    ${OUT_DIR}/unit/en_NZ.res
++    ${OUT_DIR}/unit/en_PG.res
++    ${OUT_DIR}/unit/en_PH.res
++    ${OUT_DIR}/unit/en_PK.res
++    ${OUT_DIR}/unit/en_PN.res
++    ${OUT_DIR}/unit/en_PW.res
++    ${OUT_DIR}/unit/en_RH.res
++    ${OUT_DIR}/unit/en_RW.res
++    ${OUT_DIR}/unit/en_SB.res
++    ${OUT_DIR}/unit/en_SC.res
++    ${OUT_DIR}/unit/en_SD.res
++    ${OUT_DIR}/unit/en_SE.res
++    ${OUT_DIR}/unit/en_SG.res
++    ${OUT_DIR}/unit/en_SH.res
++    ${OUT_DIR}/unit/en_SI.res
++    ${OUT_DIR}/unit/en_SL.res
++    ${OUT_DIR}/unit/en_SS.res
++    ${OUT_DIR}/unit/en_SX.res
++    ${OUT_DIR}/unit/en_SZ.res
++    ${OUT_DIR}/unit/en_TC.res
++    ${OUT_DIR}/unit/en_TK.res
++    ${OUT_DIR}/unit/en_TO.res
++    ${OUT_DIR}/unit/en_TT.res
++    ${OUT_DIR}/unit/en_TV.res
++    ${OUT_DIR}/unit/en_TZ.res
++    ${OUT_DIR}/unit/en_UG.res
++    ${OUT_DIR}/unit/en_VC.res
++    ${OUT_DIR}/unit/en_VG.res
++    ${OUT_DIR}/unit/en_VU.res
++    ${OUT_DIR}/unit/en_WS.res
++    ${OUT_DIR}/unit/en_ZA.res
++    ${OUT_DIR}/unit/en_ZM.res
++    ${OUT_DIR}/unit/en_ZW.res
++    ${OUT_DIR}/unit/eo.res
++    ${OUT_DIR}/unit/es.res
++    ${OUT_DIR}/unit/es_419.res
++    ${OUT_DIR}/unit/es_AR.res
++    ${OUT_DIR}/unit/es_BO.res
++    ${OUT_DIR}/unit/es_BR.res
++    ${OUT_DIR}/unit/es_BZ.res
++    ${OUT_DIR}/unit/es_CL.res
++    ${OUT_DIR}/unit/es_CO.res
++    ${OUT_DIR}/unit/es_CR.res
++    ${OUT_DIR}/unit/es_CU.res
++    ${OUT_DIR}/unit/es_DO.res
++    ${OUT_DIR}/unit/es_EC.res
++    ${OUT_DIR}/unit/es_GT.res
++    ${OUT_DIR}/unit/es_HN.res
++    ${OUT_DIR}/unit/es_MX.res
++    ${OUT_DIR}/unit/es_NI.res
++    ${OUT_DIR}/unit/es_PA.res
++    ${OUT_DIR}/unit/es_PE.res
++    ${OUT_DIR}/unit/es_PR.res
++    ${OUT_DIR}/unit/es_PY.res
++    ${OUT_DIR}/unit/es_SV.res
++    ${OUT_DIR}/unit/es_US.res
++    ${OUT_DIR}/unit/es_UY.res
++    ${OUT_DIR}/unit/es_VE.res
++    ${OUT_DIR}/unit/et.res
++    ${OUT_DIR}/unit/eu.res
++    ${OUT_DIR}/unit/ewo.res
++    ${OUT_DIR}/unit/fa.res
++    ${OUT_DIR}/unit/ff.res
++    ${OUT_DIR}/unit/ff_Adlm.res
++    ${OUT_DIR}/unit/ff_CM.res
++    ${OUT_DIR}/unit/ff_GN.res
++    ${OUT_DIR}/unit/ff_Latn.res
++    ${OUT_DIR}/unit/ff_Latn_CM.res
++    ${OUT_DIR}/unit/ff_Latn_GN.res
++    ${OUT_DIR}/unit/ff_Latn_MR.res
++    ${OUT_DIR}/unit/ff_Latn_SN.res
++    ${OUT_DIR}/unit/ff_MR.res
++    ${OUT_DIR}/unit/ff_SN.res
++    ${OUT_DIR}/unit/fi.res
++    ${OUT_DIR}/unit/fil.res
++    ${OUT_DIR}/unit/fil_PH.res
++    ${OUT_DIR}/unit/fo.res
++    ${OUT_DIR}/unit/fr.res
++    ${OUT_DIR}/unit/fr_CA.res
++    ${OUT_DIR}/unit/fr_HT.res
++    ${OUT_DIR}/unit/fur.res
++    ${OUT_DIR}/unit/fy.res
++    ${OUT_DIR}/unit/ga.res
++    ${OUT_DIR}/unit/gd.res
++    ${OUT_DIR}/unit/gl.res
++    ${OUT_DIR}/unit/gsw.res
++    ${OUT_DIR}/unit/gu.res
++    ${OUT_DIR}/unit/guz.res
++    ${OUT_DIR}/unit/gv.res
++    ${OUT_DIR}/unit/ha.res
++    ${OUT_DIR}/unit/haw.res
++    ${OUT_DIR}/unit/he.res
++    ${OUT_DIR}/unit/he_IL.res
++    ${OUT_DIR}/unit/hi.res
++    ${OUT_DIR}/unit/hr.res
++    ${OUT_DIR}/unit/hsb.res
++    ${OUT_DIR}/unit/hu.res
++    ${OUT_DIR}/unit/hy.res
++    ${OUT_DIR}/unit/ia.res
++    ${OUT_DIR}/unit/id.res
++    ${OUT_DIR}/unit/id_ID.res
++    ${OUT_DIR}/unit/ig.res
++    ${OUT_DIR}/unit/ii.res
++    ${OUT_DIR}/unit/in.res
++    ${OUT_DIR}/unit/in_ID.res
++    ${OUT_DIR}/unit/is.res
++    ${OUT_DIR}/unit/it.res
++    ${OUT_DIR}/unit/iw.res
++    ${OUT_DIR}/unit/iw_IL.res
++    ${OUT_DIR}/unit/ja.res
++    ${OUT_DIR}/unit/jgo.res
++    ${OUT_DIR}/unit/jmc.res
++    ${OUT_DIR}/unit/jv.res
++    ${OUT_DIR}/unit/ka.res
++    ${OUT_DIR}/unit/kab.res
++    ${OUT_DIR}/unit/kam.res
++    ${OUT_DIR}/unit/kde.res
++    ${OUT_DIR}/unit/kea.res
++    ${OUT_DIR}/unit/khq.res
++    ${OUT_DIR}/unit/ki.res
++    ${OUT_DIR}/unit/kk.res
++    ${OUT_DIR}/unit/kkj.res
++    ${OUT_DIR}/unit/kl.res
++    ${OUT_DIR}/unit/kln.res
++    ${OUT_DIR}/unit/km.res
++    ${OUT_DIR}/unit/kn.res
++    ${OUT_DIR}/unit/ko.res
++    ${OUT_DIR}/unit/kok.res
++    ${OUT_DIR}/unit/ks.res
++    ${OUT_DIR}/unit/ks_Arab.res
++    ${OUT_DIR}/unit/ks_Arab_IN.res
++    ${OUT_DIR}/unit/ks_IN.res
++    ${OUT_DIR}/unit/ksb.res
++    ${OUT_DIR}/unit/ksf.res
++    ${OUT_DIR}/unit/ksh.res
++    ${OUT_DIR}/unit/ku.res
++    ${OUT_DIR}/unit/kw.res
++    ${OUT_DIR}/unit/ky.res
++    ${OUT_DIR}/unit/lag.res
++    ${OUT_DIR}/unit/lb.res
++    ${OUT_DIR}/unit/lg.res
++    ${OUT_DIR}/unit/lkt.res
++    ${OUT_DIR}/unit/ln.res
++    ${OUT_DIR}/unit/lo.res
++    ${OUT_DIR}/unit/lrc.res
++    ${OUT_DIR}/unit/lt.res
++    ${OUT_DIR}/unit/lu.res
++    ${OUT_DIR}/unit/luo.res
++    ${OUT_DIR}/unit/luy.res
++    ${OUT_DIR}/unit/lv.res
++    ${OUT_DIR}/unit/mai.res
++    ${OUT_DIR}/unit/mas.res
++    ${OUT_DIR}/unit/mer.res
++    ${OUT_DIR}/unit/mfe.res
++    ${OUT_DIR}/unit/mg.res
++    ${OUT_DIR}/unit/mgh.res
++    ${OUT_DIR}/unit/mgo.res
++    ${OUT_DIR}/unit/mi.res
++    ${OUT_DIR}/unit/mk.res
++    ${OUT_DIR}/unit/ml.res
++    ${OUT_DIR}/unit/mn.res
++    ${OUT_DIR}/unit/mni.res
++    ${OUT_DIR}/unit/mni_Beng.res
++    ${OUT_DIR}/unit/mni_Beng_IN.res
++    ${OUT_DIR}/unit/mni_IN.res
++    ${OUT_DIR}/unit/mo.res
++    ${OUT_DIR}/unit/mr.res
++    ${OUT_DIR}/unit/ms.res
++    ${OUT_DIR}/unit/mt.res
++    ${OUT_DIR}/unit/mua.res
++    ${OUT_DIR}/unit/my.res
++    ${OUT_DIR}/unit/mzn.res
++    ${OUT_DIR}/unit/naq.res
++    ${OUT_DIR}/unit/nb.res
++    ${OUT_DIR}/unit/nb_NO.res
++    ${OUT_DIR}/unit/nd.res
++    ${OUT_DIR}/unit/nds.res
++    ${OUT_DIR}/unit/ne.res
++    ${OUT_DIR}/unit/nl.res
++    ${OUT_DIR}/unit/nmg.res
++    ${OUT_DIR}/unit/nn.res
++    ${OUT_DIR}/unit/nn_NO.res
++    ${OUT_DIR}/unit/nnh.res
++    ${OUT_DIR}/unit/no.res
++    ${OUT_DIR}/unit/no_NO.res
++    ${OUT_DIR}/unit/no_NO_NY.res
++    ${OUT_DIR}/unit/nus.res
++    ${OUT_DIR}/unit/nyn.res
++    ${OUT_DIR}/unit/om.res
++    ${OUT_DIR}/unit/or.res
++    ${OUT_DIR}/unit/os.res
++    ${OUT_DIR}/unit/pa.res
++    ${OUT_DIR}/unit/pa_Arab.res
++    ${OUT_DIR}/unit/pa_Arab_PK.res
++    ${OUT_DIR}/unit/pa_Guru.res
++    ${OUT_DIR}/unit/pa_Guru_IN.res
++    ${OUT_DIR}/unit/pa_IN.res
++    ${OUT_DIR}/unit/pa_PK.res
++    ${OUT_DIR}/unit/pcm.res
++    ${OUT_DIR}/unit/pl.res
++    ${OUT_DIR}/unit/pool.res
++    ${OUT_DIR}/unit/ps.res
++    ${OUT_DIR}/unit/ps_PK.res
++    ${OUT_DIR}/unit/pt.res
++    ${OUT_DIR}/unit/pt_AO.res
++    ${OUT_DIR}/unit/pt_CH.res
++    ${OUT_DIR}/unit/pt_CV.res
++    ${OUT_DIR}/unit/pt_GQ.res
++    ${OUT_DIR}/unit/pt_GW.res
++    ${OUT_DIR}/unit/pt_LU.res
++    ${OUT_DIR}/unit/pt_MO.res
++    ${OUT_DIR}/unit/pt_MZ.res
++    ${OUT_DIR}/unit/pt_PT.res
++    ${OUT_DIR}/unit/pt_ST.res
++    ${OUT_DIR}/unit/pt_TL.res
++    ${OUT_DIR}/unit/qu.res
++    ${OUT_DIR}/unit/rm.res
++    ${OUT_DIR}/unit/rn.res
++    ${OUT_DIR}/unit/ro.res
++    ${OUT_DIR}/unit/ro_MD.res
++    ${OUT_DIR}/unit/rof.res
++    ${OUT_DIR}/unit/root.res
++    ${OUT_DIR}/unit/ru.res
++    ${OUT_DIR}/unit/rw.res
++    ${OUT_DIR}/unit/rwk.res
++    ${OUT_DIR}/unit/sah.res
++    ${OUT_DIR}/unit/saq.res
++    ${OUT_DIR}/unit/sat.res
++    ${OUT_DIR}/unit/sat_IN.res
++    ${OUT_DIR}/unit/sat_Olck.res
++    ${OUT_DIR}/unit/sat_Olck_IN.res
++    ${OUT_DIR}/unit/sbp.res
++    ${OUT_DIR}/unit/sd.res
++    ${OUT_DIR}/unit/sd_Arab.res
++    ${OUT_DIR}/unit/sd_Arab_PK.res
++    ${OUT_DIR}/unit/sd_Deva.res
++    ${OUT_DIR}/unit/sd_PK.res
++    ${OUT_DIR}/unit/se.res
++    ${OUT_DIR}/unit/seh.res
++    ${OUT_DIR}/unit/ses.res
++    ${OUT_DIR}/unit/sg.res
++    ${OUT_DIR}/unit/sh.res
++    ${OUT_DIR}/unit/sh_BA.res
++    ${OUT_DIR}/unit/sh_CS.res
++    ${OUT_DIR}/unit/sh_YU.res
++    ${OUT_DIR}/unit/shi.res
++    ${OUT_DIR}/unit/shi_Latn.res
++    ${OUT_DIR}/unit/shi_MA.res
++    ${OUT_DIR}/unit/shi_Tfng.res
++    ${OUT_DIR}/unit/shi_Tfng_MA.res
++    ${OUT_DIR}/unit/si.res
++    ${OUT_DIR}/unit/sk.res
++    ${OUT_DIR}/unit/sl.res
++    ${OUT_DIR}/unit/smn.res
++    ${OUT_DIR}/unit/sn.res
++    ${OUT_DIR}/unit/so.res
++    ${OUT_DIR}/unit/sq.res
++    ${OUT_DIR}/unit/sr.res
++    ${OUT_DIR}/unit/sr_BA.res
++    ${OUT_DIR}/unit/sr_CS.res
++    ${OUT_DIR}/unit/sr_Cyrl.res
++    ${OUT_DIR}/unit/sr_Cyrl_BA.res
++    ${OUT_DIR}/unit/sr_Cyrl_CS.res
++    ${OUT_DIR}/unit/sr_Cyrl_RS.res
++    ${OUT_DIR}/unit/sr_Cyrl_XK.res
++    ${OUT_DIR}/unit/sr_Cyrl_YU.res
++    ${OUT_DIR}/unit/sr_Latn.res
++    ${OUT_DIR}/unit/sr_Latn_BA.res
++    ${OUT_DIR}/unit/sr_Latn_CS.res
++    ${OUT_DIR}/unit/sr_Latn_ME.res
++    ${OUT_DIR}/unit/sr_Latn_RS.res
++    ${OUT_DIR}/unit/sr_Latn_YU.res
++    ${OUT_DIR}/unit/sr_ME.res
++    ${OUT_DIR}/unit/sr_RS.res
++    ${OUT_DIR}/unit/sr_XK.res
++    ${OUT_DIR}/unit/sr_YU.res
++    ${OUT_DIR}/unit/su.res
++    ${OUT_DIR}/unit/su_ID.res
++    ${OUT_DIR}/unit/su_Latn.res
++    ${OUT_DIR}/unit/su_Latn_ID.res
++    ${OUT_DIR}/unit/sv.res
++    ${OUT_DIR}/unit/sv_FI.res
++    ${OUT_DIR}/unit/sw.res
++    ${OUT_DIR}/unit/sw_KE.res
++    ${OUT_DIR}/unit/ta.res
++    ${OUT_DIR}/unit/te.res
++    ${OUT_DIR}/unit/teo.res
++    ${OUT_DIR}/unit/tg.res
++    ${OUT_DIR}/unit/th.res
++    ${OUT_DIR}/unit/ti.res
++    ${OUT_DIR}/unit/tk.res
++    ${OUT_DIR}/unit/tl.res
++    ${OUT_DIR}/unit/tl_PH.res
++    ${OUT_DIR}/unit/to.res
++    ${OUT_DIR}/unit/tr.res
++    ${OUT_DIR}/unit/tt.res
++    ${OUT_DIR}/unit/twq.res
++    ${OUT_DIR}/unit/tzm.res
++    ${OUT_DIR}/unit/ug.res
++    ${OUT_DIR}/unit/uk.res
++    ${OUT_DIR}/unit/ur.res
++    ${OUT_DIR}/unit/ur_IN.res
++    ${OUT_DIR}/unit/uz.res
++    ${OUT_DIR}/unit/uz_AF.res
++    ${OUT_DIR}/unit/uz_Arab.res
++    ${OUT_DIR}/unit/uz_Arab_AF.res
++    ${OUT_DIR}/unit/uz_Cyrl.res
++    ${OUT_DIR}/unit/uz_Latn.res
++    ${OUT_DIR}/unit/uz_Latn_UZ.res
++    ${OUT_DIR}/unit/uz_UZ.res
++    ${OUT_DIR}/unit/vai.res
++    ${OUT_DIR}/unit/vai_LR.res
++    ${OUT_DIR}/unit/vai_Latn.res
++    ${OUT_DIR}/unit/vai_Vaii.res
++    ${OUT_DIR}/unit/vai_Vaii_LR.res
++    ${OUT_DIR}/unit/vi.res
++    ${OUT_DIR}/unit/vun.res
++    ${OUT_DIR}/unit/wae.res
++    ${OUT_DIR}/unit/wo.res
++    ${OUT_DIR}/unit/xh.res
++    ${OUT_DIR}/unit/xog.res
++    ${OUT_DIR}/unit/yav.res
++    ${OUT_DIR}/unit/yi.res
++    ${OUT_DIR}/unit/yo.res
++    ${OUT_DIR}/unit/yo_BJ.res
++    ${OUT_DIR}/unit/yue.res
++    ${OUT_DIR}/unit/yue_CN.res
++    ${OUT_DIR}/unit/yue_HK.res
++    ${OUT_DIR}/unit/yue_Hans.res
++    ${OUT_DIR}/unit/yue_Hans_CN.res
++    ${OUT_DIR}/unit/yue_Hant.res
++    ${OUT_DIR}/unit/yue_Hant_HK.res
++    ${OUT_DIR}/unit/zgh.res
++    ${OUT_DIR}/unit/zh.res
++    ${OUT_DIR}/unit/zh_CN.res
++    ${OUT_DIR}/unit/zh_HK.res
++    ${OUT_DIR}/unit/zh_Hans.res
++    ${OUT_DIR}/unit/zh_Hans_CN.res
++    ${OUT_DIR}/unit/zh_Hans_HK.res
++    ${OUT_DIR}/unit/zh_Hans_MO.res
++    ${OUT_DIR}/unit/zh_Hans_SG.res
++    ${OUT_DIR}/unit/zh_Hant.res
++    ${OUT_DIR}/unit/zh_Hant_HK.res
++    ${OUT_DIR}/unit/zh_Hant_MO.res
++    ${OUT_DIR}/unit/zh_Hant_TW.res
++    ${OUT_DIR}/unit/zh_MO.res
++    ${OUT_DIR}/unit/zh_SG.res
++    ${OUT_DIR}/unit/zh_TW.res
++    ${OUT_DIR}/unit/zu.res
++    ${OUT_DIR}/ur.res
++    ${OUT_DIR}/ur_IN.res
++    ${OUT_DIR}/ur_PK.res
++    ${OUT_DIR}/uts46.nrm
++    ${OUT_DIR}/uz.res
++    ${OUT_DIR}/uz_AF.res
++    ${OUT_DIR}/uz_Arab.res
++    ${OUT_DIR}/uz_Arab_AF.res
++    ${OUT_DIR}/uz_Cyrl.res
++    ${OUT_DIR}/uz_Cyrl_UZ.res
++    ${OUT_DIR}/uz_Latn.res
++    ${OUT_DIR}/uz_Latn_UZ.res
++    ${OUT_DIR}/uz_UZ.res
++    ${OUT_DIR}/vai.res
++    ${OUT_DIR}/vai_LR.res
++    ${OUT_DIR}/vai_Latn.res
++    ${OUT_DIR}/vai_Latn_LR.res
++    ${OUT_DIR}/vai_Vaii.res
++    ${OUT_DIR}/vai_Vaii_LR.res
++    ${OUT_DIR}/vi.res
++    ${OUT_DIR}/vi_VN.res
++    ${OUT_DIR}/vun.res
++    ${OUT_DIR}/vun_TZ.res
++    ${OUT_DIR}/wae.res
++    ${OUT_DIR}/wae_CH.res
++    ${OUT_DIR}/windows-874-2000.cnv
++    ${OUT_DIR}/windows-936-2000.cnv
++    ${OUT_DIR}/windows-949-2000.cnv
++    ${OUT_DIR}/windows-950-2000.cnv
++    ${OUT_DIR}/windowsZones.res
++    ${OUT_DIR}/wo.res
++    ${OUT_DIR}/wo_SN.res
++    ${OUT_DIR}/xh.res
++    ${OUT_DIR}/xh_ZA.res
++    ${OUT_DIR}/xog.res
++    ${OUT_DIR}/xog_UG.res
++    ${OUT_DIR}/yav.res
++    ${OUT_DIR}/yav_CM.res
++    ${OUT_DIR}/yi.res
++    ${OUT_DIR}/yi_001.res
++    ${OUT_DIR}/yo.res
++    ${OUT_DIR}/yo_BJ.res
++    ${OUT_DIR}/yo_NG.res
++    ${OUT_DIR}/yue.res
++    ${OUT_DIR}/yue_CN.res
++    ${OUT_DIR}/yue_HK.res
++    ${OUT_DIR}/yue_Hans.res
++    ${OUT_DIR}/yue_Hans_CN.res
++    ${OUT_DIR}/yue_Hant.res
++    ${OUT_DIR}/yue_Hant_HK.res
++    ${OUT_DIR}/zgh.res
++    ${OUT_DIR}/zgh_MA.res
++    ${OUT_DIR}/zh.res
++    ${OUT_DIR}/zh_CN.res
++    ${OUT_DIR}/zh_HK.res
++    ${OUT_DIR}/zh_Hans.res
++    ${OUT_DIR}/zh_Hans_CN.res
++    ${OUT_DIR}/zh_Hans_HK.res
++    ${OUT_DIR}/zh_Hans_MO.res
++    ${OUT_DIR}/zh_Hans_SG.res
++    ${OUT_DIR}/zh_Hant.res
++    ${OUT_DIR}/zh_Hant_HK.res
++    ${OUT_DIR}/zh_Hant_MO.res
++    ${OUT_DIR}/zh_Hant_TW.res
++    ${OUT_DIR}/zh_MO.res
++    ${OUT_DIR}/zh_SG.res
++    ${OUT_DIR}/zh_TW.res
++    ${OUT_DIR}/zone/${INDEX_NAME}.res
++    ${OUT_DIR}/zone/af.res
++    ${OUT_DIR}/zone/agq.res
++    ${OUT_DIR}/zone/ak.res
++    ${OUT_DIR}/zone/am.res
++    ${OUT_DIR}/zone/ar.res
++    ${OUT_DIR}/zone/ar_SA.res
++    ${OUT_DIR}/zone/ars.res
++    ${OUT_DIR}/zone/as.res
++    ${OUT_DIR}/zone/asa.res
++    ${OUT_DIR}/zone/ast.res
++    ${OUT_DIR}/zone/az.res
++    ${OUT_DIR}/zone/az_AZ.res
++    ${OUT_DIR}/zone/az_Cyrl.res
++    ${OUT_DIR}/zone/az_Latn.res
++    ${OUT_DIR}/zone/az_Latn_AZ.res
++    ${OUT_DIR}/zone/bas.res
++    ${OUT_DIR}/zone/be.res
++    ${OUT_DIR}/zone/bem.res
++    ${OUT_DIR}/zone/bez.res
++    ${OUT_DIR}/zone/bg.res
++    ${OUT_DIR}/zone/bm.res
++    ${OUT_DIR}/zone/bn.res
++    ${OUT_DIR}/zone/bo.res
++    ${OUT_DIR}/zone/br.res
++    ${OUT_DIR}/zone/brx.res
++    ${OUT_DIR}/zone/bs.res
++    ${OUT_DIR}/zone/bs_BA.res
++    ${OUT_DIR}/zone/bs_Cyrl.res
++    ${OUT_DIR}/zone/bs_Latn.res
++    ${OUT_DIR}/zone/bs_Latn_BA.res
++    ${OUT_DIR}/zone/ca.res
++    ${OUT_DIR}/zone/ccp.res
++    ${OUT_DIR}/zone/ce.res
++    ${OUT_DIR}/zone/ceb.res
++    ${OUT_DIR}/zone/cgg.res
++    ${OUT_DIR}/zone/chr.res
++    ${OUT_DIR}/zone/ckb.res
++    ${OUT_DIR}/zone/cs.res
++    ${OUT_DIR}/zone/cy.res
++    ${OUT_DIR}/zone/da.res
++    ${OUT_DIR}/zone/dav.res
++    ${OUT_DIR}/zone/de.res
++    ${OUT_DIR}/zone/de_CH.res
++    ${OUT_DIR}/zone/dje.res
++    ${OUT_DIR}/zone/dsb.res
++    ${OUT_DIR}/zone/dua.res
++    ${OUT_DIR}/zone/dyo.res
++    ${OUT_DIR}/zone/dz.res
++    ${OUT_DIR}/zone/ebu.res
++    ${OUT_DIR}/zone/ee.res
++    ${OUT_DIR}/zone/el.res
++    ${OUT_DIR}/zone/en.res
++    ${OUT_DIR}/zone/en_001.res
++    ${OUT_DIR}/zone/en_150.res
++    ${OUT_DIR}/zone/en_AE.res
++    ${OUT_DIR}/zone/en_AG.res
++    ${OUT_DIR}/zone/en_AI.res
++    ${OUT_DIR}/zone/en_AT.res
++    ${OUT_DIR}/zone/en_AU.res
++    ${OUT_DIR}/zone/en_BB.res
++    ${OUT_DIR}/zone/en_BE.res
++    ${OUT_DIR}/zone/en_BM.res
++    ${OUT_DIR}/zone/en_BS.res
++    ${OUT_DIR}/zone/en_BW.res
++    ${OUT_DIR}/zone/en_BZ.res
++    ${OUT_DIR}/zone/en_CA.res
++    ${OUT_DIR}/zone/en_CC.res
++    ${OUT_DIR}/zone/en_CH.res
++    ${OUT_DIR}/zone/en_CK.res
++    ${OUT_DIR}/zone/en_CM.res
++    ${OUT_DIR}/zone/en_CX.res
++    ${OUT_DIR}/zone/en_CY.res
++    ${OUT_DIR}/zone/en_DE.res
++    ${OUT_DIR}/zone/en_DG.res
++    ${OUT_DIR}/zone/en_DK.res
++    ${OUT_DIR}/zone/en_DM.res
++    ${OUT_DIR}/zone/en_ER.res
++    ${OUT_DIR}/zone/en_FI.res
++    ${OUT_DIR}/zone/en_FJ.res
++    ${OUT_DIR}/zone/en_FK.res
++    ${OUT_DIR}/zone/en_FM.res
++    ${OUT_DIR}/zone/en_GB.res
++    ${OUT_DIR}/zone/en_GD.res
++    ${OUT_DIR}/zone/en_GG.res
++    ${OUT_DIR}/zone/en_GH.res
++    ${OUT_DIR}/zone/en_GI.res
++    ${OUT_DIR}/zone/en_GM.res
++    ${OUT_DIR}/zone/en_GU.res
++    ${OUT_DIR}/zone/en_GY.res
++    ${OUT_DIR}/zone/en_HK.res
++    ${OUT_DIR}/zone/en_IE.res
++    ${OUT_DIR}/zone/en_IL.res
++    ${OUT_DIR}/zone/en_IM.res
++    ${OUT_DIR}/zone/en_IN.res
++    ${OUT_DIR}/zone/en_IO.res
++    ${OUT_DIR}/zone/en_JE.res
++    ${OUT_DIR}/zone/en_JM.res
++    ${OUT_DIR}/zone/en_KE.res
++    ${OUT_DIR}/zone/en_KI.res
++    ${OUT_DIR}/zone/en_KN.res
++    ${OUT_DIR}/zone/en_KY.res
++    ${OUT_DIR}/zone/en_LC.res
++    ${OUT_DIR}/zone/en_LR.res
++    ${OUT_DIR}/zone/en_LS.res
++    ${OUT_DIR}/zone/en_MG.res
++    ${OUT_DIR}/zone/en_MH.res
++    ${OUT_DIR}/zone/en_MO.res
++    ${OUT_DIR}/zone/en_MP.res
++    ${OUT_DIR}/zone/en_MS.res
++    ${OUT_DIR}/zone/en_MT.res
++    ${OUT_DIR}/zone/en_MU.res
++    ${OUT_DIR}/zone/en_MW.res
++    ${OUT_DIR}/zone/en_MY.res
++    ${OUT_DIR}/zone/en_NA.res
++    ${OUT_DIR}/zone/en_NF.res
++    ${OUT_DIR}/zone/en_NG.res
++    ${OUT_DIR}/zone/en_NH.res
++    ${OUT_DIR}/zone/en_NL.res
++    ${OUT_DIR}/zone/en_NR.res
++    ${OUT_DIR}/zone/en_NU.res
++    ${OUT_DIR}/zone/en_NZ.res
++    ${OUT_DIR}/zone/en_PG.res
++    ${OUT_DIR}/zone/en_PH.res
++    ${OUT_DIR}/zone/en_PK.res
++    ${OUT_DIR}/zone/en_PN.res
++    ${OUT_DIR}/zone/en_PW.res
++    ${OUT_DIR}/zone/en_RH.res
++    ${OUT_DIR}/zone/en_RW.res
++    ${OUT_DIR}/zone/en_SB.res
++    ${OUT_DIR}/zone/en_SC.res
++    ${OUT_DIR}/zone/en_SD.res
++    ${OUT_DIR}/zone/en_SE.res
++    ${OUT_DIR}/zone/en_SG.res
++    ${OUT_DIR}/zone/en_SH.res
++    ${OUT_DIR}/zone/en_SI.res
++    ${OUT_DIR}/zone/en_SL.res
++    ${OUT_DIR}/zone/en_SS.res
++    ${OUT_DIR}/zone/en_SX.res
++    ${OUT_DIR}/zone/en_SZ.res
++    ${OUT_DIR}/zone/en_TC.res
++    ${OUT_DIR}/zone/en_TK.res
++    ${OUT_DIR}/zone/en_TO.res
++    ${OUT_DIR}/zone/en_TT.res
++    ${OUT_DIR}/zone/en_TV.res
++    ${OUT_DIR}/zone/en_TZ.res
++    ${OUT_DIR}/zone/en_UG.res
++    ${OUT_DIR}/zone/en_VC.res
++    ${OUT_DIR}/zone/en_VG.res
++    ${OUT_DIR}/zone/en_VU.res
++    ${OUT_DIR}/zone/en_WS.res
++    ${OUT_DIR}/zone/en_ZA.res
++    ${OUT_DIR}/zone/en_ZM.res
++    ${OUT_DIR}/zone/en_ZW.res
++    ${OUT_DIR}/zone/eo.res
++    ${OUT_DIR}/zone/es.res
++    ${OUT_DIR}/zone/es_419.res
++    ${OUT_DIR}/zone/es_AR.res
++    ${OUT_DIR}/zone/es_BO.res
++    ${OUT_DIR}/zone/es_BR.res
++    ${OUT_DIR}/zone/es_BZ.res
++    ${OUT_DIR}/zone/es_CL.res
++    ${OUT_DIR}/zone/es_CO.res
++    ${OUT_DIR}/zone/es_CR.res
++    ${OUT_DIR}/zone/es_CU.res
++    ${OUT_DIR}/zone/es_DO.res
++    ${OUT_DIR}/zone/es_EC.res
++    ${OUT_DIR}/zone/es_GT.res
++    ${OUT_DIR}/zone/es_HN.res
++    ${OUT_DIR}/zone/es_MX.res
++    ${OUT_DIR}/zone/es_NI.res
++    ${OUT_DIR}/zone/es_PA.res
++    ${OUT_DIR}/zone/es_PE.res
++    ${OUT_DIR}/zone/es_PR.res
++    ${OUT_DIR}/zone/es_PY.res
++    ${OUT_DIR}/zone/es_SV.res
++    ${OUT_DIR}/zone/es_US.res
++    ${OUT_DIR}/zone/es_UY.res
++    ${OUT_DIR}/zone/es_VE.res
++    ${OUT_DIR}/zone/et.res
++    ${OUT_DIR}/zone/eu.res
++    ${OUT_DIR}/zone/ewo.res
++    ${OUT_DIR}/zone/fa.res
++    ${OUT_DIR}/zone/ff.res
++    ${OUT_DIR}/zone/ff_Adlm.res
++    ${OUT_DIR}/zone/ff_CM.res
++    ${OUT_DIR}/zone/ff_GN.res
++    ${OUT_DIR}/zone/ff_Latn.res
++    ${OUT_DIR}/zone/ff_Latn_CM.res
++    ${OUT_DIR}/zone/ff_Latn_GN.res
++    ${OUT_DIR}/zone/ff_Latn_MR.res
++    ${OUT_DIR}/zone/ff_Latn_SN.res
++    ${OUT_DIR}/zone/ff_MR.res
++    ${OUT_DIR}/zone/ff_SN.res
++    ${OUT_DIR}/zone/fi.res
++    ${OUT_DIR}/zone/fil.res
++    ${OUT_DIR}/zone/fil_PH.res
++    ${OUT_DIR}/zone/fo.res
++    ${OUT_DIR}/zone/fr.res
++    ${OUT_DIR}/zone/fr_CA.res
++    ${OUT_DIR}/zone/fr_GF.res
++    ${OUT_DIR}/zone/fur.res
++    ${OUT_DIR}/zone/fy.res
++    ${OUT_DIR}/zone/ga.res
++    ${OUT_DIR}/zone/gd.res
++    ${OUT_DIR}/zone/gl.res
++    ${OUT_DIR}/zone/gsw.res
++    ${OUT_DIR}/zone/gu.res
++    ${OUT_DIR}/zone/guz.res
++    ${OUT_DIR}/zone/gv.res
++    ${OUT_DIR}/zone/ha.res
++    ${OUT_DIR}/zone/haw.res
++    ${OUT_DIR}/zone/he.res
++    ${OUT_DIR}/zone/he_IL.res
++    ${OUT_DIR}/zone/hi.res
++    ${OUT_DIR}/zone/hr.res
++    ${OUT_DIR}/zone/hsb.res
++    ${OUT_DIR}/zone/hu.res
++    ${OUT_DIR}/zone/hy.res
++    ${OUT_DIR}/zone/ia.res
++    ${OUT_DIR}/zone/id.res
++    ${OUT_DIR}/zone/id_ID.res
++    ${OUT_DIR}/zone/ig.res
++    ${OUT_DIR}/zone/ii.res
++    ${OUT_DIR}/zone/in.res
++    ${OUT_DIR}/zone/in_ID.res
++    ${OUT_DIR}/zone/is.res
++    ${OUT_DIR}/zone/it.res
++    ${OUT_DIR}/zone/iw.res
++    ${OUT_DIR}/zone/iw_IL.res
++    ${OUT_DIR}/zone/ja.res
++    ${OUT_DIR}/zone/jgo.res
++    ${OUT_DIR}/zone/jmc.res
++    ${OUT_DIR}/zone/jv.res
++    ${OUT_DIR}/zone/ka.res
++    ${OUT_DIR}/zone/kab.res
++    ${OUT_DIR}/zone/kam.res
++    ${OUT_DIR}/zone/kde.res
++    ${OUT_DIR}/zone/kea.res
++    ${OUT_DIR}/zone/khq.res
++    ${OUT_DIR}/zone/ki.res
++    ${OUT_DIR}/zone/kk.res
++    ${OUT_DIR}/zone/kkj.res
++    ${OUT_DIR}/zone/kl.res
++    ${OUT_DIR}/zone/kln.res
++    ${OUT_DIR}/zone/km.res
++    ${OUT_DIR}/zone/kn.res
++    ${OUT_DIR}/zone/ko.res
++    ${OUT_DIR}/zone/ko_KP.res
++    ${OUT_DIR}/zone/kok.res
++    ${OUT_DIR}/zone/ks.res
++    ${OUT_DIR}/zone/ks_Arab.res
++    ${OUT_DIR}/zone/ks_Arab_IN.res
++    ${OUT_DIR}/zone/ks_IN.res
++    ${OUT_DIR}/zone/ksb.res
++    ${OUT_DIR}/zone/ksf.res
++    ${OUT_DIR}/zone/ksh.res
++    ${OUT_DIR}/zone/ku.res
++    ${OUT_DIR}/zone/kw.res
++    ${OUT_DIR}/zone/ky.res
++    ${OUT_DIR}/zone/lag.res
++    ${OUT_DIR}/zone/lb.res
++    ${OUT_DIR}/zone/lg.res
++    ${OUT_DIR}/zone/lkt.res
++    ${OUT_DIR}/zone/ln.res
++    ${OUT_DIR}/zone/lo.res
++    ${OUT_DIR}/zone/lrc.res
++    ${OUT_DIR}/zone/lt.res
++    ${OUT_DIR}/zone/lu.res
++    ${OUT_DIR}/zone/luo.res
++    ${OUT_DIR}/zone/luy.res
++    ${OUT_DIR}/zone/lv.res
++    ${OUT_DIR}/zone/mai.res
++    ${OUT_DIR}/zone/mas.res
++    ${OUT_DIR}/zone/mer.res
++    ${OUT_DIR}/zone/mfe.res
++    ${OUT_DIR}/zone/mg.res
++    ${OUT_DIR}/zone/mgh.res
++    ${OUT_DIR}/zone/mgo.res
++    ${OUT_DIR}/zone/mi.res
++    ${OUT_DIR}/zone/mk.res
++    ${OUT_DIR}/zone/ml.res
++    ${OUT_DIR}/zone/mn.res
++    ${OUT_DIR}/zone/mni.res
++    ${OUT_DIR}/zone/mni_Beng.res
++    ${OUT_DIR}/zone/mni_Beng_IN.res
++    ${OUT_DIR}/zone/mni_IN.res
++    ${OUT_DIR}/zone/mo.res
++    ${OUT_DIR}/zone/mr.res
++    ${OUT_DIR}/zone/ms.res
++    ${OUT_DIR}/zone/ms_ID.res
++    ${OUT_DIR}/zone/mt.res
++    ${OUT_DIR}/zone/mua.res
++    ${OUT_DIR}/zone/my.res
++    ${OUT_DIR}/zone/mzn.res
++    ${OUT_DIR}/zone/naq.res
++    ${OUT_DIR}/zone/nb.res
++    ${OUT_DIR}/zone/nb_NO.res
++    ${OUT_DIR}/zone/nd.res
++    ${OUT_DIR}/zone/nds.res
++    ${OUT_DIR}/zone/ne.res
++    ${OUT_DIR}/zone/ne_IN.res
++    ${OUT_DIR}/zone/nl.res
++    ${OUT_DIR}/zone/nl_SR.res
++    ${OUT_DIR}/zone/nmg.res
++    ${OUT_DIR}/zone/nn.res
++    ${OUT_DIR}/zone/nn_NO.res
++    ${OUT_DIR}/zone/nnh.res
++    ${OUT_DIR}/zone/no.res
++    ${OUT_DIR}/zone/no_NO.res
++    ${OUT_DIR}/zone/no_NO_NY.res
++    ${OUT_DIR}/zone/nus.res
++    ${OUT_DIR}/zone/nyn.res
++    ${OUT_DIR}/zone/om.res
++    ${OUT_DIR}/zone/or.res
++    ${OUT_DIR}/zone/os.res
++    ${OUT_DIR}/zone/pa.res
++    ${OUT_DIR}/zone/pa_Arab.res
++    ${OUT_DIR}/zone/pa_Arab_PK.res
++    ${OUT_DIR}/zone/pa_Guru.res
++    ${OUT_DIR}/zone/pa_Guru_IN.res
++    ${OUT_DIR}/zone/pa_IN.res
++    ${OUT_DIR}/zone/pa_PK.res
++    ${OUT_DIR}/zone/pcm.res
++    ${OUT_DIR}/zone/pl.res
++    ${OUT_DIR}/zone/pool.res
++    ${OUT_DIR}/zone/ps.res
++    ${OUT_DIR}/zone/ps_PK.res
++    ${OUT_DIR}/zone/pt.res
++    ${OUT_DIR}/zone/pt_AO.res
++    ${OUT_DIR}/zone/pt_CH.res
++    ${OUT_DIR}/zone/pt_CV.res
++    ${OUT_DIR}/zone/pt_GQ.res
++    ${OUT_DIR}/zone/pt_GW.res
++    ${OUT_DIR}/zone/pt_LU.res
++    ${OUT_DIR}/zone/pt_MO.res
++    ${OUT_DIR}/zone/pt_MZ.res
++    ${OUT_DIR}/zone/pt_PT.res
++    ${OUT_DIR}/zone/pt_ST.res
++    ${OUT_DIR}/zone/pt_TL.res
++    ${OUT_DIR}/zone/qu.res
++    ${OUT_DIR}/zone/qu_BO.res
++    ${OUT_DIR}/zone/qu_EC.res
++    ${OUT_DIR}/zone/rm.res
++    ${OUT_DIR}/zone/rn.res
++    ${OUT_DIR}/zone/ro.res
++    ${OUT_DIR}/zone/rof.res
++    ${OUT_DIR}/zone/root.res
++    ${OUT_DIR}/zone/ru.res
++    ${OUT_DIR}/zone/rw.res
++    ${OUT_DIR}/zone/rwk.res
++    ${OUT_DIR}/zone/sah.res
++    ${OUT_DIR}/zone/saq.res
++    ${OUT_DIR}/zone/sat.res
++    ${OUT_DIR}/zone/sat_IN.res
++    ${OUT_DIR}/zone/sat_Olck.res
++    ${OUT_DIR}/zone/sat_Olck_IN.res
++    ${OUT_DIR}/zone/sbp.res
++    ${OUT_DIR}/zone/sd.res
++    ${OUT_DIR}/zone/sd_Arab.res
++    ${OUT_DIR}/zone/sd_Arab_PK.res
++    ${OUT_DIR}/zone/sd_Deva.res
++    ${OUT_DIR}/zone/sd_PK.res
++    ${OUT_DIR}/zone/se.res
++    ${OUT_DIR}/zone/se_FI.res
++    ${OUT_DIR}/zone/seh.res
++    ${OUT_DIR}/zone/ses.res
++    ${OUT_DIR}/zone/sg.res
++    ${OUT_DIR}/zone/sh.res
++    ${OUT_DIR}/zone/sh_BA.res
++    ${OUT_DIR}/zone/sh_CS.res
++    ${OUT_DIR}/zone/sh_YU.res
++    ${OUT_DIR}/zone/shi.res
++    ${OUT_DIR}/zone/shi_Latn.res
++    ${OUT_DIR}/zone/shi_MA.res
++    ${OUT_DIR}/zone/shi_Tfng.res
++    ${OUT_DIR}/zone/shi_Tfng_MA.res
++    ${OUT_DIR}/zone/si.res
++    ${OUT_DIR}/zone/sk.res
++    ${OUT_DIR}/zone/sl.res
++    ${OUT_DIR}/zone/smn.res
++    ${OUT_DIR}/zone/sn.res
++    ${OUT_DIR}/zone/so.res
++    ${OUT_DIR}/zone/sq.res
++    ${OUT_DIR}/zone/sr.res
++    ${OUT_DIR}/zone/sr_BA.res
++    ${OUT_DIR}/zone/sr_CS.res
++    ${OUT_DIR}/zone/sr_Cyrl.res
++    ${OUT_DIR}/zone/sr_Cyrl_BA.res
++    ${OUT_DIR}/zone/sr_Cyrl_CS.res
++    ${OUT_DIR}/zone/sr_Cyrl_RS.res
++    ${OUT_DIR}/zone/sr_Cyrl_XK.res
++    ${OUT_DIR}/zone/sr_Cyrl_YU.res
++    ${OUT_DIR}/zone/sr_Latn.res
++    ${OUT_DIR}/zone/sr_Latn_BA.res
++    ${OUT_DIR}/zone/sr_Latn_CS.res
++    ${OUT_DIR}/zone/sr_Latn_ME.res
++    ${OUT_DIR}/zone/sr_Latn_RS.res
++    ${OUT_DIR}/zone/sr_Latn_YU.res
++    ${OUT_DIR}/zone/sr_ME.res
++    ${OUT_DIR}/zone/sr_RS.res
++    ${OUT_DIR}/zone/sr_XK.res
++    ${OUT_DIR}/zone/sr_YU.res
++    ${OUT_DIR}/zone/su.res
++    ${OUT_DIR}/zone/su_ID.res
++    ${OUT_DIR}/zone/su_Latn.res
++    ${OUT_DIR}/zone/su_Latn_ID.res
++    ${OUT_DIR}/zone/sv.res
++    ${OUT_DIR}/zone/sw.res
++    ${OUT_DIR}/zone/sw_KE.res
++    ${OUT_DIR}/zone/ta.res
++    ${OUT_DIR}/zone/ta_MY.res
++    ${OUT_DIR}/zone/ta_SG.res
++    ${OUT_DIR}/zone/te.res
++    ${OUT_DIR}/zone/teo.res
++    ${OUT_DIR}/zone/tg.res
++    ${OUT_DIR}/zone/th.res
++    ${OUT_DIR}/zone/ti.res
++    ${OUT_DIR}/zone/tk.res
++    ${OUT_DIR}/zone/tl.res
++    ${OUT_DIR}/zone/tl_PH.res
++    ${OUT_DIR}/zone/to.res
++    ${OUT_DIR}/zone/tr.res
++    ${OUT_DIR}/zone/tt.res
++    ${OUT_DIR}/zone/twq.res
++    ${OUT_DIR}/zone/tzdbNames.res
++    ${OUT_DIR}/zone/tzm.res
++    ${OUT_DIR}/zone/ug.res
++    ${OUT_DIR}/zone/uk.res
++    ${OUT_DIR}/zone/ur.res
++    ${OUT_DIR}/zone/ur_IN.res
++    ${OUT_DIR}/zone/uz.res
++    ${OUT_DIR}/zone/uz_AF.res
++    ${OUT_DIR}/zone/uz_Arab.res
++    ${OUT_DIR}/zone/uz_Arab_AF.res
++    ${OUT_DIR}/zone/uz_Cyrl.res
++    ${OUT_DIR}/zone/uz_Latn.res
++    ${OUT_DIR}/zone/uz_Latn_UZ.res
++    ${OUT_DIR}/zone/uz_UZ.res
++    ${OUT_DIR}/zone/vai.res
++    ${OUT_DIR}/zone/vai_LR.res
++    ${OUT_DIR}/zone/vai_Latn.res
++    ${OUT_DIR}/zone/vai_Vaii.res
++    ${OUT_DIR}/zone/vai_Vaii_LR.res
++    ${OUT_DIR}/zone/vi.res
++    ${OUT_DIR}/zone/vun.res
++    ${OUT_DIR}/zone/wae.res
++    ${OUT_DIR}/zone/wo.res
++    ${OUT_DIR}/zone/xh.res
++    ${OUT_DIR}/zone/xog.res
++    ${OUT_DIR}/zone/yav.res
++    ${OUT_DIR}/zone/yi.res
++    ${OUT_DIR}/zone/yo.res
++    ${OUT_DIR}/zone/yo_BJ.res
++    ${OUT_DIR}/zone/yue.res
++    ${OUT_DIR}/zone/yue_CN.res
++    ${OUT_DIR}/zone/yue_HK.res
++    ${OUT_DIR}/zone/yue_Hans.res
++    ${OUT_DIR}/zone/yue_Hans_CN.res
++    ${OUT_DIR}/zone/yue_Hant.res
++    ${OUT_DIR}/zone/yue_Hant_HK.res
++    ${OUT_DIR}/zone/zgh.res
++    ${OUT_DIR}/zone/zh.res
++    ${OUT_DIR}/zone/zh_CN.res
++    ${OUT_DIR}/zone/zh_HK.res
++    ${OUT_DIR}/zone/zh_Hans.res
++    ${OUT_DIR}/zone/zh_Hans_CN.res
++    ${OUT_DIR}/zone/zh_Hans_SG.res
++    ${OUT_DIR}/zone/zh_Hant.res
++    ${OUT_DIR}/zone/zh_Hant_HK.res
++    ${OUT_DIR}/zone/zh_Hant_MO.res
++    ${OUT_DIR}/zone/zh_Hant_TW.res
++    ${OUT_DIR}/zone/zh_MO.res
++    ${OUT_DIR}/zone/zh_SG.res
++    ${OUT_DIR}/zone/zh_TW.res
++    ${OUT_DIR}/zone/zu.res
++    ${OUT_DIR}/zoneinfo64.res
++    ${OUT_DIR}/zu.res
++    ${OUT_DIR}/zu_ZA.res
++    ${TMP_DIR}/icudata.lst
 +)
 +list(APPEND tmpdep ${ICUDATA_ALL_OUTPUT_FILES})
-+
 diff --git a/source/i18n/CMakeLists.txt b/source/i18n/CMakeLists.txt
 new file mode 100644
-index 0000000000..6ce842d16d
+index 0000000000..c237333eb3
 --- /dev/null
 +++ b/source/i18n/CMakeLists.txt
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,80 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_I18N})
 +set(lib_NAME_SUFFIX ${I18N_STUBNAME})
 +
 +set(private_src_DIR "${CMAKE_CURRENT_LIST_DIR}")
 +set(interface_src_DIR "${includedir}")
-+set(build_src_DIR
-+  "$<BUILD_INTERFACE:${private_src_DIR}>"
-+)
-+set(install_src_DIR
-+  "$<INSTALL_INTERFACE:${interface_src_DIR}>"
-+)
++set(build_src_DIR "$<BUILD_INTERFACE:${private_src_DIR}>")
++set(install_src_DIR "$<INSTALL_INTERFACE:${interface_src_DIR}>")
 +set(public_src_DIR "${build_src_DIR}${install_src_DIR}")
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGSICUI18N}
-+    U_I18N_IMPLEMENTATION
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGSICUI18N} U_I18N_IMPLEMENTATION
 +)
 +if(MSVC)
-+  if(WINDOWS_STORE)
-+    set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+      COMPILE_DEFINITIONS U_PLATFORM_USES_ONLY_WIN32_API=1
-+    )
-+  endif()
++    if(WINDOWS_STORE)
++        set_property(
++            TARGET ${lib_NAME}
++            APPEND
++            PROPERTY COMPILE_DEFINITIONS U_PLATFORM_USES_ONLY_WIN32_API=1
++        )
++    endif()
 +endif()
 +if(MINGW AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS U_USE_STRTOD_L=0
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS U_USE_STRTOD_L=0
++    )
 +endif()
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICUI18N}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICUI18N}
 +)
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${private_src_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+)
++# Include directories PRIVATE
++target_include_directories(${lib_NAME} PRIVATE ${private_src_DIR} ${PROJECT_SOURCE_DIR}/common)
 +
-+### Link libraries
-+# PUBLIC
-+# LIBS = $(LIBICUUC) $(DEFAULT_LIBS)
++# Link libraries PUBLIC LIBS = $(LIBICUUC) $(DEFAULT_LIBS)
 +target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_UC})
 +
-+#setup_icu_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}")
-+setup_icu_lib_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}")
-+
-+install(
-+  FILES ${${lib_NAME}_PUBLIC_HEADERS}
-+  DESTINATION "${includedir}/unicode"
++# setup_icu_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}")
++setup_icu_lib_target(
++    "${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}"
 +)
 +
-+#install(
-+#  DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode
-+#  DESTINATION "${includedir}"
-+#  FILES_MATCHING
-+#  PATTERN "*.h"
-+#)
++install(FILES ${${lib_NAME}_PUBLIC_HEADERS} DESTINATION "${includedir}/unicode")
++
++# install( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode DESTINATION "${includedir}" FILES_MATCHING PATTERN
++# "*.h" )
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/icudefs.cmake b/source/icudefs.cmake
 new file mode 100644
-index 0000000000..0272844248
+index 0000000000..34688e4317
 --- /dev/null
 +++ b/source/icudefs.cmake
-@@ -0,0 +1,268 @@
+@@ -0,0 +1,245 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +# Standard directories
 +include(GNUInstallDirs)
-+set(bindir      ${CMAKE_INSTALL_BINDIR})
-+set(sbindir     ${CMAKE_INSTALL_SBINDIR})
++set(bindir ${CMAKE_INSTALL_BINDIR})
++set(sbindir ${CMAKE_INSTALL_SBINDIR})
 +set(datarootdir ${CMAKE_INSTALL_DATAROOTDIR})
-+set(datadir     ${CMAKE_INSTALL_DATADIR})
-+set(libdir      ${CMAKE_INSTALL_LIBDIR})
-+set(includedir  ${CMAKE_INSTALL_INCLUDEDIR})
-+set(mandir      ${CMAKE_INSTALL_MANDIR})
-+set(sysconfdir  ${CMAKE_INSTALL_SYSCONFDIR})
++set(datadir ${CMAKE_INSTALL_DATADIR})
++set(libdir ${CMAKE_INSTALL_LIBDIR})
++set(includedir ${CMAKE_INSTALL_INCLUDEDIR})
++set(mandir ${CMAKE_INSTALL_MANDIR})
++set(sysconfdir ${CMAKE_INSTALL_SYSCONFDIR})
 +
 +if(MSVC AND "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-+  set(bindir "bin64")
-+  set(libdir "lib64")
++    set(bindir "bin64")
++    set(libdir "lib64")
 +endif()
 +
 +# Package information
 +set(PACKAGE_ICU_DESCRIPTION "International Components for Unicode")
 +set(PACKAGE_ICU_URL "http://icu-project.org")
-+#set(PACKAGE @PACKAGE@)  # set in configure_2nd.cmake
-+#set(VERSION @VERSION@)  # set in configure_2nd.cmake
-+#set(UNICODE_VERSION @UNICODE_VERSION@)  # set in configure_2nd.cmake
++# set(PACKAGE @PACKAGE@)  # set in configure_2nd.cmake set(VERSION @VERSION@)  # set in
++# configure_2nd.cmake set(UNICODE_VERSION @UNICODE_VERSION@)  # set in configure_2nd.cmake
 +set(SO_TARGET_VERSION ${PROJECT_VERSION})
 +set(SO_TARGET_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 +
-+
-+# The ICU data external name is usually icudata; the entry point name is
-+# the version-dependent name (for no particular reason except it was easier
-+# to change the build this way). When building in common mode, the data
-+# name is the versioned platform-dependent one.
++# The ICU data external name is usually icudata; the entry point name is the version-dependent name (for
++# no particular reason except it was easier to change the build this way). When building in common mode,
++# the data name is the versioned platform-dependent one.
 +set(ICUDATA_DIR ${datarootdir}/${PACKAGE}/${PROJECT_VERSION})
 +
 +set(ICUDATA_BASENAME_VERSION ${ICUPREFIX}dt${PROJECT_VERSION_MAJOR})
 +# The entry point is almost like the basename, but has the lib suffix.
 +set(ICUDATA_ENTRY_POINT ${ICUPREFIX}dt${ICULIBSUFFIXCNAME}${PROJECT_VERSION_MAJOR})
-+#set(ICUDATA_CHAR @ICUDATA_CHAR@)  # set in configure_2nd.cmake
++# set(ICUDATA_CHAR @ICUDATA_CHAR@)  # set in configure_2nd.cmake
 +set(ICUDATA_PLATFORM_NAME ${ICUDATA_BASENAME_VERSION}${ICUDATA_CHAR})
 +
 +if(NOT PKGDATA_MODE)
-+  set(PKGDATA_MODE ${DATA_PACKAGING_MODE})
++    set(PKGDATA_MODE ${DATA_PACKAGING_MODE})
 +endif()
 +if(PKGDATA_MODE STREQUAL "common")
-+  set(ICUPKGDATA_DIR ${ICUDATA_DIR})
++    set(ICUPKGDATA_DIR ${ICUDATA_DIR})
 +elseif(PKGDATA_MODE STREQUAL "dll" OR PKGDATA_MODE STREQUAL "static")
-+  set(ICUPKGDATA_DIR ${libdir})
++    set(ICUPKGDATA_DIR ${libdir})
 +else()
-+  set(ICUPKGDATA_DIR ${ICUDATA_DIR})
++    set(ICUPKGDATA_DIR ${ICUDATA_DIR})
 +endif()
 +
 +set(ICUDATA_NAME ${ICUDATA_PLATFORM_NAME})
 +
 +# These are defined here because mh-cygwin-msvc needs to override these values.
-+#set(ICUPKGDATA_INSTALL_DIR ${DESTDIR}${ICUPKGDATA_DIR})
-+#set(ICUPKGDATA_INSTALL_LIBDIR ${DESTDIR}${libdir})
++# set(ICUPKGDATA_INSTALL_DIR ${DESTDIR}${ICUPKGDATA_DIR}) set(ICUPKGDATA_INSTALL_LIBDIR
++# ${DESTDIR}${libdir})
 +
-+# If defined to a valid value, pkgdata will generate a data library more quickly
-+#set(GENCCODE_ASSEMBLY @GENCCODE_ASSEMBLY@)  # set in configure_2nd.cmake
++# If defined to a valid value, pkgdata will generate a data library more quickly set(GENCCODE_ASSEMBLY
++# @GENCCODE_ASSEMBLY@)  # set in configure_2nd.cmake
 +
 +# ICU specific directories
 +set(pkgdatadir ${datadir}/${PACKAGE}${ICULIBSUFFIX}/${PROJECT_VERSION})
 +set(pkglibdir ${libdir}/${PACKAGE}${ICULIBSUFFIX}/${PROJECT_VERSION})
 +set(pkgsysconfdir ${sysconfdir}/${PACKAGE}${ICULIBSUFFIX})
 +
-+# Library suffix (to support different C++ compilers). Usually empty.
-+#set(ICULIBSUFFIX @ICULIBSUFFIX@)  # set in configure_2nd.cmake
-+
++# Library suffix (to support different C++ compilers). Usually empty. set(ICULIBSUFFIX @ICULIBSUFFIX@)  #
++# set in configure_2nd.cmake
 +
 +# Various flags for the tools
 +
-+# DEFS is for common macro definitions.
-+# configure prevents user defined DEFS, and configure's DEFS is not needed
-+# So we ignore the DEFS that comes from configure
-+# U_ATTRIBUTE_DEPRECATED is defined to hide warnings about deprecated API warnings.
++# DEFS is for common macro definitions. configure prevents user defined DEFS, and configure's DEFS is not
++# needed So we ignore the DEFS that comes from configure U_ATTRIBUTE_DEPRECATED is defined to hide
++# warnings about deprecated API warnings.
 +set(DEFS U_ATTRIBUTE_DEPRECATED=)
 +
-+# CFLAGS is for C only flags
-+#set(CFLAGS @CFLAGS@)  # set in configure_2nd.cmake
-+# CXXFLAGS is for C++ only flags
-+#set(CXXFLAGS @CXXFLAGS@)  # set in configure_2nd.cmake
-+# CPPFLAGS is for C Pre-Processor flags
-+#set(CPPFLAGS @CPPFLAGS@)  # set in configure_2nd.cmake
-+# LIBCFLAGS are the flags for static and shared libraries.
-+#set(LIBCFLAGS @LIBCFLAGS@)  # set in configure_2nd.cmake
-+# LIBCXXFLAGS are the flags for static and shared libraries.
-+#set(LIBCXXFLAGS @LIBCXXFLAGS@)  # set in configure_2nd.cmake
-+# LIBCPPFLAGS are the flags for static and shared libraries.
-+# set(LIBCPPFLAGS @LIBCPPFLAGS@)  # set in configure_2nd.cmake
-+# DEFAULT_LIBS are the default libraries to link against
++# CFLAGS is for C only flags set(CFLAGS @CFLAGS@)  # set in configure_2nd.cmake CXXFLAGS is for C++ only
++# flags set(CXXFLAGS @CXXFLAGS@)  # set in configure_2nd.cmake CPPFLAGS is for C Pre-Processor flags
++# set(CPPFLAGS @CPPFLAGS@)  # set in configure_2nd.cmake LIBCFLAGS are the flags for static and shared
++# libraries. set(LIBCFLAGS @LIBCFLAGS@)  # set in configure_2nd.cmake LIBCXXFLAGS are the flags for
++# static and shared libraries. set(LIBCXXFLAGS @LIBCXXFLAGS@)  # set in configure_2nd.cmake LIBCPPFLAGS
++# are the flags for static and shared libraries. set(LIBCPPFLAGS @LIBCPPFLAGS@)  # set in
++# configure_2nd.cmake DEFAULT_LIBS are the default libraries to link against
 +set(DEFAULT_LIBS ${LIBS})
-+# LIB_M is for linking against the math library
-+#set(LIB_M @LIB_M@)  # We do not use.
-+set(LIB_M "")  # We do not use.
-+# LIB_THREAD is for linking against the threading library
-+#set(LIB_THREAD @LIB_THREAD@)  # We do not use.
++# LIB_M is for linking against the math library set(LIB_M @LIB_M@)  # We do not use.
++set(LIB_M "") # We do not use.
++# LIB_THREAD is for linking against the threading library set(LIB_THREAD @LIB_THREAD@)  # We do not use.
 +
-+##  How ICU libraries are named...  ex. $(LIBICU)uc$(SO)
-+# Prefix for the ICU library names
-+#set(ICUPREFIX "icu)  # set in source/CMakeLists.txt
++# How ICU libraries are named...  ex. $(LIBICU)uc$(SO) Prefix for the ICU library names set(ICUPREFIX
++# "icu)  # set in source/CMakeLists.txt
 +set(LIBICU ${ICUPREFIX})
 +
 +# Location of the libraries before "make install" is used
@@ -18930,86 +18956,81 @@ index 0000000000..0272844248
 +# Location of the executables before "make install" is used
 +set(BINDIR ${PROJECT_BINARY_DIR}/bin)
 +
-+# Name flexibility for the library naming scheme.  Any modifications should
-+# be made in the mh- file for the specific platform.
++# Name flexibility for the library naming scheme.  Any modifications should be made in the mh- file for
++# the specific platform.
 +set(STUBDATA_STUBNAME stubdata)
-+set(DATA_STUBNAME     data)
-+set(COMMON_STUBNAME   uc)
-+set(I18N_STUBNAME     i18n)
++set(DATA_STUBNAME data)
++set(COMMON_STUBNAME uc)
++set(I18N_STUBNAME i18n)
 +set(LAYOUTEX_STUBNAME lx)
-+set(IO_STUBNAME       io)
++set(IO_STUBNAME io)
 +set(TOOLUTIL_STUBNAME tu)
-+set(CTESTFW_STUBNAME  test)
++set(CTESTFW_STUBNAME test)
 +
 +if(WIN32)
-+  set(DATA_STUBNAME dt)
-+  set(I18N_STUBNAME in)
++    set(DATA_STUBNAME dt)
++    set(I18N_STUBNAME in)
 +endif()
 +
 +# overridden by icucross.cmake
 +if(CMAKE_GENERATOR MATCHES "Visual Studio.*" OR CMAKE_GENERATOR MATCHES "Xcode")
-+  set(CONFIG_DIR_NAME "/$<CONFIG>")
++    set(CONFIG_DIR_NAME "/$<CONFIG>")
 +endif()
 +set(TOOLBINDIR ${BINDIR}${CONFIG_DIR_NAME})
 +set(TOOLLIBDIR ${LIBDIR}${CONFIG_DIR_NAME})
 +
 +# TODO: HAVE_ICU_LE_HB set in configure_2nd.cmake
 +if(HAVE_ICU_LE_HB)
-+#  set(ICULEHB_CFLAGS @ICULEHB_CFLAGS@)
-+#  set(ICULEHB_CFLAGS "-I/usr/include/icu-le-hb -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include")
-+#  set(ICULEHB_LIBS @ICULEHB_LIBS@)
-+#  set(ICULEHB_LIBS "-licu-le-hb")
++    # set(ICULEHB_CFLAGS @ICULEHB_CFLAGS@) set(ICULEHB_CFLAGS "-I/usr/include/icu-le-hb
++    # -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include")
++    # set(ICULEHB_LIBS @ICULEHB_LIBS@) set(ICULEHB_LIBS "-licu-le-hb")
 +else()
-+  set(ICULEHB_CFLAGS "")
-+  set(ICULEHB_LIBS "")
++    set(ICULEHB_CFLAGS "")
++    set(ICULEHB_LIBS "")
 +endif()
 +if(ICULEHB_CFLAGS)
-+  set(USING_ICULEHB yes)
-+  set(ICULEHB_TRUE "")
-+  set(ICULEHB_FALSE "#")
-+  set(ICULIBS_LE ${ICULEHB_LIBS})
-+  set(ICULE_CFLAGS "${ICULEHB_CFLAGS} -DUSING_ICULEHB") # TODO: list(APPEND ) without "-D"
++    set(USING_ICULEHB yes)
++    set(ICULEHB_TRUE "")
++    set(ICULEHB_FALSE "#")
++    set(ICULIBS_LE ${ICULEHB_LIBS})
++    set(ICULE_CFLAGS "${ICULEHB_CFLAGS} -DUSING_ICULEHB") # TODO: list(APPEND ) without "-D"
 +else()
-+  set(USING_ICULEHB no)
-+  set(ICULEHB_TRUE "#")
-+  set(ICULEHB_FALSE "")
-+  set(ICULIBS_LE "")
-+  set(ICULE_CFLAGS "")
++    set(USING_ICULEHB no)
++    set(ICULEHB_TRUE "#")
++    set(ICULEHB_FALSE "")
++    set(ICULIBS_LE "")
++    set(ICULE_CFLAGS "")
 +endif()
 +
 +# Just the libs.
-+set(ICULIBS_STUBDT   ${ICUPREFIX}${STUBDATA_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_DT       ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_UC       ${ICUPREFIX}${COMMON_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_I18N     ${ICUPREFIX}${I18N_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_LX       ${ICUPREFIX}${LAYOUTEX_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_IO       ${ICUPREFIX}${IO_STUBNAME}${ICULIBSUFFIX})
-+set(ICULIBS_CTESTFW  ${ICUPREFIX}${CTESTFW_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_STUBDT ${ICUPREFIX}${STUBDATA_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_DT ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_UC ${ICUPREFIX}${COMMON_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_I18N ${ICUPREFIX}${I18N_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_LX ${ICUPREFIX}${LAYOUTEX_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_IO ${ICUPREFIX}${IO_STUBNAME}${ICULIBSUFFIX})
++set(ICULIBS_CTESTFW ${ICUPREFIX}${CTESTFW_STUBNAME}${ICULIBSUFFIX})
 +set(ICULIBS_TOOLUTIL ${ICUPREFIX}${TOOLUTIL_STUBNAME}${ICULIBSUFFIX})
 +
-+set(LIBICUSTUBDT    ${ICULIBS_STUBDT})
-+set(LIBICUDT        ${ICULIBS_DT})
-+set(LIBICUUC        ${ICULIBS_UC} ${ICULIBS_DT})
-+set(LIBICUI18N      ${ICULIBS_I18N})
-+#set(LIBICULE        ${ICULEHB_CFLAGS} ${ICULIBS_LE}) # Add ICULEHB_CFLAGS to ..
-+set(LIBICULE        ${ICULIBS_LE})
-+set(LIBICULX        ${ICULIBS_LX})
-+set(LIBCTESTFW      ${ICULIBS_CTESTFW})
-+set(LIBICUTOOLUTIL  ${ICULIBS_TOOLUTIL})
-+set(LIBICUIO        ${ICULIBS_IO})
++set(LIBICUSTUBDT ${ICULIBS_STUBDT})
++set(LIBICUDT ${ICULIBS_DT})
++set(LIBICUUC ${ICULIBS_UC} ${ICULIBS_DT})
++set(LIBICUI18N ${ICULIBS_I18N})
++# set(LIBICULE        ${ICULEHB_CFLAGS} ${ICULIBS_LE}) # Add ICULEHB_CFLAGS to ..
++set(LIBICULE ${ICULIBS_LE})
++set(LIBICULX ${ICULIBS_LX})
++set(LIBCTESTFW ${ICULIBS_CTESTFW})
++set(LIBICUTOOLUTIL ${ICULIBS_TOOLUTIL})
++set(LIBICUIO ${ICULIBS_IO})
 +
-+set(PKGDATA_LIBSTATICNAME
-+#  -L ${STATIC_PREFIX}${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX}
-+  -L ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX}
++set(PKGDATA_LIBSTATICNAME # -L ${STATIC_PREFIX}${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX}
++    -L ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX}
 +)
-+set(PKGDATA_LIBNAME
-+  -L ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX}
-+)
++set(PKGDATA_LIBNAME -L ${ICUPREFIX}${DATA_STUBNAME}${ICULIBSUFFIX})
 +
-+# Platform-specific setup
-+# Values are from source/config/mh-* files.
++# Platform-specific setup Values are from source/config/mh-* files.
 +
-+## These are the library specific CPPFLAGS
++# These are the library specific CPPFLAGS
 +set(CPPFLAGSICUDT "")
 +set(CPPFLAGSICUUC "")
 +set(CPPFLAGSICUI18N "")
@@ -19018,7 +19039,7 @@ index 0000000000..0272844248
 +set(CPPFLAGSCTESTFW "")
 +set(CPPFLAGSICUTOOLUTIL "")
 +
-+## These are the library specific LDFLAGS
++# These are the library specific LDFLAGS
 +set(LDFLAGSICUDT " ")
 +set(LDFLAGSICUUC " ")
 +set(LDFLAGSICUI18N " ")
@@ -19028,421 +19049,431 @@ index 0000000000..0272844248
 +set(LDFLAGSICUTOOLUTIL " ")
 +
 +if(MSVC)
-+  # Make sure that assertions are disabled
-+  #list(APPEND CPPFLAGS_RELEASE U_RELEASE=1#M#)
-+  list(APPEND CPPFLAGS_RELEASE U_RELEASE=1)
++    # Make sure that assertions are disabled list(APPEND CPPFLAGS_RELEASE U_RELEASE=1#M#)
++    list(APPEND CPPFLAGS_RELEASE U_RELEASE=1)
 +
-+  # Pass debugging flag through
-+  #list(APPEND CPPFLAGS_DEBUG _DEBUG=1#M#)
-+  list(APPEND CPPFLAGS_DEBUG _DEBUG=1)
++    # Pass debugging flag through list(APPEND CPPFLAGS_DEBUG _DEBUG=1#M#)
++    list(APPEND CPPFLAGS_DEBUG _DEBUG=1)
 +
-+  if(NOT BUILD_SHARED_LIBS)
-+    # Static library prefix
-+    set(STATIC_PREFIX "s")
-+  endif()
-+  set(ICULIBSUFFIX_VERSION ${PROJECT_VERSION_MAJOR})
-+  set(ICULIBSUFFIX_DEBUG $<$<CONFIG:Debug>:d>)
++    if(NOT BUILD_SHARED_LIBS)
++        # Static library prefix
++        set(STATIC_PREFIX "s")
++    endif()
++    set(ICULIBSUFFIX_VERSION ${PROJECT_VERSION_MAJOR})
++    set(ICULIBSUFFIX_DEBUG $<$<CONFIG:Debug>:d>)
 +
-+  # -GF pools strings and places them into read-only memory
-+  # -EHsc enables exception handling
-+  # -Zc:wchar_t makes wchar_t a native type. Required for C++ ABI compatibility.
-+  # -D_CRT_SECURE_NO_DEPRECATE is needed to quiet warnings about using standard C functions.
-+  # -utf-8 set source file encoding to utf-8.
-+  if(PROJECT_VERSION VERSION_GREATER 58.9)
-+    set(UTF8_VS_KEY -utf-8)
-+  endif()
-+  list(APPEND CFLAGS -GF ${UTF8_VS_KEY})
-+  list(APPEND CXXFLAGS -GF -EHsc -Zc:wchar_t ${UTF8_VS_KEY})
-+  list(APPEND CPPFLAGS _CRT_SECURE_NO_DEPRECATE)
-+  #list(APPEND DEFS WIN32)
++    # -GF pools strings and places them into read-only memory -EHsc enables exception handling
++    # -Zc:wchar_t makes wchar_t a native type. Required for C++ ABI compatibility.
++    # -D_CRT_SECURE_NO_DEPRECATE is needed to quiet warnings about using standard C functions. -utf-8 set
++    # source file encoding to utf-8.
++    if(PROJECT_VERSION VERSION_GREATER 58.9)
++        set(UTF8_VS_KEY -utf-8)
++    endif()
++    list(APPEND CFLAGS -GF ${UTF8_VS_KEY})
++    list(APPEND CXXFLAGS -GF -EHsc -Zc:wchar_t ${UTF8_VS_KEY})
++    list(APPEND CPPFLAGS _CRT_SECURE_NO_DEPRECATE)
++    # list(APPEND DEFS WIN32)
 +
-+  ## These are the library specific LDFLAGS
-+  # The NOENTRY option is required for creating a resource-only DLL.
-+  set(LDFLAGSICUDT "${LDFLAGSICUDT} -base:\"0x4ad00000\" -NOENTRY")
-+  set(LDFLAGSICUUC "${LDFLAGSICUUC} -base:\"0x4a800000\"")    # in-uc = 1MB
-+  set(LDFLAGSICUI18N "${LDFLAGSICUI18N} -base:\"0x4a900000\"")  # io-in = 2MB
-+  set(LDFLAGSICUIO "${LDFLAGSICUIO} -base:\"0x4ab00000\"")    # le-io = 1MB
-+  set(LDFLAGSICULX "${LDFLAGSICULX} -base:\"0x4ac80000\"")
-+  #set(LDFLAGSCTESTFW "") # Unused for now.
-+  # Same as layout. Layout and tools probably won't mix.
-+  set(LDFLAGSICUTOOLUTIL "${LDFLAGSICUTOOLUTIL} -base:\"0x4ac00000\"")
++    # These are the library specific LDFLAGS The NOENTRY option is required for creating a resource-only
++    # DLL.
++    set(LDFLAGSICUDT "${LDFLAGSICUDT} -base:\"0x4ad00000\" -NOENTRY")
++    set(LDFLAGSICUUC "${LDFLAGSICUUC} -base:\"0x4a800000\"") # in-uc = 1MB
++    set(LDFLAGSICUI18N "${LDFLAGSICUI18N} -base:\"0x4a900000\"") # io-in = 2MB
++    set(LDFLAGSICUIO "${LDFLAGSICUIO} -base:\"0x4ab00000\"") # le-io = 1MB
++    set(LDFLAGSICULX "${LDFLAGSICULX} -base:\"0x4ac80000\"")
++    # set(LDFLAGSCTESTFW "") # Unused for now. Same as layout. Layout and tools probably won't mix.
++    set(LDFLAGSICUTOOLUTIL "${LDFLAGSICUTOOLUTIL} -base:\"0x4ac00000\"")
 +
-+  if(WINDOWS_STORE)
-+    list(APPEND CPPFLAGS U_PLATFORM_HAS_WINUWP_API=1)
-+  endif()
++    if(WINDOWS_STORE)
++        list(APPEND CPPFLAGS U_PLATFORM_HAS_WINUWP_API=1)
++    endif()
 +endif()
 +
 +if(MINGW AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+  if(PROJECT_VERSION VERSION_GREATER 58.9)
-+    ## ICU requires a minimum target of Windows 7, and MinGW does not set this by default.
-+    ## https://msdn.microsoft.com/en-us/library/aa383745.aspx
-+    list(APPEND CPPFLAGS WINVER=0x0601 _WIN32_WINNT=0x0601)
-+  endif()
++    if(PROJECT_VERSION VERSION_GREATER 58.9)
++        # ICU requires a minimum target of Windows 7, and MinGW does not set this by default.
++        # https://msdn.microsoft.com/en-us/library/aa383745.aspx
++        list(APPEND CPPFLAGS WINVER=0x0601 _WIN32_WINNT=0x0601)
++    endif()
 +endif()
 +
 +if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-+  set(LDFLAGSICUDT "${LDFLAGSICUDT} -nodefaultlibs -nostdlib")
++    set(LDFLAGSICUDT "${LDFLAGSICUDT} -nodefaultlibs -nostdlib")
 +endif()
 +
 +# some imported things from the cross env
 +if(ICU_CROSS_BUILDROOT)
-+  include(${ICU_CROSS_BUILDROOT}/config/icucross.cmake)
++    include(${ICU_CROSS_BUILDROOT}/config/icucross.cmake)
 +endif()
 diff --git a/source/icufunctions.cmake b/source/icufunctions.cmake
 new file mode 100644
-index 0000000000..b5b507249d
+index 0000000000..4a3bc155b2
 --- /dev/null
 +++ b/source/icufunctions.cmake
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,99 @@
 +function(load_icu_sources VARIABLE SOURCE_FILE BASE_DIR)
-+  file(STRINGS ${SOURCE_FILE} LOAD_SOURCES_FILES)
-+#  message(WARNING "${LOAD_SOURCES_FILES}")
-+  foreach(LOAD_SOURCES_FILE ${LOAD_SOURCES_FILES})
-+    list(APPEND ${VARIABLE} "${BASE_DIR}/${LOAD_SOURCES_FILE}")
-+  endforeach()
-+  set(${VARIABLE} ${${VARIABLE}} PARENT_SCOPE)
++    file(STRINGS ${SOURCE_FILE} LOAD_SOURCES_FILES)
++    # message(WARNING "${LOAD_SOURCES_FILES}")
++    foreach(LOAD_SOURCES_FILE ${LOAD_SOURCES_FILES})
++        list(APPEND ${VARIABLE} "${BASE_DIR}/${LOAD_SOURCES_FILE}")
++    endforeach()
++    set(${VARIABLE}
++        ${${VARIABLE}}
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +macro(get_icu_private_headers VARIABLE DIR)
-+  file(GLOB ${VARIABLE} "${DIR}/*.h")
++    file(GLOB ${VARIABLE} "${DIR}/*.h")
 +endmacro()
 +
 +macro(get_icu_public_headers_old VARIABLE DIR)
-+  file(GLOB ${VARIABLE} "${DIR}/unicode/*.h")
++    file(GLOB ${VARIABLE} "${DIR}/unicode/*.h")
 +endmacro()
 +
 +function(get_icu_public_headers VARIABLE SEARCH_DIR OUT_DIR)
-+  file(GLOB ${VARIABLE}_HEADERS "${SEARCH_DIR}/unicode/*.h")
-+  foreach(HEADER ${${VARIABLE}_HEADERS})
-+    file(RELATIVE_PATH HEADER_REL ${SEARCH_DIR} ${HEADER})
-+    list(APPEND ${VARIABLE} "${OUT_DIR}/${HEADER_REL}")
-+  endforeach()
-+  set(${VARIABLE} ${${VARIABLE}} PARENT_SCOPE)
++    file(GLOB ${VARIABLE}_HEADERS "${SEARCH_DIR}/unicode/*.h")
++    foreach(HEADER ${${VARIABLE}_HEADERS})
++        file(RELATIVE_PATH HEADER_REL ${SEARCH_DIR} ${HEADER})
++        list(APPEND ${VARIABLE} "${OUT_DIR}/${HEADER_REL}")
++    endforeach()
++    set(${VARIABLE}
++        ${${VARIABLE}}
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +macro(setup_icu_target TARGET SOURCE_FILE SOURCE_DIR)
-+  load_icu_sources(${TARGET}_SOURCES ${SOURCE_FILE} ${SOURCE_DIR})
-+  get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
-+  get_icu_public_headers_old(${TARGET}_PUBLIC_HEADERS ${SOURCE_DIR})
++    load_icu_sources(${TARGET}_SOURCES ${SOURCE_FILE} ${SOURCE_DIR})
++    get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
++    get_icu_public_headers_old(${TARGET}_PUBLIC_HEADERS ${SOURCE_DIR})
 +
-+  target_sources(${TARGET} PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS} PUBLIC ${${TARGET}_PUBLIC_HEADERS})
++    target_sources(
++        ${TARGET}
++        PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS}
++        PUBLIC ${${TARGET}_PUBLIC_HEADERS}
++    )
 +endmacro()
 +
 +function(setup_icu_lib_target TARGET SOURCES_FILE SOURCE_DIR PUBLIC_DIR)
-+  load_icu_sources(${TARGET}_SOURCES ${SOURCES_FILE} ${SOURCE_DIR})
-+  get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
-+  get_icu_public_headers(${TARGET}_PUBLIC_HEADERS ${SOURCE_DIR} ${PUBLIC_DIR})
++    load_icu_sources(${TARGET}_SOURCES ${SOURCES_FILE} ${SOURCE_DIR})
++    get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
++    get_icu_public_headers(${TARGET}_PUBLIC_HEADERS ${SOURCE_DIR} ${PUBLIC_DIR})
 +
-+  target_sources(${TARGET} PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS} PUBLIC ${${TARGET}_PUBLIC_HEADERS})
++    target_sources(
++        ${TARGET}
++        PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS}
++        PUBLIC ${${TARGET}_PUBLIC_HEADERS}
++    )
 +
-+  set(${TARGET}_SOURCES ${${TARGET}_SOURCES} PARENT_SCOPE)
-+  set(${TARGET}_PRIVATE_HEADERS ${${TARGET}_PRIVATE_HEADERS} PARENT_SCOPE)
-+  set(${TARGET}_PUBLIC_HEADERS ${${TARGET}_PUBLIC_HEADERS} PARENT_SCOPE)
++    set(${TARGET}_SOURCES
++        ${${TARGET}_SOURCES}
++        PARENT_SCOPE
++    )
++    set(${TARGET}_PRIVATE_HEADERS
++        ${${TARGET}_PRIVATE_HEADERS}
++        PARENT_SCOPE
++    )
++    set(${TARGET}_PUBLIC_HEADERS
++        ${${TARGET}_PUBLIC_HEADERS}
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +function(setup_icu_exe_target TARGET SOURCES_FILE SOURCE_DIR)
-+  load_icu_sources(${TARGET}_SOURCES ${SOURCES_FILE} ${SOURCE_DIR})
-+  get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
++    load_icu_sources(${TARGET}_SOURCES ${SOURCES_FILE} ${SOURCE_DIR})
++    get_icu_private_headers(${TARGET}_PRIVATE_HEADERS ${SOURCE_DIR})
 +
-+  target_sources(${TARGET} PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS})
-+  set(${VARIABLE}_SOURCES ${${VARIABLE}} PARENT_SCOPE)
-+  set(${VARIABLE}_PRIVATE_HEADERS ${${VARIABLE}_PRIVATE_HEADERS} PARENT_SCOPE)
++    target_sources(${TARGET} PRIVATE ${${TARGET}_SOURCES} ${${TARGET}_PRIVATE_HEADERS})
++    set(${VARIABLE}_SOURCES
++        ${${VARIABLE}}
++        PARENT_SCOPE
++    )
++    set(${VARIABLE}_PRIVATE_HEADERS
++        ${${VARIABLE}_PRIVATE_HEADERS}
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +function(add_prefix VARIABLE PREFIX)
-+  set(${VARIABLE})
-+  foreach(ELEMENT ${ARGN})
-+    list(APPEND ${VARIABLE} "${PREFIX}/${ELEMENT}")
-+  endforeach()
-+  set(${VARIABLE} ${${VARIABLE}} PARENT_SCOPE)
++    set(${VARIABLE})
++    foreach(ELEMENT ${ARGN})
++        list(APPEND ${VARIABLE} "${PREFIX}/${ELEMENT}")
++    endforeach()
++    set(${VARIABLE}
++        ${${VARIABLE}}
++        PARENT_SCOPE
++    )
 +endfunction()
 +
 +function(make_custom_command_and_target TARGET OUTPUT)
-+  add_custom_command(OUTPUT ${OUTPUT} ${ARGN})
-+  add_custom_target(${TARGET} DEPENDS ${DEP})
++    add_custom_command(OUTPUT ${OUTPUT} ${ARGN})
++    add_custom_target(${TARGET} DEPENDS ${DEP})
 +endfunction()
-\ No newline at end of file
 diff --git a/source/io/CMakeLists.txt b/source/io/CMakeLists.txt
 new file mode 100644
-index 0000000000..0c13593604
+index 0000000000..94043af012
 --- /dev/null
 +++ b/source/io/CMakeLists.txt
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,67 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_IO})
 +set(lib_NAME_SUFFIX ${IO_STUBNAME})
 +
 +set(private_src_DIR "${CMAKE_CURRENT_LIST_DIR}")
 +set(interface_src_DIR "${includedir}")
-+set(build_src_DIR
-+  "$<BUILD_INTERFACE:${private_src_DIR}>"
-+)
-+set(install_src_DIR
-+  "$<INSTALL_INTERFACE:${interface_src_DIR}>"
-+)
++set(build_src_DIR "$<BUILD_INTERFACE:${private_src_DIR}>")
++set(install_src_DIR "$<INSTALL_INTERFACE:${interface_src_DIR}>")
 +set(public_src_DIR "${build_src_DIR}${install_src_DIR}")
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGSICUIO}
-+    U_IO_IMPLEMENTATION
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGSICUIO} U_IO_IMPLEMENTATION
 +)
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICUIO}
-+)
-+
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${private_src_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/i18n
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICUIO}
 +)
 +
-+### Link libraries
-+# PUBLIC
-+# LIBS = $(LIBICUUC) $(LIBICUI18N) $(DEFAULT_LIBS)
++# Include directories PRIVATE
++target_include_directories(
++    ${lib_NAME} PRIVATE ${private_src_DIR} ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/i18n
++)
++
++# Link libraries PUBLIC LIBS = $(LIBICUUC) $(LIBICUI18N) $(DEFAULT_LIBS)
 +target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_I18N})
 +
-+setup_icu_lib_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}")
-+
-+install(
-+  FILES ${${lib_NAME}_PUBLIC_HEADERS}
-+  DESTINATION "${includedir}/unicode"
++setup_icu_lib_target(
++    "${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}"
 +)
 +
-+#include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
++install(FILES ${${lib_NAME}_PUBLIC_HEADERS} DESTINATION "${includedir}/unicode")
++
++# include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
 +#
-+#install(
-+#  DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode
-+#  DESTINATION "${includedir}"
-+#  FILES_MATCHING
-+#  PATTERN "*.h"
-+#)
++# install( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/unicode DESTINATION "${includedir}" FILES_MATCHING PATTERN
++# "*.h" )
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/layoutex/CMakeLists.txt b/source/layoutex/CMakeLists.txt
 new file mode 100644
-index 0000000000..a43a1a6305
+index 0000000000..98cb81f9e1
 --- /dev/null
 +++ b/source/layoutex/CMakeLists.txt
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,71 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_LX})
 +set(lib_NAME_SUFFIX ${LAYOUTEX_STUBNAME})
 +
 +set(private_src_DIR "${CMAKE_CURRENT_LIST_DIR}")
 +set(interface_src_DIR "${includedir}")
-+set(build_src_DIR
-+  "$<BUILD_INTERFACE:${private_src_DIR}>"
-+)
-+set(install_src_DIR
-+  "$<INSTALL_INTERFACE:${interface_src_DIR}>"
-+)
++set(build_src_DIR "$<BUILD_INTERFACE:${private_src_DIR}>")
++set(install_src_DIR "$<INSTALL_INTERFACE:${interface_src_DIR}>")
 +set(public_src_DIR "${build_src_DIR}${install_src_DIR}")
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS
-+    U_LAYOUTEX_IMPLEMENTATION
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS U_LAYOUTEX_IMPLEMENTATION
 +)
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICULX}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICULX}
 +)
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${private_src_DIR}
-+  ${private_src_DIR}/unicode
-+  ${PROJECT_SOURCE_DIR}/common
++# Include directories PRIVATE
++target_include_directories(
++    ${lib_NAME} PRIVATE ${private_src_DIR} ${private_src_DIR}/unicode ${PROJECT_SOURCE_DIR}/common
 +)
 +if(NOT USING_ICULEHB)
-+  # cppflags: load .. so that #include <layout/...> works
-+  target_include_directories(${lib_NAME} PRIVATE
-+    ${PROJECT_SOURCE_DIR}
-+  )
++    # cppflags: load .. so that #include <layout/...> works
++    target_include_directories(${lib_NAME} PRIVATE ${PROJECT_SOURCE_DIR})
 +else()
-+  target_include_directories(${lib_NAME} PRIVATE
-+    ${ICULEHB_CFLAGS} # TODO: check it
-+  )
++    target_include_directories(${lib_NAME} PRIVATE ${ICULEHB_CFLAGS} # TODO: check it
++    )
 +endif()
 +
-+### Link libraries
-+# PUBLIC
-+# LIBS = $(LIBICUUC) $(LIBICULE) $(DEFAULT_LIBS)
++# Link libraries PUBLIC LIBS = $(LIBICUUC) $(LIBICULE) $(DEFAULT_LIBS)
 +target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_UC} ${ICULIBS_LE})
 +
 +setup_icu_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}")
 +
-+install(
-+  FILES ${${lib_NAME}_PUBLIC_HEADERS}
-+  DESTINATION "${includedir}/unicode"
-+)
-+#include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
++install(FILES ${${lib_NAME}_PUBLIC_HEADERS} DESTINATION "${includedir}/unicode")
++# include(${CMAKE_CURRENT_LIST_DIR}/ICU-${PROJECT_VERSION}-source_files.cmake)
 +#
-+#install(
-+#  DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/layout
-+#  DESTINATION "${includedir}"
-+#  FILES_MATCHING
-+#  PATTERN "*.h"
-+#)
++# install( DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/layout DESTINATION "${includedir}" FILES_MATCHING PATTERN
++# "*.h" )
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/stubdata/CMakeLists.txt b/source/stubdata/CMakeLists.txt
 new file mode 100644
-index 0000000000..250160fe57
+index 0000000000..a109ffa5fd
 --- /dev/null
 +++ b/source/stubdata/CMakeLists.txt
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,77 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_STUBDT})
-+#set(lib_NAME_SUFFIX ${DATA_STUBNAME})  # not STUBDATA_STUBNAME !!!
++# set(lib_NAME_SUFFIX ${DATA_STUBNAME})  # not STUBDATA_STUBNAME !!!
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${DATA_STUBNAME}  # not STUBDATA_STUBNAME !!!
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${ICULIBS_DT}${ICULIBSUFFIX_DEBUG}  # not ICULIBS_STUBDT !!!
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${ICULIBS_DT}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}  # not ICULIBS_STUBDT !!!
-+  ARCHIVE_OUTPUT_DIRECTORY ${LIBDIR}/${STUBDATA_STUBNAME}
-+  LIBRARY_OUTPUT_DIRECTORY ${LIBDIR}/${STUBDATA_STUBNAME}
-+  RUNTIME_OUTPUT_DIRECTORY ${BINDIR}/${STUBDATA_STUBNAME}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${DATA_STUBNAME} # not STUBDATA_STUBNAME !!!
++               OUTPUT_NAME ${STATIC_PREFIX}${ICULIBS_DT}${ICULIBSUFFIX_DEBUG} # not ICULIBS_STUBDT !!!
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${ICULIBS_DT}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG} # not
++                                                                                         # ICULIBS_STUBDT
++                                                                                         # !!!
++               ARCHIVE_OUTPUT_DIRECTORY ${LIBDIR}/${STUBDATA_STUBNAME}
++               LIBRARY_OUTPUT_DIRECTORY ${LIBDIR}/${STUBDATA_STUBNAME}
++               RUNTIME_OUTPUT_DIRECTORY ${BINDIR}/${STUBDATA_STUBNAME}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
-+#include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
++# include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
 +
-+### Library's specific flags
-+# PRIVATE flags
++# Library's specific flags PRIVATE flags
 +if(MSVC)
-+  set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS STUBDATA_BUILD
-+  )
++    set_property(
++        TARGET ${lib_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS STUBDATA_BUILD
++    )
 +endif()
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICUDT}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICUDT}
 +)
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+)
++# Include directories PRIVATE
++target_include_directories(${lib_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common)
 +
 +setup_icu_target("${lib_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
-+if(CMAKE_HOST_WIN32 AND BUILD_SHARED_LIBS AND (MSVC OR MINGW))
-+  add_custom_command(TARGET ${lib_NAME} POST_BUILD
-+    COMMAND ${CMAKE_COMMAND} -E make_directory ${BINDIR}${CONFIG_DIR_NAME}
-+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-+      $<TARGET_FILE:${lib_NAME}> ${BINDIR}${CONFIG_DIR_NAME}/
-+  )
++if(CMAKE_HOST_WIN32
++   AND BUILD_SHARED_LIBS
++   AND (MSVC OR MINGW)
++)
++    add_custom_command(
++        TARGET ${lib_NAME}
++        POST_BUILD
++        COMMAND ${CMAKE_COMMAND} -E make_directory ${BINDIR}${CONFIG_DIR_NAME}
++        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${lib_NAME}>
++                ${BINDIR}${CONFIG_DIR_NAME}/
++    )
 +endif()
 +
 +if(PKGDATA_MODE STREQUAL "common")
-+  add_custom_command(TARGET ${lib_NAME} POST_BUILD
-+    COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBDIR}${CONFIG_DIR_NAME}
-+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-+      $<TARGET_FILE:${lib_NAME}> ${LIBDIR}${CONFIG_DIR_NAME}/
-+  )
++    add_custom_command(
++        TARGET ${lib_NAME}
++        POST_BUILD
++        COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBDIR}${CONFIG_DIR_NAME}
++        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${lib_NAME}>
++                ${LIBDIR}${CONFIG_DIR_NAME}/
++    )
 +
-+  install(
-+    TARGETS ${lib_NAME}
-+    EXPORT "${TARGETS_EXPORT_NAME}"
-+    ARCHIVE  DESTINATION "${libdir}"
-+    LIBRARY  DESTINATION "${libdir}"
-+    RUNTIME  DESTINATION "${bindir}"
-+    INCLUDES DESTINATION "${includedir}"
-+  )
++    install(
++        TARGETS ${lib_NAME}
++        EXPORT "${TARGETS_EXPORT_NAME}"
++        ARCHIVE DESTINATION "${libdir}"
++        LIBRARY DESTINATION "${libdir}"
++        RUNTIME DESTINATION "${bindir}"
++        INCLUDES
++        DESTINATION "${includedir}"
++    )
 +endif()
 diff --git a/source/test/CMakeLists.txt b/source/test/CMakeLists.txt
 new file mode 100644
-index 0000000000..d715bf4c2d
+index 0000000000..880adeca53
 --- /dev/null
 +++ b/source/test/CMakeLists.txt
 @@ -0,0 +1,34 @@
 +# Copyright (c) 2020, Stephan Szabo
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +include(CTest)
 +
 +set(SUBDIRS)
 +
-+if (ICU_ENABLE_TOOLS)
++if(ICU_ENABLE_TOOLS)
 +    list(APPEND SUBDIRS testdata)
 +endif()
 +
 +list(APPEND SUBDIRS intltest)
 +
-+if (ICU_ENABLE_IO)
++if(ICU_ENABLE_IO)
 +    list(APPEND SUBDIRS iotest)
 +endif()
 +
 +list(APPEND SUBDIRS cintltst)
 +
-+if (ICU_ENABLE_LAYOUTEX)
++if(ICU_ENABLE_LAYOUTEX)
 +    list(APPEND SUBDIRS letest)
 +endif()
 +
-+if (ICU_ENABLE_FUZZER)
++if(ICU_ENABLE_FUZZER)
 +    list(APPEND SUBDIRS fuzzer)
 +endif()
 +
@@ -19454,13 +19485,13 @@ index 0000000000..d715bf4c2d
 +endforeach()
 diff --git a/source/test/testdata/CMakeLists.txt b/source/test/testdata/CMakeLists.txt
 new file mode 100644
-index 0000000000..61883899d0
+index 0000000000..ef679c682d
 --- /dev/null
 +++ b/source/test/testdata/CMakeLists.txt
 @@ -0,0 +1,52 @@
 +# Copyright (c) 2020, Stephan Szabo
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +# relative lib links from pkgdata are the same as for tmp
 +set(GENRBOPTS -k)
@@ -19507,37 +19538,56 @@ index 0000000000..61883899d0
 +
 +include("${CMAKE_CURRENT_LIST_DIR}/rules.cmake")
 +
-+#...
++# ...
 +
 +add_custom_target(foo2 DEPENDS ${TESTDATA_ALL_OUTPUT_FILES})
 diff --git a/source/test/testdata/rules.cmake b/source/test/testdata/rules.cmake
 new file mode 100644
-index 0000000000..be5515e1bf
+index 0000000000..8706ee044a
 --- /dev/null
 +++ b/source/test/testdata/rules.cmake
-@@ -0,0 +1,187 @@
+@@ -0,0 +1,216 @@
 +set(INDEX_NAME res_index)
 +set(IN_DIR ${CMAKE_CURRENT_LIST_DIR})
 +set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR})
 +
-+add_custom_target(test_testdata_dirs
-+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR} ${TMP_DIR}
-+)
++add_custom_target(test_testdata_dirs COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_DIR} ${TMP_DIR})
 +
 +# runs of genrb
-+set(GENRB_RUNS calendar casing conversion format icuio idna_rules mc root sh_YU sh structLocale te_IN_REVISED te_IN te testaliases testempty testtypes encoded zoneinfo64 filtertest)
++set(GENRB_RUNS
++    calendar
++    casing
++    conversion
++    format
++    icuio
++    idna_rules
++    mc
++    root
++    sh_YU
++    sh
++    structLocale
++    te_IN_REVISED
++    te_IN
++    te
++    testaliases
++    testempty
++    testtypes
++    encoded
++    zoneinfo64
++    filtertest
++)
 +function(make_genrb_tests FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.res
-+    DEPENDS test_testdata_dirs ${IN_DIR}/${FILE}.txt ${TOOLBINDIR}/genrb
-+    COMMAND ${TOOLBINDIR}/genrb -q -s ${IN_DIR} -d ${OUT_DIR} ${FILE}.txt
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.res
++        DEPENDS test_testdata_dirs ${IN_DIR}/${FILE}.txt ${TOOLBINDIR}/genrb
++        COMMAND ${TOOLBINDIR}/genrb -q -s ${IN_DIR} -d ${OUT_DIR} ${FILE}.txt
++    )
 +endfunction()
 +foreach(GENRB_RUN ${GENRB_RUNS})
 +    make_genrb_tests(${GENRB_RUN})
 +endforeach()
 +
-+#runs of gensprep
++# runs of gensprep
 +add_custom_command(
 +    OUTPUT ${OUT_DIR}/nfscsi.spp
 +    DEPENDS test_testdata_dirs ${IN_DIR}/nfs4_cs_prep_ci.txt ${TOOLBINDIR}/genrb
@@ -19565,13 +19615,22 @@ index 0000000000..be5515e1bf
 +)
 +
 +# makeconv
-+set(MAKECONVRUNS test1 test1bmp test2 test3 test4 test4x test5 ibm9027)
++set(MAKECONVRUNS
++    test1
++    test1bmp
++    test2
++    test3
++    test4
++    test4x
++    test5
++    ibm9027
++)
 +function(make_makeconv_tests FILE)
-+  add_custom_command(
-+    OUTPUT ${OUT_DIR}/${FILE}.cnv
-+    DEPENDS test_testdata_dirs ${IN_DIR}/${FILE}.ucm ${TOOLBINDIR}/makeconv
-+    COMMAND ${TOOLBINDIR}/makeconv --small -d ${OUT_DIR} ${IN_DIR}/${FILE}.ucm
-+  )
++    add_custom_command(
++        OUTPUT ${OUT_DIR}/${FILE}.cnv
++        DEPENDS test_testdata_dirs ${IN_DIR}/${FILE}.ucm ${TOOLBINDIR}/makeconv
++        COMMAND ${TOOLBINDIR}/makeconv --small -d ${OUT_DIR} ${IN_DIR}/${FILE}.ucm
++    )
 +endfunction()
 +foreach(MAKECONVRUN ${MAKECONVRUNS})
 +    make_makeconv_tests(${MAKECONVRUN})
@@ -19619,646 +19678,630 @@ index 0000000000..be5515e1bf
 +    COMMAND ${CMAKE_COMMAND} -E copy ${IN_DIR}/old_e_testtypes.res ${OUT_DIR}/od_e_testtypes.res
 +)
 +
-+string(CONCAT TESTDATA_LIST_CONTENT
-+    "calendar.res\n"
-+    "casing.res\n"
-+    "conversion.res\n"
-+    "encoded.res\n"
-+    "filtertest.res\n"
-+    "format.res\n"
-+    "ibm9027.cnv\n"
-+    "icuio.res\n"
-+    "idna_rules.res\n"
-+    "mc.res\n"
-+    "nfscis.spp\n"
-+    "nfscsi.spp\n"
-+    "nfscss.spp\n"
-+    "nfsmxp.spp\n"
-+    "nfsmxs.spp\n"
-+    "old_e_testtypes.res\n"
-+    "old_l_testtypes.res\n"
-+    "root.res\n"
-+    "sh.res\n"
-+    "sh_YU.res\n"
-+    "structLocale.res\n"
-+    "te.res\n"
-+    "te_IN.res\n"
-+    "te_IN_REVISED.res\n"
-+    "test.icu\n"
-+    "test1.cnv\n"
-+    "test1bmp.cnv\n"
-+    "test2.cnv\n"
-+    "test3.cnv\n"
-+    "test4.cnv\n"
-+    "test4x.cnv\n"
-+    "test5.cnv\n"
-+    "testaliases.res\n"
-+    "testempty.res\n"
-+    "testnorm.nrm\n"
-+    "testtable32.res\n"
-+    "testtypes.res\n"
++string(
++    CONCAT TESTDATA_LIST_CONTENT
++           "calendar.res\n"
++           "casing.res\n"
++           "conversion.res\n"
++           "encoded.res\n"
++           "filtertest.res\n"
++           "format.res\n"
++           "ibm9027.cnv\n"
++           "icuio.res\n"
++           "idna_rules.res\n"
++           "mc.res\n"
++           "nfscis.spp\n"
++           "nfscsi.spp\n"
++           "nfscss.spp\n"
++           "nfsmxp.spp\n"
++           "nfsmxs.spp\n"
++           "old_e_testtypes.res\n"
++           "old_l_testtypes.res\n"
++           "root.res\n"
++           "sh.res\n"
++           "sh_YU.res\n"
++           "structLocale.res\n"
++           "te.res\n"
++           "te_IN.res\n"
++           "te_IN_REVISED.res\n"
++           "test.icu\n"
++           "test1.cnv\n"
++           "test1bmp.cnv\n"
++           "test2.cnv\n"
++           "test3.cnv\n"
++           "test4.cnv\n"
++           "test4x.cnv\n"
++           "test5.cnv\n"
++           "testaliases.res\n"
++           "testempty.res\n"
++           "testnorm.nrm\n"
++           "testtable32.res\n"
++           "testtypes.res\n"
 +)
 +file(WRITE ${TMP_DIR}/testdata.lst ${TESTDATA_LIST_CONTENT})
 +
 +set(TESTDATA_ALL_OUTPUT_FILES
-+        ${OUT_DIR}/calendar.res
-+		${OUT_DIR}/casing.res
-+		${OUT_DIR}/conversion.res
-+		${OUT_DIR}/encoded.res
-+		${OUT_DIR}/filtertest.res
-+		${OUT_DIR}/format.res
-+		${OUT_DIR}/ibm9027.cnv
-+		${OUT_DIR}/icuio.res
-+		${OUT_DIR}/idna_rules.res
-+		${OUT_DIR}/mc.res
-+		${TMP_DIR}/nam.typ
-+		${OUT_DIR}/nfscis.spp
-+		${OUT_DIR}/nfscsi.spp
-+		${OUT_DIR}/nfscss.spp
-+		${OUT_DIR}/nfsmxp.spp
-+		${OUT_DIR}/nfsmxs.spp
-+		${OUT_DIR}/old_e_testtypes.res
-+		${OUT_DIR}/old_l_testtypes.res
-+		${OUT_DIR}/root.res
-+		${OUT_DIR}/sh.res
-+		${OUT_DIR}/sh_YU.res
-+		${OUT_DIR}/structLocale.res
-+		${OUT_DIR}/te.res
-+		${OUT_DIR}/te_IN.res
-+		${OUT_DIR}/te_IN_REVISED.res
-+		${OUT_DIR}/test.icu
-+		${OUT_DIR}/test1.cnv
-+		${OUT_DIR}/test1bmp.cnv
-+		${OUT_DIR}/test2.cnv
-+		${OUT_DIR}/test3.cnv
-+		${OUT_DIR}/test4.cnv
-+		${OUT_DIR}/test4x.cnv
-+		${OUT_DIR}/test5.cnv
-+		${OUT_DIR}/testaliases.res
-+		${TMP_DIR}/testdata.lst
-+		${OUT_DIR}/testempty.res
-+		${OUT_DIR}/testnorm.nrm
-+		${OUT_DIR}/testtable32.res
-+		${TMP_DIR}/testtable32.txt
-+		${OUT_DIR}/testtypes.res
-+		${TMP_DIR}/zoneinfo64.res
++    ${OUT_DIR}/calendar.res
++    ${OUT_DIR}/casing.res
++    ${OUT_DIR}/conversion.res
++    ${OUT_DIR}/encoded.res
++    ${OUT_DIR}/filtertest.res
++    ${OUT_DIR}/format.res
++    ${OUT_DIR}/ibm9027.cnv
++    ${OUT_DIR}/icuio.res
++    ${OUT_DIR}/idna_rules.res
++    ${OUT_DIR}/mc.res
++    ${TMP_DIR}/nam.typ
++    ${OUT_DIR}/nfscis.spp
++    ${OUT_DIR}/nfscsi.spp
++    ${OUT_DIR}/nfscss.spp
++    ${OUT_DIR}/nfsmxp.spp
++    ${OUT_DIR}/nfsmxs.spp
++    ${OUT_DIR}/old_e_testtypes.res
++    ${OUT_DIR}/old_l_testtypes.res
++    ${OUT_DIR}/root.res
++    ${OUT_DIR}/sh.res
++    ${OUT_DIR}/sh_YU.res
++    ${OUT_DIR}/structLocale.res
++    ${OUT_DIR}/te.res
++    ${OUT_DIR}/te_IN.res
++    ${OUT_DIR}/te_IN_REVISED.res
++    ${OUT_DIR}/test.icu
++    ${OUT_DIR}/test1.cnv
++    ${OUT_DIR}/test1bmp.cnv
++    ${OUT_DIR}/test2.cnv
++    ${OUT_DIR}/test3.cnv
++    ${OUT_DIR}/test4.cnv
++    ${OUT_DIR}/test4x.cnv
++    ${OUT_DIR}/test5.cnv
++    ${OUT_DIR}/testaliases.res
++    ${TMP_DIR}/testdata.lst
++    ${OUT_DIR}/testempty.res
++    ${OUT_DIR}/testnorm.nrm
++    ${OUT_DIR}/testtable32.res
++    ${TMP_DIR}/testtable32.txt
++    ${OUT_DIR}/testtypes.res
++    ${TMP_DIR}/zoneinfo64.res
 +)
 diff --git a/source/tools/CMakeLists.txt b/source/tools/CMakeLists.txt
 new file mode 100644
-index 0000000000..2c9590903c
+index 0000000000..9db8d28f37
 --- /dev/null
 +++ b/source/tools/CMakeLists.txt
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,38 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +# Subdirectories ordered by SUBDIRS in Makefile.in
 +
 +# Libraries
-+include(${CMAKE_CURRENT_LIST_DIR}/toolutil/CMakeLists.txt)     # lib  # before pkgdata
-+include(${CMAKE_CURRENT_LIST_DIR}/ctestfw/CMakeLists.txt)      # lib
++include(${CMAKE_CURRENT_LIST_DIR}/toolutil/CMakeLists.txt) # lib  # before pkgdata
++include(${CMAKE_CURRENT_LIST_DIR}/ctestfw/CMakeLists.txt) # lib
 +
 +# Executables
-+include(${CMAKE_CURRENT_LIST_DIR}/makeconv/CMakeLists.txt)     # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/genrb/CMakeLists.txt)        # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/genbrk/CMakeLists.txt)       # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gencnval/CMakeLists.txt)     # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gensprep/CMakeLists.txt)     # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/icuinfo/CMakeLists.txt)      # exe + TODO: lib
-+include(${CMAKE_CURRENT_LIST_DIR}/genccode/CMakeLists.txt)     # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gencmn/CMakeLists.txt)       # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/icupkg/CMakeLists.txt)       # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/pkgdata/CMakeLists.txt)      # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gentest/CMakeLists.txt)      # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gennorm2/CMakeLists.txt)     # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gencfu/CMakeLists.txt)       # exe
-+include(${CMAKE_CURRENT_LIST_DIR}/gendict/CMakeLists.txt)      # exe
++include(${CMAKE_CURRENT_LIST_DIR}/makeconv/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/genrb/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/genbrk/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gencnval/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gensprep/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/icuinfo/CMakeLists.txt) # exe + TODO: lib
++include(${CMAKE_CURRENT_LIST_DIR}/genccode/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gencmn/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/icupkg/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/pkgdata/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gentest/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gennorm2/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gencfu/CMakeLists.txt) # exe
++include(${CMAKE_CURRENT_LIST_DIR}/gendict/CMakeLists.txt) # exe
 +
 +if(PROJECT_VERSION VERSION_GREATER 58.9)
-+  #ifneq (@platform_make_fragment_name@,mh-cygwin-msvc)
-+  if(NOT MSVC)
-+    include(${CMAKE_CURRENT_LIST_DIR}/escapesrc/CMakeLists.txt)  # exe
-+  endif()
++    # ifneq (@platform_make_fragment_name@,mh-cygwin-msvc)
++    if(NOT MSVC)
++        include(${CMAKE_CURRENT_LIST_DIR}/escapesrc/CMakeLists.txt) # exe
++    endif()
 +endif()
 +
-+# Excluded in SUBDIRS in Makefile.in
-+#include(${CMAKE_CURRENT_LIST_DIR}/gencolusb/CMakeLists.txt)
-+#include(${CMAKE_CURRENT_LIST_DIR}/genren/CMakeLists.txt)
-+#include(${CMAKE_CURRENT_LIST_DIR}/icuswap/CMakeLists.txt)
-+#include(${CMAKE_CURRENT_LIST_DIR}/memcheck/CMakeLists.txt)
-+#include(${CMAKE_CURRENT_LIST_DIR}/tzcode/CMakeLists.txt)
++# Excluded in SUBDIRS in Makefile.in include(${CMAKE_CURRENT_LIST_DIR}/gencolusb/CMakeLists.txt)
++# include(${CMAKE_CURRENT_LIST_DIR}/genren/CMakeLists.txt)
++# include(${CMAKE_CURRENT_LIST_DIR}/icuswap/CMakeLists.txt)
++# include(${CMAKE_CURRENT_LIST_DIR}/memcheck/CMakeLists.txt)
++# include(${CMAKE_CURRENT_LIST_DIR}/tzcode/CMakeLists.txt)
 diff --git a/source/tools/ctestfw/CMakeLists.txt b/source/tools/ctestfw/CMakeLists.txt
 new file mode 100644
-index 0000000000..fe06630db8
+index 0000000000..0035668dfe
 --- /dev/null
 +++ b/source/tools/ctestfw/CMakeLists.txt
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,61 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_CTESTFW})
 +set(lib_NAME_SUFFIX ${CTESTFW_STUBNAME})
 +
 +set(private_src_DIR "${CMAKE_CURRENT_LIST_DIR}")
 +set(interface_src_DIR "${includedir}")
-+set(build_src_DIR
-+  "$<BUILD_INTERFACE:${private_src_DIR}>"
-+)
-+set(install_src_DIR
-+  "$<INSTALL_INTERFACE:${interface_src_DIR}>"
-+)
++set(build_src_DIR "$<BUILD_INTERFACE:${private_src_DIR}>")
++set(install_src_DIR "$<INSTALL_INTERFACE:${interface_src_DIR}>")
 +set(public_src_DIR "${build_src_DIR}${install_src_DIR}")
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
-+#include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
++# include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS ${CPPFLAGSCTESTFW}
-+    T_CTEST_IMPLEMENTATION
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS ${CPPFLAGSCTESTFW} T_CTEST_IMPLEMENTATION
 +)
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSCTESTFW}
-+)
-+
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/i18n
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
-+  ${private_src_DIR}
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSCTESTFW}
 +)
 +
-+### Link libraries
-+# PUBLIC
-+# LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS)
++# Include directories PRIVATE
++target_include_directories(
++    ${lib_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/i18n
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil ${private_src_DIR}
++)
++
++# Link libraries PUBLIC LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS)
 +target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_TOOLUTIL})
 +
-+setup_icu_lib_target("${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}")
++setup_icu_lib_target(
++    "${lib_NAME}" "${private_src_DIR}/sources.txt" "${private_src_DIR}" "${public_src_DIR}"
++)
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/escapesrc/CMakeLists.txt b/source/tools/escapesrc/CMakeLists.txt
 new file mode 100644
-index 0000000000..dffc3201f6
+index 0000000000..134833be0e
 --- /dev/null
 +++ b/source/tools/escapesrc/CMakeLists.txt
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,35 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME escapesrc)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
-+#include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)  # Not included, see below.
++# include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)  # Not included, see below.
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
-+### Executable's libraries
-+# See Makefile.in
-+##LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC)
-+#LIBS += $(DEFAULT_LIBS) $(LIB_M)
++# Executable's libraries See Makefile.in LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) LIBS +=
++# $(DEFAULT_LIBS) $(LIB_M)
 +target_link_libraries(${exe_NAME} PRIVATE ${DEFAULT_LIBS} ${LIB_M})
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/genbrk/CMakeLists.txt b/source/tools/genbrk/CMakeLists.txt
 new file mode 100644
-index 0000000000..054c028959
+index 0000000000..d799103aa4
 --- /dev/null
 +++ b/source/tools/genbrk/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME genbrk)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/genccode/CMakeLists.txt b/source/tools/genccode/CMakeLists.txt
 new file mode 100644
-index 0000000000..13fed24c88
+index 0000000000..9960cb2259
 --- /dev/null
 +++ b/source/tools/genccode/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME genccode)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gencfu/CMakeLists.txt b/source/tools/gencfu/CMakeLists.txt
 new file mode 100644
-index 0000000000..e13b6b9916
+index 0000000000..fd7b95484e
 --- /dev/null
 +++ b/source/tools/gencfu/CMakeLists.txt
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gencfu)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/i18n
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/i18n
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gencmn/CMakeLists.txt b/source/tools/gencmn/CMakeLists.txt
 new file mode 100644
-index 0000000000..7d5626729e
+index 0000000000..197f402bb1
 --- /dev/null
 +++ b/source/tools/gencmn/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gencmn)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gencnval/CMakeLists.txt b/source/tools/gencnval/CMakeLists.txt
 new file mode 100644
-index 0000000000..0bc2e3e134
+index 0000000000..abcb2b9beb
 --- /dev/null
 +++ b/source/tools/gencnval/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gencnval)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gendict/CMakeLists.txt b/source/tools/gendict/CMakeLists.txt
 new file mode 100644
-index 0000000000..f7e7a71bca
+index 0000000000..062a91ba5d
 --- /dev/null
 +++ b/source/tools/gendict/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gendict)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gennorm2/CMakeLists.txt b/source/tools/gennorm2/CMakeLists.txt
 new file mode 100644
-index 0000000000..082d976556
+index 0000000000..ce286fe502
 --- /dev/null
 +++ b/source/tools/gennorm2/CMakeLists.txt
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gennorm2)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/genrb/CMakeLists.txt b/source/tools/genrb/CMakeLists.txt
 new file mode 100644
-index 0000000000..39ef73960d
+index 0000000000..f43720d1d2
 --- /dev/null
 +++ b/source/tools/genrb/CMakeLists.txt
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,65 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(GENRB_TARGETS genrb)
-+if (NOT MSVC)
-+  list(append GENRB_TARGETS derb)
++if(NOT MSVC)
++    list(append GENRB_TARGETS derb)
 +endif()
 +foreach(exe_NAME ${GENRB_TARGETS})
-+  if(exe_NAME STREQUAL "derb" AND NOT ICU_ENABLE_ICUIO)
-+    continue()
-+  endif()
++    if(exe_NAME STREQUAL "derb" AND NOT ICU_ENABLE_ICUIO)
++        continue()
++    endif()
 +
-+  add_executable(${exe_NAME} "")
++    add_executable(${exe_NAME} "")
 +
-+  ### Common executables options
-+  include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
-+  #include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)  # Included below.
++    # Common executables options
++    include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
++    # include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)  # Included below.
 +
-+  ### Executable's specifics
++    # Executable's specifics
 +
-+  # PRIVATE flags
-+  set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+    COMPILE_DEFINITIONS
-+      UNISTR_FROM_CHAR_EXPLICIT=explicit
-+      UNISTR_FROM_STRING_EXPLICIT=explicit
-+  )
++    # PRIVATE flags
++    set_property(
++        TARGET ${exe_NAME}
++        APPEND
++        PROPERTY COMPILE_DEFINITIONS UNISTR_FROM_CHAR_EXPLICIT=explicit
++                 UNISTR_FROM_STRING_EXPLICIT=explicit
++    )
 +
-+  ### Include directories
-+  # PRIVATE
-+  target_include_directories(${exe_NAME} PRIVATE
-+    ${CMAKE_CURRENT_LIST_DIR}
-+    ${PROJECT_SOURCE_DIR}/common
-+    ${PROJECT_SOURCE_DIR}/i18n
-+    ${PROJECT_SOURCE_DIR}/tools/toolutil
-+    ${PROJECT_SOURCE_DIR}/io
-+  )
++    # Include directories PRIVATE
++    target_include_directories(
++        ${exe_NAME}
++        PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/i18n
++                ${PROJECT_SOURCE_DIR}/tools/toolutil ${PROJECT_SOURCE_DIR}/io
++    )
 +
-+  ### Link libraries
-+  # PRIVATE
-+  if(exe_NAME STREQUAL "derb")
-+    # $(LIBICUIO) $(LIBS)
-+    target_link_libraries(${exe_NAME} PRIVATE ${ICULIBS_IO})
-+  endif()
++    # Link libraries PRIVATE
++    if(exe_NAME STREQUAL "derb")
++        # $(LIBICUIO) $(LIBS)
++        target_link_libraries(${exe_NAME} PRIVATE ${ICULIBS_IO})
++    endif()
 +
-+  # Common libs must be after the ${ICULIBS_IO}
-+  include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
++    # Common libs must be after the ${ICULIBS_IO}
++    include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+  if(exe_NAME STREQUAL "derb")
-+    setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/derb_sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
-+  else()
-+    setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
-+  endif()
++    if(exe_NAME STREQUAL "derb")
++        setup_icu_target(
++            "${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/derb_sources.txt" "${CMAKE_CURRENT_LIST_DIR}"
++        )
++    else()
++        setup_icu_target(
++            "${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}"
++        )
++    endif()
 +
-+  install(
-+    TARGETS ${exe_NAME}
-+    EXPORT "${TARGETS_EXPORT_NAME}"
-+    ARCHIVE  DESTINATION "${libdir}"
-+    LIBRARY  DESTINATION "${libdir}"
-+    RUNTIME  DESTINATION "${bindir}"
-+    INCLUDES DESTINATION "${includedir}"
-+  )
++    install(
++        TARGETS ${exe_NAME}
++        EXPORT "${TARGETS_EXPORT_NAME}"
++        ARCHIVE DESTINATION "${libdir}"
++        LIBRARY DESTINATION "${libdir}"
++        RUNTIME DESTINATION "${bindir}"
++        INCLUDES
++        DESTINATION "${includedir}"
++    )
 +endforeach()
 diff --git a/source/tools/gensprep/CMakeLists.txt b/source/tools/gensprep/CMakeLists.txt
 new file mode 100644
-index 0000000000..1c13f6016f
+index 0000000000..8477d1da78
 --- /dev/null
 +++ b/source/tools/gensprep/CMakeLists.txt
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gensprep)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/gentest/CMakeLists.txt b/source/tools/gentest/CMakeLists.txt
 new file mode 100644
-index 0000000000..6f253e2443
+index 0000000000..421b3daddb
 --- /dev/null
 +++ b/source/tools/gentest/CMakeLists.txt
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,38 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME gentest)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
-+#include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake) # Included below
++# include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake) # Included below
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
-+  ${PROJECT_SOURCE_DIR}/tools/ctestfw
-+  ${PROJECT_SOURCE_DIR}/i18n
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME}
++    PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
++            ${PROJECT_SOURCE_DIR}/tools/ctestfw ${PROJECT_SOURCE_DIR}/i18n
 +)
 +
 +# LIBS = $(LIBCTESTFW) $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS) $(LIB_M)
@@ -20270,262 +20313,252 @@ index 0000000000..6f253e2443
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/icuinfo/CMakeLists.txt b/source/tools/icuinfo/CMakeLists.txt
 new file mode 100644
-index 0000000000..66baf30378
+index 0000000000..35d78b66f8
 --- /dev/null
 +++ b/source/tools/icuinfo/CMakeLists.txt
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,53 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME icuinfo)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
-+  ${PROJECT_SOURCE_DIR}/tools/ctestfw
-+  ${PROJECT_SOURCE_DIR}/i18n
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
++                        ${PROJECT_SOURCE_DIR}/tools/ctestfw ${PROJECT_SOURCE_DIR}/i18n
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 +
 +# TODO: fix plugin
-+if (ICU_ENABLE_PLUGINS)
-+  set(plugin_NAME plugin)
-+  add_library(${plugin_NAME} SHARED "")
-+  target_include_directories(${plugin_NAME} PRIVATE
-+    ${PROJECT_SOURCE_DIR}/common
-+    ${PROJECT_SOURCE_DIR}/tools/toolutil
-+    ${PROJECT_SOURCE_DIR}/tools/ctestfw
-+    ${PROJECT_SOURCE_DIR}/i18n
-+  )
-+  setup_icu_target("${plugin_NAME}" "${CMAKE_CURRENT_LIST_DIR}/plugin_sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
-+  install(
-+    TARGETS ${plugin_NAME}
-+    EXPORT "${TARGETS_EXPORT_NAME}"
-+    ARCHIVE  DESTINATION "${libdir}"
-+    LIBRARY  DESTINATION "${libdir}"
-+    RUNTIME  DESTINATION "${bindir}"
-+    INCLUDES DESTINATION "${includedir}"
-+  )
++if(ICU_ENABLE_PLUGINS)
++    set(plugin_NAME plugin)
++    add_library(${plugin_NAME} SHARED "")
++    target_include_directories(
++        ${plugin_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
++                               ${PROJECT_SOURCE_DIR}/tools/ctestfw ${PROJECT_SOURCE_DIR}/i18n
++    )
++    setup_icu_target(
++        "${plugin_NAME}" "${CMAKE_CURRENT_LIST_DIR}/plugin_sources.txt" "${CMAKE_CURRENT_LIST_DIR}"
++    )
++    install(
++        TARGETS ${plugin_NAME}
++        EXPORT "${TARGETS_EXPORT_NAME}"
++        ARCHIVE DESTINATION "${libdir}"
++        LIBRARY DESTINATION "${libdir}"
++        RUNTIME DESTINATION "${bindir}"
++        INCLUDES
++        DESTINATION "${includedir}"
++    )
 +endif()
 diff --git a/source/tools/icupkg/CMakeLists.txt b/source/tools/icupkg/CMakeLists.txt
 new file mode 100644
-index 0000000000..ac999b78c9
+index 0000000000..48d7ada6b2
 --- /dev/null
 +++ b/source/tools/icupkg/CMakeLists.txt
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME icupkg)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/common ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${sbindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${sbindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/makeconv/CMakeLists.txt b/source/tools/makeconv/CMakeLists.txt
 new file mode 100644
-index 0000000000..3593fb7285
+index 0000000000..a9edbb4d3f
 --- /dev/null
 +++ b/source/tools/makeconv/CMakeLists.txt
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME makeconv)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/pkgdata/CMakeLists.txt b/source/tools/pkgdata/CMakeLists.txt
 new file mode 100644
-index 0000000000..5236d8f278
+index 0000000000..27e4c98420
 --- /dev/null
 +++ b/source/tools/pkgdata/CMakeLists.txt
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,35 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(exe_NAME pkgdata)
 +
 +add_executable(${exe_NAME} "")
 +
-+### Common executables options
++# Common executables options
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_flags.cmake)
 +include(${PROJECT_SOURCE_DIR}/common_tools_exe_libs.cmake)
 +
-+### Executable's specifics
++# Executable's specifics
 +
-+# TODO:
-+# PRIVATE flags
-+#set_property(TARGET ${exe_NAME} APPEND PROPERTY
-+#  COMPILE_DEFINITIONS
-+#  # DEFS += -DUDATA_SO_SUFFIX=\".$(SO)\" -DSTATIC_O=\"$(STATIC_O)\"
-+#  UDATA_SO_SUFFIX=\".$(SO)\"
-+#  STATIC_O=\"$(STATIC_O)\"
-+#)
++# TODO: PRIVATE flags set_property(TARGET ${exe_NAME} APPEND PROPERTY COMPILE_DEFINITIONS # DEFS +=
++# -DUDATA_SO_SUFFIX=\".$(SO)\" -DSTATIC_O=\"$(STATIC_O)\" UDATA_SO_SUFFIX=\".$(SO)\"
++# STATIC_O=\"$(STATIC_O)\" )
 +
-+### Include directories
-+# PRIVATE
-+target_include_directories(${exe_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/tools/toolutil
++# Include directories PRIVATE
++target_include_directories(
++    ${exe_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/tools/toolutil
 +)
 +
 +setup_icu_target("${exe_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${exe_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${exe_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 diff --git a/source/tools/toolutil/CMakeLists.txt b/source/tools/toolutil/CMakeLists.txt
 new file mode 100644
-index 0000000000..eb22a9aee2
+index 0000000000..36b15d4783
 --- /dev/null
 +++ b/source/tools/toolutil/CMakeLists.txt
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,59 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +#
-+## ICU build file for CMake build tools
++# ICU build file for CMake build tools
 +
 +set(lib_NAME ${ICULIBS_TOOLUTIL})
 +set(lib_NAME_SUFFIX ${TOOLUTIL_STUBNAME})
 +
 +add_library(${lib_NAME} "")
 +
-+set_target_properties(${lib_NAME} PROPERTIES
-+  EXPORT_NAME ${lib_NAME_SUFFIX}
-+  OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
-+  RUNTIME_OUTPUT_NAME
-+    ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
++set_target_properties(
++    ${lib_NAME}
++    PROPERTIES EXPORT_NAME ${lib_NAME_SUFFIX}
++               OUTPUT_NAME ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_DEBUG}
++               RUNTIME_OUTPUT_NAME
++               ${STATIC_PREFIX}${lib_NAME}${ICULIBSUFFIX_VERSION}${ICULIBSUFFIX_DEBUG}
 +)
 +
-+### Common libraries options
++# Common libraries options
 +include(${PROJECT_SOURCE_DIR}/common_icu_lib_flags.cmake)
-+#include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
++# include(${PROJECT_SOURCE_DIR}/common_icu_lib_includes.cmake)  # Not included.
 +
-+### Library's specific flags
-+# PRIVATE flags
-+set_property(TARGET ${lib_NAME} APPEND PROPERTY
-+  COMPILE_DEFINITIONS
-+    U_TOOLUTIL_IMPLEMENTATION
-+    UNISTR_FROM_CHAR_EXPLICIT=explicit
-+    UNISTR_FROM_STRING_EXPLICIT=explicit
-+
-+    # TODO:
-+    # from icuinfo
-+    #CPPFLAGS+=  "-DU_BUILD=\"@build@\"" "-DU_HOST=\"@host@\"" "-DU_CC=\"@CC@\"" "-DU_CXX=\"@CXX@\""
-+    #CPPFLAGS+=  "-DU_BUILD=\"x86_64-pc-linux-gnu\"" "-DU_HOST=\"x86_64-pc-linux-gnu\"" "-DU_CC=\"clang\"" "-DU_CXX=\"clang++\""
++# Library's specific flags PRIVATE flags
++set_property(
++    TARGET ${lib_NAME}
++    APPEND
++    PROPERTY COMPILE_DEFINITIONS
++             U_TOOLUTIL_IMPLEMENTATION
++             UNISTR_FROM_CHAR_EXPLICIT=explicit
++             UNISTR_FROM_STRING_EXPLICIT=explicit
++             # TODO: from icuinfo CPPFLAGS+=  "-DU_BUILD=\"@build@\"" "-DU_HOST=\"@host@\""
++             # "-DU_CC=\"@CC@\"" "-DU_CXX=\"@CXX@\"" CPPFLAGS+=  "-DU_BUILD=\"x86_64-pc-linux-gnu\""
++             # "-DU_HOST=\"x86_64-pc-linux-gnu\"" "-DU_CC=\"clang\"" "-DU_CXX=\"clang++\""
 +)
-+set_property(TARGET ${lib_NAME} APPEND_STRING PROPERTY
-+  LINK_FLAGS ${LDFLAGSICUTOOLUTIL}
-+)
-+
-+### Include directories
-+# PRIVATE
-+target_include_directories(${lib_NAME} PRIVATE
-+  ${CMAKE_CURRENT_LIST_DIR}
-+  ${PROJECT_SOURCE_DIR}/common
-+  ${PROJECT_SOURCE_DIR}/i18n
++set_property(
++    TARGET ${lib_NAME}
++    APPEND_STRING
++    PROPERTY LINK_FLAGS ${LDFLAGSICUTOOLUTIL}
 +)
 +
-+### Link libraries
-+# PUBLIC
-+# LIBS = $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS)
++# Include directories PRIVATE
++target_include_directories(
++    ${lib_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PROJECT_SOURCE_DIR}/common
++                        ${PROJECT_SOURCE_DIR}/i18n
++)
++
++# Link libraries PUBLIC LIBS = $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS)
 +target_link_libraries(${lib_NAME} PUBLIC ${ICULIBS_I18N})
 +
 +setup_icu_target("${lib_NAME}" "${CMAKE_CURRENT_LIST_DIR}/sources.txt" "${CMAKE_CURRENT_LIST_DIR}")
 +
 +install(
-+  TARGETS ${lib_NAME}
-+  EXPORT "${TARGETS_EXPORT_NAME}"
-+  ARCHIVE  DESTINATION "${libdir}"
-+  LIBRARY  DESTINATION "${libdir}"
-+  RUNTIME  DESTINATION "${bindir}"
-+  INCLUDES DESTINATION "${includedir}"
++    TARGETS ${lib_NAME}
++    EXPORT "${TARGETS_EXPORT_NAME}"
++    ARCHIVE DESTINATION "${libdir}"
++    LIBRARY DESTINATION "${libdir}"
++    RUNTIME DESTINATION "${bindir}"
++    INCLUDES
++    DESTINATION "${includedir}"
 +)
 -- 
-2.29.2.windows.1
+2.35.1.windows.2
 

--- a/ports/icu/patches/0002-Remove-install-suffix-on-Windows.patch
+++ b/ports/icu/patches/0002-Remove-install-suffix-on-Windows.patch
@@ -1,4 +1,4 @@
-From 98751190c76e3de00486313bb5f1e482c7630884 Mon Sep 17 00:00:00 2001
+From 3e69d7a7d60ad4aa4fab388c742ef607538d942a Mon Sep 17 00:00:00 2001
 From: foopoiuyt <github@zombiestormtrooper.com>
 Date: Tue, 3 Nov 2020 09:02:25 -0800
 Subject: [PATCH 2/2] Remove install suffix on Windows
@@ -8,24 +8,24 @@ Subject: [PATCH 2/2] Remove install suffix on Windows
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/source/icudefs.cmake b/source/icudefs.cmake
-index 0272844248..b11c203b93 100644
+index 34688e4317..f1e1ba7b13 100644
 --- a/source/icudefs.cmake
 +++ b/source/icudefs.cmake
-@@ -13,10 +13,10 @@ set(includedir  ${CMAKE_INSTALL_INCLUDEDIR})
- set(mandir      ${CMAKE_INSTALL_MANDIR})
- set(sysconfdir  ${CMAKE_INSTALL_SYSCONFDIR})
+@@ -13,10 +13,10 @@ set(includedir ${CMAKE_INSTALL_INCLUDEDIR})
+ set(mandir ${CMAKE_INSTALL_MANDIR})
+ set(sysconfdir ${CMAKE_INSTALL_SYSCONFDIR})
  
 -if(MSVC AND "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
--  set(bindir "bin64")
--  set(libdir "lib64")
+-    set(bindir "bin64")
+-    set(libdir "lib64")
 -endif()
 +#if(MSVC AND "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-+#  set(bindir "bin64")
-+#  set(libdir "lib64")
++#    set(bindir "bin64")
++#    set(libdir "lib64")
 +#endif()
  
  # Package information
  set(PACKAGE_ICU_DESCRIPTION "International Components for Unicode")
 -- 
-2.29.2.windows.1
+2.35.1.windows.2
 


### PR DESCRIPTION
The CMake platform files were stylistically inconsistent. ICU itself uses clang-format so that config was referenced when setting the options. The .cmake-format.py config file looks like the following.

```
with section("format"):
    line_width = 105
    tab_size = 4
    dangle_parens = True
```