### PR TITLE
Remove curl-config from debug/bin

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -157,6 +157,7 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
 else ()
     file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/curl-config")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/curl-config")
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
The curl-config file isn't useful for any of our supported platforms. It was removed from release builds but debug was missed.