### PR TITLE
Update libpsl build files

### DIFF
--- a/ports/libpsl/patches/0001-Add-CMake-platform.patch
+++ b/ports/libpsl/patches/0001-Add-CMake-platform.patch
@@ -1,15 +1,15 @@
-From d242644b81558dbd2acfd25fe9ba20c8f9ea089c Mon Sep 17 00:00:00 2001
+From 7e4b5e1063e05446628d6b27fd6754b9d46bdcbd Mon Sep 17 00:00:00 2001
 From: Don <don.j.olmstead@gmail.com>
 Date: Tue, 29 Mar 2022 16:37:06 -0700
-Subject: [PATCH 1/2] Add CMake platform
+Subject: [PATCH] Add CMake platform
 
 This mirrors the meson build files as closely as possible. It ignores options that aren't supported like non-ICU backends.
 ---
- CMakeLists.txt         |  68 ++++++++++++++++++++++++
+ CMakeLists.txt         |  69 +++++++++++++++++++++++++
  config.h.in            | 114 +++++++++++++++++++++++++++++++++++++++++
  include/CMakeLists.txt |  15 ++++++
  src/CMakeLists.txt     |  23 +++++++++
- 4 files changed, 220 insertions(+)
+ 4 files changed, 221 insertions(+)
  create mode 100644 CMakeLists.txt
  create mode 100644 config.h.in
  create mode 100644 include/CMakeLists.txt
@@ -17,10 +17,10 @@ This mirrors the meson build files as closely as possible. It ignores options th
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..5fa05ac
+index 0000000..e7c8959
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,69 @@
 +cmake_minimum_required(VERSION 3.13)
 +project(
 +    psl
@@ -49,6 +49,7 @@ index 0000000..5fa05ac
 +
 +# Config file
 +set(PACKAGE_VERSION ${PROJECT_VERSION})
++set(BUILTIN_GENERATOR_LIBICU ON)
 +set(WITH_LIBICU ON)
 +check_include_file("alloca.h" HAVE_ALLOCA_H)
 +check_include_file("inttypes.h" HAVE_INTTYPES_H)
@@ -140,5 +141,5 @@ index 0000000..e26d18f
 +    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 +)
 -- 
-2.35.1.windows.2
+2.36.0.windows.1
 


### PR DESCRIPTION
The libpsl build file wasn't setting `BUILTIN_GENERATOR_LIBICU` which meant it wasn't returning queries.