### PR TITLE
Rename curl ssl feature to libressl

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -24,7 +24,7 @@ def build_config(triplet):
       "brotli",
       "libressl[tools]",
       "nghttp2",
-      "curl[ssl,ipv6]",
+      "curl[libressl,ipv6]",
       "icu",
       "libxml2[xslt]",
       "libxslt",

--- a/WindowsRequirements.json
+++ b/WindowsRequirements.json
@@ -3,7 +3,7 @@
     "brotli",
     "libressl[tools]",
     "nghttp2",
-    "curl[ssl,ipv6]",
+    "curl[libressl,ipv6]",
     "icu",
     "libxml2[xslt]",
     "libxslt",

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -20,8 +20,8 @@ Feature: ipv6
 Description: |
   Enable IPV6 support.
 
-Feature: ssl
+Feature: libressl
 Build-Depends: libressl
 Description: |
-  SSL support through libressl. If not specified then the system SSL library
-  will be used.
+  SSL support through libressl. If no SSL libraries are specified then the
+  system SSL library will be used.

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -108,8 +108,10 @@ if (VCPKG_WINDOWS)
     list(APPEND BUILD_OPTIONS -DCURL_STATIC_CRT=${CURL_STATICLIB})
 endif ()
 
+# Each port of an OpenSSL equivalent checks to see that no other variant is installed so
+# just check to see if any OpenSSL variants are requested and if not use the system one
 set(USE_OPENSSL ON)
-if (NOT ssl IN_LIST FEATURES)
+if (NOT libressl IN_LIST FEATURES)
     message(STATUS "Using system SSL library")
 
     if (VCPKG_WINDOWS)

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -1,3 +1,7 @@
+if (EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
+    message(FATAL_ERROR "Can't build LibreSSL if another OpenSSL equivalent is installed. Please remove the OpenSSL variant, and try to install LibreSSL again if you need it. Build will continue since LibreSSL is a drop-in replacement for OpenSSL")
+endif()
+
 set(VERSION 3.5.2)
 
 # Get archive


### PR DESCRIPTION
This makes the library usage explicit and allows for alternate OpenSSL implementations to be specified in the future.