### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,21 +4,22 @@
 .drone.yml
 
 # Ignore vcpkg paths
-buildtrees
-downloads
-installed
-packages
+/buildtrees/
+/build*/
+/downloads/
+/installed*/
+/packages/
 
 # Ignore vcpkg files
 # TODO Remove once third party repositories are supported
 .vcpkg-root
-scripts
+/scripts/
 vcpkg.exe
 
 # Ignore community triplets
-triplets/
-!triplets/x64-windows-webkit.cmake
-!triplets/x86-windows-webkit.cmake
+/triplets/*
+!/triplets/x64-windows-webkit.cmake
+!/triplets/x86-windows-webkit.cmake
 
 # Packaging files
 *.zip


### PR DESCRIPTION
Grab related patterns from the microsoft/vcpkg .gitignore file. Primary change is to prefix `/` when matching the root folders in the repository.