### PR TITLE
Update documentation on building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 # WebKitRequirements
 > Third party packages required for building the open source WebKit port for Windows.
 
+## Setup
+
+WebKitRequirements uses [vcpkg](https://github.com/microsoft/vcpkg) to drive
+building the libraries. A helper script, `Install-Vcpkg.ps1`, configures
+`vcpkg` to be able to build the repository.
+
+```powershell
+> Install-Vcpkg.ps1 -vcpkgPath <path-to-vcpkg> [-update]
+```
+
+The script clones `vcpkg` at the given location if it is not already there. If
+the `vcpkg` repository was already checked out at that location the script does
+not automatically update the sources. An optional flag, `-update`, is required
+to trigger a `git pull`.
+
+After the repository is ready the script will copy over any resources from the
+`vcpkg` checkout that are required to do the build. View the
+[Install-Vcpkg.ps1](Install-Vcpkg.ps1) script for additional options.
+
 ## Building
 
-1. Install `vckpg` by following [its installation instructions](https://github.com/Microsoft/vcpkg)
-2. Copy the following files and folders from the `vcpkg` root into this repository
-    1. `.vcpkg-root`
-    2. `vcpkg.exe`
-    2. `scripts/`
-3. Run `vcpkg install <name>` for any packages under the port directory
+After installing `vcpkg` the requirements can be fully built using the
+`Install-Requirements` script, which is just a wrapper around `vcpkg` which
+builds the listed ports. A default is chosen based on the triplet, for windows
+[WindowsRequirements.json](WindowsRequirements.json) is used.
 
+```powershell
+> Install-Requirements.ps1 -triplet <triplet-file>
+```
+
+After the script runs the requirements will be built in the expected manner for
+use within WebKit. View the
+[Install-Requirements.ps1](Install-Requirements.ps1) script for additional
+options.
+
+Ports can be manually built using `vcpkg` directly. The
+`Install-Requirements.ps1` is just provided as a convenience for fully building
+the requirements.
+
+```powershell
+> vcpkg.exe install <port> --triplet <triplet>
+```
 
 ## Current Versions
 


### PR DESCRIPTION
Add information on the `Install-Vcpkg.ps1` and `Install-Requirements.ps1` scripts so they can be used to setup and build the requirements.