### PR TITLE
Add boringssl port

### DIFF
--- a/ports/boringssl/CONTROL
+++ b/ports/boringssl/CONTROL
@@ -1,0 +1,8 @@
+Source: boringssl
+Version: 2022.04.01
+Description: |
+  BoringSSL is a fork of OpenSSL that is designed to meet Google's needs.
+
+Feature: tools
+Description: |
+  Build openssl executables.

--- a/ports/boringssl/patches/0001-Find-threading-library.patch
+++ b/ports/boringssl/patches/0001-Find-threading-library.patch
@@ -1,0 +1,27 @@
+From 65288d0c7995d451494e27506dd3ec7769b8afd7 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Tue, 28 Jun 2022 18:02:25 -0700
+Subject: [PATCH 1/5] Find threading library
+
+Use the FindThreads module instead of just linking with pthread directly.
+---
+ crypto/CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+index 312c08007..461f34b70 100644
+--- a/crypto/CMakeLists.txt
++++ b/crypto/CMakeLists.txt
+@@ -461,7 +461,8 @@ endif()
+ SET_TARGET_PROPERTIES(crypto PROPERTIES LINKER_LANGUAGE C)
+ 
+ if(NOT WIN32 AND NOT ANDROID)
+-  target_link_libraries(crypto pthread)
++  find_package(Threads REQUIRED)
++  target_link_libraries(crypto Threads::Threads)
+ endif()
+ 
+ # Every target depends on crypto, so we add libcxx as a dependency here to
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0002-Make-gtest-library-static.patch
+++ b/ports/boringssl/patches/0002-Make-gtest-library-static.patch
@@ -1,0 +1,25 @@
+From 1e2d9b09eb58a078c052ee38dc6e37ceea5de340 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Mon, 28 Feb 2022 11:11:17 -0800
+Subject: [PATCH 2/5] Make gtest library static
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 35ff4c112..ccfdf3404 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -560,7 +560,7 @@ endif()
+ 
+ # Add minimal googletest targets. The provided one has many side-effects, and
+ # googletest has a very straightforward build.
+-add_library(boringssl_gtest third_party/googletest/src/gtest-all.cc)
++add_library(boringssl_gtest STATIC third_party/googletest/src/gtest-all.cc)
+ target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
+ 
+ include_directories(third_party/googletest/include)
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0003-Make-building-tests-optional.patch
+++ b/ports/boringssl/patches/0003-Make-building-tests-optional.patch
@@ -1,0 +1,128 @@
+From 21146b0ab51a3e7f787f90173eca398bf6861a5a Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Tue, 28 Jun 2022 18:04:56 -0700
+Subject: [PATCH 3/5] Make building tests optional
+
+---
+ CMakeLists.txt             | 4 ++++
+ crypto/CMakeLists.txt      | 2 ++
+ crypto/test/CMakeLists.txt | 2 ++
+ decrepit/CMakeLists.txt    | 2 ++
+ ssl/CMakeLists.txt         | 2 ++
+ ssl/test/CMakeLists.txt    | 2 ++
+ 6 files changed, 14 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ccfdf3404..cb3b390fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -558,12 +558,14 @@ if(USE_CUSTOM_LIBCXX)
+   target_link_libraries(libcxx libcxxabi)
+ endif()
+ 
++if(ENABLE_TESTING)
+ # Add minimal googletest targets. The provided one has many side-effects, and
+ # googletest has a very straightforward build.
+ add_library(boringssl_gtest STATIC third_party/googletest/src/gtest-all.cc)
+ target_include_directories(boringssl_gtest PRIVATE third_party/googletest)
+ 
+ include_directories(third_party/googletest/include)
++endif()
+ 
+ # Declare a dummy target to build all unit tests. Test targets should inject
+ # themselves as dependencies next to the target definition.
+@@ -646,6 +648,7 @@ else()
+   add_custom_target(fips_specific_tests_if_any)
+ endif()
+ 
++if(ENABLE_TESTING)
+ add_custom_target(
+     run_tests
+     COMMAND ${GO_EXECUTABLE} run util/all_tests.go -build-dir
+@@ -656,3 +659,4 @@ add_custom_target(
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
+     USES_TERMINAL)
++endif()
+diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+index 461f34b70..49203ad4f 100644
+--- a/crypto/CMakeLists.txt
++++ b/crypto/CMakeLists.txt
+@@ -471,6 +471,7 @@ if(USE_CUSTOM_LIBCXX)
+   target_link_libraries(crypto libcxx)
+ endif()
+ 
++if(ENABLE_TESTING)
+ # urandom_test is a separate binary because it needs to be able to observe the
+ # PRNG initialisation, which means that it can't have other tests running before
+ # it does.
+@@ -563,3 +564,4 @@ if(WIN32)
+   target_link_libraries(crypto_test ws2_32)
+ endif()
+ add_dependencies(all_tests crypto_test)
++endif()
+diff --git a/crypto/test/CMakeLists.txt b/crypto/test/CMakeLists.txt
+index b968fd78c..767f61474 100644
+--- a/crypto/test/CMakeLists.txt
++++ b/crypto/test/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if(ENABLE_TESTING)
+ add_library(
+   test_support_lib
+ 
+@@ -29,3 +30,4 @@ add_library(
+ )
+ 
+ add_dependencies(boringssl_gtest_main global_target)
++endif()
+diff --git a/decrepit/CMakeLists.txt b/decrepit/CMakeLists.txt
+index 16985da19..7bcb7dc42 100644
+--- a/decrepit/CMakeLists.txt
++++ b/decrepit/CMakeLists.txt
+@@ -26,6 +26,7 @@ add_dependencies(decrepit global_target)
+ 
+ target_link_libraries(decrepit crypto ssl)
+ 
++if(ENABLE_TESTING)
+ add_executable(
+   decrepit_test
+ 
+@@ -47,3 +48,4 @@ if(WIN32)
+   target_link_libraries(decrepit_test ws2_32)
+ endif()
+ add_dependencies(all_tests decrepit_test)
++endif()
+diff --git a/ssl/CMakeLists.txt b/ssl/CMakeLists.txt
+index 4f4abf8a4..8b72238d0 100644
+--- a/ssl/CMakeLists.txt
++++ b/ssl/CMakeLists.txt
+@@ -46,6 +46,7 @@ add_dependencies(ssl global_target)
+ 
+ target_link_libraries(ssl crypto)
+ 
++if(ENABLE_TESTING)
+ add_executable(
+   ssl_test
+ 
+@@ -63,3 +64,4 @@ if(WIN32)
+   target_link_libraries(ssl_test ws2_32)
+ endif()
+ add_dependencies(all_tests ssl_test)
++endif()
+diff --git a/ssl/test/CMakeLists.txt b/ssl/test/CMakeLists.txt
+index f02d6e24f..e312929e3 100644
+--- a/ssl/test/CMakeLists.txt
++++ b/ssl/test/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if(ENABLE_TESTING)
+ include_directories(../../include)
+ 
+ add_executable(
+@@ -38,3 +39,4 @@ else()
+   # Declare a dummy target for run_tests to depend on.
+   add_custom_target(handshaker)
+ endif()
++endif()
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0004-Make-building-tools-optional.patch
+++ b/ports/boringssl/patches/0004-Make-building-tools-optional.patch
@@ -1,0 +1,26 @@
+From d956769f9a9f2b86819fe5c5ca801660d1d781bc Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Tue, 28 Jun 2022 18:06:37 -0700
+Subject: [PATCH 4/5] Make building tools optional
+
+---
+ tool/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tool/CMakeLists.txt b/tool/CMakeLists.txt
+index a591b7def..929a9ca53 100644
+--- a/tool/CMakeLists.txt
++++ b/tool/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if(ENABLE_TOOLS)
+ include_directories(../include)
+ 
+ add_executable(
+@@ -38,3 +39,4 @@ else()
+     target_link_libraries(bssl ssl crypto)
+   endif()
+ endif()
++endif()
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0005-Add-install-targets.patch
+++ b/ports/boringssl/patches/0005-Add-install-targets.patch
@@ -1,0 +1,33 @@
+From b58a2bbd412274ec39248609b27c5923f41518a6 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Mon, 28 Feb 2022 10:53:57 -0800
+Subject: [PATCH 5/5] Add install targets
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb3b390fb..172d8aa28 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -660,3 +660,16 @@ add_custom_target(
+     DEPENDS all_tests bssl_shim handshaker fips_specific_tests_if_any
+     USES_TERMINAL)
+ endif()
++
++include(GNUInstallDirs)
++
++install(TARGETS crypto ssl
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++)
++install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
++if(ENABLE_TOOLS)
++  install(TARGETS bssl DESTINATION tools/boringssl)
++endif()
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0006-Use-the-correct-function-types-in-X509V3_EXT_METHODs.patch
+++ b/ports/boringssl/patches/0006-Use-the-correct-function-types-in-X509V3_EXT_METHODs.patch
@@ -1,0 +1,974 @@
+From f82fcdc060dac32d0f9b1623d08a5e271da95167 Mon Sep 17 00:00:00 2001
+From: David Benjamin <davidben@google.com>
+Date: Mon, 23 May 2022 14:56:15 -0400
+Subject: [PATCH] Use the correct function types in X509V3_EXT_METHODs.
+
+While C allows function pointer casts, it is UB to call a function with
+a different type than its actual type signature. That is, even though
+`void f(int *)` and `void g(void *)` have the same ABI, it is UB to
+cast `f` to a `void(*)(void *)` and then call it through that pointer.
+Clang CFI will try to enforce this rule.
+
+The recent CL to call X509_print in tests revealed that all the i2? and
+?2i callbacks in X509V3_EXT_METHODs were implemented with functions of
+the wrong type, out of some combination of missing consts and void*
+turned into T*.
+
+This CL fixes this. Where the function wasn't exported, or had no
+callers, I just fixed the function itself. Where it had extension
+callers, I added a wrapper function with a void* type.
+
+I'm not positive whether the wrappers are the right call. On the one
+hand, keeping the exported functions as-is is more type-safe and more
+OpenSSL-compatible. However, most (but not all) uses of these are in
+other code defining X509V3_EXT_METHODs themselves, so the void*
+signature is more correct for them too. And the functions have a type
+signature meant for X509V3_EXT_METHOD, complete with method pointer.
+
+I've gone with leaving the exported ones as-is for now. Probably the
+right answer anyway is to migrate the external callers, of either type
+signature.
+
+Change-Id: Ib8f2995cbd890221eaa9ac864a7e553cb6711901
+Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/52686
+Commit-Queue: Bob Beck <bbe@google.com>
+Reviewed-by: Bob Beck <bbe@google.com>
+---
+ crypto/x509v3/v3_akey.c  | 27 +++++++---------
+ crypto/x509v3/v3_alt.c   | 40 ++++++++++++-----------
+ crypto/x509v3/v3_bcons.c | 29 ++++++++---------
+ crypto/x509v3/v3_bitst.c | 27 +++++++++-------
+ crypto/x509v3/v3_cpols.c | 42 +++++++++++-------------
+ crypto/x509v3/v3_enum.c  | 27 ++++++++--------
+ crypto/x509v3/v3_ia5.c   | 43 +++++++++++++-----------
+ crypto/x509v3/v3_info.c  | 50 +++++++++++-----------------
+ crypto/x509v3/v3_int.c   | 26 +++++++++------
+ crypto/x509v3/v3_pci.c   | 21 ++++++------
+ crypto/x509v3/v3_skey.c  | 35 +++++++++++---------
+ crypto/x509v3/v3_utl.c   |  8 +++--
+ include/openssl/x509v3.h | 70 ++++++++++++----------------------------
+ 13 files changed, 209 insertions(+), 236 deletions(-)
+
+diff --git a/crypto/x509v3/v3_akey.c b/crypto/x509v3/v3_akey.c
+index e64e99fea..ca581d91a 100644
+--- a/crypto/x509v3/v3_akey.c
++++ b/crypto/x509v3/v3_akey.c
+@@ -69,30 +69,26 @@
+ #include "internal.h"
+ 
+ 
+-static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+-                                                 AUTHORITY_KEYID *akeyid,
+-                                                 STACK_OF(CONF_VALUE)
+-                                                 *extlist);
+-static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+-                                            X509V3_CTX *ctx,
+-                                            STACK_OF(CONF_VALUE) *values);
++static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *extlist);
++static void *v2i_AUTHORITY_KEYID(const X509V3_EXT_METHOD *method,
++                                 X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *values);
+ 
+ const X509V3_EXT_METHOD v3_akey_id = {
+     NID_authority_key_identifier,
+     X509V3_EXT_MULTILINE, ASN1_ITEM_ref(AUTHORITY_KEYID),
+     0, 0, 0, 0,
+     0, 0,
+-    (X509V3_EXT_I2V) i2v_AUTHORITY_KEYID,
+-    (X509V3_EXT_V2I)v2i_AUTHORITY_KEYID,
++    i2v_AUTHORITY_KEYID,
++    v2i_AUTHORITY_KEYID,
+     0, 0,
+     NULL
+ };
+ 
+-static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+-                                                 AUTHORITY_KEYID *akeyid,
+-                                                 STACK_OF(CONF_VALUE)
+-                                                 *extlist)
++static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *extlist)
+ {
++    const AUTHORITY_KEYID *akeyid = ext;
+     int extlist_was_null = extlist == NULL;
+     if (akeyid->keyid) {
+         char *tmp = x509v3_bytes_to_hex(akeyid->keyid->data,
+@@ -133,9 +129,8 @@ err:
+  * is always included.
+  */
+ 
+-static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+-                                            X509V3_CTX *ctx,
+-                                            STACK_OF(CONF_VALUE) *values)
++static void *v2i_AUTHORITY_KEYID(const X509V3_EXT_METHOD *method,
++                                 X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *values)
+ {
+     char keyid = 0, issuer = 0;
+     size_t i;
+diff --git a/crypto/x509v3/v3_alt.c b/crypto/x509v3/v3_alt.c
+index eb9c9757a..c057da1a1 100644
+--- a/crypto/x509v3/v3_alt.c
++++ b/crypto/x509v3/v3_alt.c
+@@ -68,40 +68,44 @@
+ #include "internal.h"
+ 
+ 
+-static GENERAL_NAMES *v2i_subject_alt(X509V3_EXT_METHOD *method,
+-                                      X509V3_CTX *ctx,
+-                                      STACK_OF(CONF_VALUE) *nval);
+-static GENERAL_NAMES *v2i_issuer_alt(X509V3_EXT_METHOD *method,
+-                                     X509V3_CTX *ctx,
+-                                     STACK_OF(CONF_VALUE) *nval);
++static void *v2i_subject_alt(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                             STACK_OF(CONF_VALUE) *nval);
++static void *v2i_issuer_alt(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                            STACK_OF(CONF_VALUE) *nval);
+ static int copy_email(X509V3_CTX *ctx, GENERAL_NAMES *gens, int move_p);
+ static int copy_issuer(X509V3_CTX *ctx, GENERAL_NAMES *gens);
+ static int do_othername(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx);
+ static int do_dirname(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx);
+ 
++static STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES_cb(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *ret)
++{
++    return i2v_GENERAL_NAMES(method, ext, ret);
++}
++
+ const X509V3_EXT_METHOD v3_alt[] = {
+     {NID_subject_alt_name, 0, ASN1_ITEM_ref(GENERAL_NAMES),
+      0, 0, 0, 0,
+      0, 0,
+-     (X509V3_EXT_I2V) i2v_GENERAL_NAMES,
+-     (X509V3_EXT_V2I)v2i_subject_alt,
++     i2v_GENERAL_NAMES_cb,
++     v2i_subject_alt,
+      NULL, NULL, NULL},
+ 
+     {NID_issuer_alt_name, 0, ASN1_ITEM_ref(GENERAL_NAMES),
+      0, 0, 0, 0,
+      0, 0,
+-     (X509V3_EXT_I2V) i2v_GENERAL_NAMES,
+-     (X509V3_EXT_V2I)v2i_issuer_alt,
++     i2v_GENERAL_NAMES_cb,
++     v2i_issuer_alt,
+      NULL, NULL, NULL},
+ 
+     {NID_certificate_issuer, 0, ASN1_ITEM_ref(GENERAL_NAMES),
+      0, 0, 0, 0,
+      0, 0,
+-     (X509V3_EXT_I2V) i2v_GENERAL_NAMES,
++     i2v_GENERAL_NAMES_cb,
+      NULL, NULL, NULL, NULL},
+ };
+ 
+-STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(X509V3_EXT_METHOD *method,
++STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(const X509V3_EXT_METHOD *method,
+                                         GENERAL_NAMES *gens,
+                                         STACK_OF(CONF_VALUE) *ret)
+ {
+@@ -122,7 +126,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(X509V3_EXT_METHOD *method,
+     return ret;
+ }
+ 
+-STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
++STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(const X509V3_EXT_METHOD *method,
+                                        GENERAL_NAME *gen,
+                                        STACK_OF(CONF_VALUE) *ret)
+ {
+@@ -266,9 +270,8 @@ int GENERAL_NAME_print(BIO *out, GENERAL_NAME *gen)
+     return 1;
+ }
+ 
+-static GENERAL_NAMES *v2i_issuer_alt(X509V3_EXT_METHOD *method,
+-                                     X509V3_CTX *ctx,
+-                                     STACK_OF(CONF_VALUE) *nval)
++static void *v2i_issuer_alt(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                            STACK_OF(CONF_VALUE) *nval)
+ {
+     GENERAL_NAMES *gens = NULL;
+     CONF_VALUE *cnf;
+@@ -336,9 +339,8 @@ err:
+     return ret;
+ }
+ 
+-static GENERAL_NAMES *v2i_subject_alt(X509V3_EXT_METHOD *method,
+-                                      X509V3_CTX *ctx,
+-                                      STACK_OF(CONF_VALUE) *nval)
++static void *v2i_subject_alt(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                             STACK_OF(CONF_VALUE) *nval)
+ {
+     GENERAL_NAMES *gens = NULL;
+     CONF_VALUE *cnf;
+diff --git a/crypto/x509v3/v3_bcons.c b/crypto/x509v3/v3_bcons.c
+index aefefdff7..4edf27b8a 100644
+--- a/crypto/x509v3/v3_bcons.c
++++ b/crypto/x509v3/v3_bcons.c
+@@ -65,21 +65,19 @@
+ #include <openssl/obj.h>
+ #include <openssl/x509v3.h>
+ 
+-static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+-                                                   BASIC_CONSTRAINTS *bcons,
+-                                                   STACK_OF(CONF_VALUE)
+-                                                   *extlist);
+-static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+-                                                X509V3_CTX *ctx,
+-                                                STACK_OF(CONF_VALUE) *values);
++static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *extlist);
++static void *v2i_BASIC_CONSTRAINTS(const X509V3_EXT_METHOD *method,
++                                   X509V3_CTX *ctx,
++                                   STACK_OF(CONF_VALUE) *values);
+ 
+ const X509V3_EXT_METHOD v3_bcons = {
+     NID_basic_constraints, 0,
+     ASN1_ITEM_ref(BASIC_CONSTRAINTS),
+     0, 0, 0, 0,
+     0, 0,
+-    (X509V3_EXT_I2V) i2v_BASIC_CONSTRAINTS,
+-    (X509V3_EXT_V2I)v2i_BASIC_CONSTRAINTS,
++    i2v_BASIC_CONSTRAINTS,
++    v2i_BASIC_CONSTRAINTS,
+     NULL, NULL,
+     NULL
+ };
+@@ -91,19 +89,18 @@ ASN1_SEQUENCE(BASIC_CONSTRAINTS) = {
+ 
+ IMPLEMENT_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)
+ 
+-static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+-                                                   BASIC_CONSTRAINTS *bcons,
+-                                                   STACK_OF(CONF_VALUE)
+-                                                   *extlist)
++static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *extlist)
+ {
++    const BASIC_CONSTRAINTS *bcons = ext;
+     X509V3_add_value_bool("CA", bcons->ca, &extlist);
+     X509V3_add_value_int("pathlen", bcons->pathlen, &extlist);
+     return extlist;
+ }
+ 
+-static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+-                                                X509V3_CTX *ctx,
+-                                                STACK_OF(CONF_VALUE) *values)
++static void *v2i_BASIC_CONSTRAINTS(const X509V3_EXT_METHOD *method,
++                                   X509V3_CTX *ctx,
++                                   STACK_OF(CONF_VALUE) *values)
+ {
+     BASIC_CONSTRAINTS *bcons = NULL;
+     CONF_VALUE *val;
+diff --git a/crypto/x509v3/v3_bitst.c b/crypto/x509v3/v3_bitst.c
+index 871b77617..3420b126b 100644
+--- a/crypto/x509v3/v3_bitst.c
++++ b/crypto/x509v3/v3_bitst.c
+@@ -91,15 +91,10 @@ static const BIT_STRING_BITNAME key_usage_type_table[] = {
+     {-1, NULL, NULL}
+ };
+ 
+-const X509V3_EXT_METHOD v3_nscert =
+-EXT_BITSTRING(NID_netscape_cert_type, ns_cert_type_table);
+-const X509V3_EXT_METHOD v3_key_usage =
+-EXT_BITSTRING(NID_key_usage, key_usage_type_table);
+-
+-STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
+-                                          ASN1_BIT_STRING *bits,
+-                                          STACK_OF(CONF_VALUE) *ret)
++static STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *ret)
+ {
++    const ASN1_BIT_STRING *bits = ext;
+     const BIT_STRING_BITNAME *bnam;
+     for (bnam = method->usr_data; bnam->lname; bnam++) {
+         if (ASN1_BIT_STRING_get_bit(bits, bnam->bitnum))
+@@ -108,9 +103,8 @@ STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
+     return ret;
+ }
+ 
+-ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
+-                                     X509V3_CTX *ctx,
+-                                     STACK_OF(CONF_VALUE) *nval)
++static void *v2i_ASN1_BIT_STRING(const X509V3_EXT_METHOD *method,
++                                 X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+ {
+     CONF_VALUE *val;
+     ASN1_BIT_STRING *bs;
+@@ -142,3 +136,14 @@ ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
+     }
+     return bs;
+ }
++
++#define EXT_BITSTRING(nid, table)                                             \
++  {                                                                           \
++    nid, 0, ASN1_ITEM_ref(ASN1_BIT_STRING), 0, 0, 0, 0, 0, 0,                 \
++        i2v_ASN1_BIT_STRING, v2i_ASN1_BIT_STRING, NULL, NULL, (void *)(table) \
++  }
++
++const X509V3_EXT_METHOD v3_nscert =
++EXT_BITSTRING(NID_netscape_cert_type, ns_cert_type_table);
++const X509V3_EXT_METHOD v3_key_usage =
++EXT_BITSTRING(NID_key_usage, key_usage_type_table);
+diff --git a/crypto/x509v3/v3_cpols.c b/crypto/x509v3/v3_cpols.c
+index 6e3eb1419..9290556b6 100644
+--- a/crypto/x509v3/v3_cpols.c
++++ b/crypto/x509v3/v3_cpols.c
+@@ -73,13 +73,13 @@
+ 
+ /* Certificate policies extension support: this one is a bit complex... */
+ 
+-static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
+-                       BIO *out, int indent);
+-static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
+-                                         X509V3_CTX *ctx, char *value);
+-static void print_qualifiers(BIO *out, STACK_OF(POLICYQUALINFO) *quals,
++static int i2r_certpol(const X509V3_EXT_METHOD *method, void *ext, BIO *out,
++                       int indent);
++static void *r2i_certpol(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                         const char *value);
++static void print_qualifiers(BIO *out, const STACK_OF(POLICYQUALINFO) *quals,
+                              int indent);
+-static void print_notice(BIO *out, USERNOTICE *notice, int indent);
++static void print_notice(BIO *out, const USERNOTICE *notice, int indent);
+ static POLICYINFO *policy_section(X509V3_CTX *ctx,
+                                   STACK_OF(CONF_VALUE) *polstrs, int ia5org);
+ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
+@@ -91,8 +91,8 @@ const X509V3_EXT_METHOD v3_cpols = {
+     0, 0, 0, 0,
+     0, 0,
+     0, 0,
+-    (X509V3_EXT_I2R)i2r_certpol,
+-    (X509V3_EXT_R2I)r2i_certpol,
++    i2r_certpol,
++    r2i_certpol,
+     NULL
+ };
+ 
+@@ -137,8 +137,8 @@ ASN1_SEQUENCE(NOTICEREF) = {
+ 
+ IMPLEMENT_ASN1_FUNCTIONS(NOTICEREF)
+ 
+-static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
+-                                         X509V3_CTX *ctx, char *value)
++static void *r2i_certpol(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                         const char *value)
+ {
+     STACK_OF(POLICYINFO) *pols = NULL;
+     char *pstr;
+@@ -405,14 +405,13 @@ static int nref_nos(STACK_OF(ASN1_INTEGER) *nnums, STACK_OF(CONF_VALUE) *nos)
+     return 0;
+ }
+ 
+-static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
++static int i2r_certpol(const X509V3_EXT_METHOD *method, void *ext,
+                        BIO *out, int indent)
+ {
+-    size_t i;
+-    POLICYINFO *pinfo;
++    const STACK_OF(POLICYINFO) *pol = ext;
+     /* First print out the policy OIDs */
+-    for (i = 0; i < sk_POLICYINFO_num(pol); i++) {
+-        pinfo = sk_POLICYINFO_value(pol, i);
++    for (size_t i = 0; i < sk_POLICYINFO_num(pol); i++) {
++        const POLICYINFO *pinfo = sk_POLICYINFO_value(pol, i);
+         BIO_printf(out, "%*sPolicy: ", indent, "");
+         i2a_ASN1_OBJECT(out, pinfo->policyid);
+         BIO_puts(out, "\n");
+@@ -422,13 +421,11 @@ static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
+     return 1;
+ }
+ 
+-static void print_qualifiers(BIO *out, STACK_OF(POLICYQUALINFO) *quals,
++static void print_qualifiers(BIO *out, const STACK_OF(POLICYQUALINFO) *quals,
+                              int indent)
+ {
+-    POLICYQUALINFO *qualinfo;
+-    size_t i;
+-    for (i = 0; i < sk_POLICYQUALINFO_num(quals); i++) {
+-        qualinfo = sk_POLICYQUALINFO_value(quals, i);
++    for (size_t i = 0; i < sk_POLICYQUALINFO_num(quals); i++) {
++        const POLICYQUALINFO *qualinfo = sk_POLICYQUALINFO_value(quals, i);
+         switch (OBJ_obj2nid(qualinfo->pqualid)) {
+         case NID_id_qt_cps:
+             BIO_printf(out, "%*sCPS: %.*s\n", indent, "",
+@@ -450,9 +447,8 @@ static void print_qualifiers(BIO *out, STACK_OF(POLICYQUALINFO) *quals,
+     }
+ }
+ 
+-static void print_notice(BIO *out, USERNOTICE *notice, int indent)
++static void print_notice(BIO *out, const USERNOTICE *notice, int indent)
+ {
+-    size_t i;
+     if (notice->noticeref) {
+         NOTICEREF *ref;
+         ref = notice->noticeref;
+@@ -460,7 +456,7 @@ static void print_notice(BIO *out, USERNOTICE *notice, int indent)
+                    ref->organization->length, ref->organization->data);
+         BIO_printf(out, "%*sNumber%s: ", indent, "",
+                    sk_ASN1_INTEGER_num(ref->noticenos) > 1 ? "s" : "");
+-        for (i = 0; i < sk_ASN1_INTEGER_num(ref->noticenos); i++) {
++        for (size_t i = 0; i < sk_ASN1_INTEGER_num(ref->noticenos); i++) {
+             ASN1_INTEGER *num;
+             char *tmp;
+             num = sk_ASN1_INTEGER_value(ref->noticenos, i);
+diff --git a/crypto/x509v3/v3_enum.c b/crypto/x509v3/v3_enum.c
+index 9b222bbd4..5c9585853 100644
+--- a/crypto/x509v3/v3_enum.c
++++ b/crypto/x509v3/v3_enum.c
+@@ -83,24 +83,23 @@ static const ENUMERATED_NAMES crl_reasons[] = {
+     {-1, NULL, NULL}
+ };
+ 
++static char *i2s_ASN1_ENUMERATED_TABLE(const X509V3_EXT_METHOD *method,
++                                       void *ext)
++{
++    const ASN1_ENUMERATED *e = ext;
++    long strval = ASN1_ENUMERATED_get(e);
++    for (const ENUMERATED_NAMES *enam = method->usr_data; enam->lname; enam++) {
++        if (strval == enam->bitnum)
++            return OPENSSL_strdup(enam->lname);
++    }
++    return i2s_ASN1_ENUMERATED(method, e);
++}
++
+ const X509V3_EXT_METHOD v3_crl_reason = {
+     NID_crl_reason, 0, ASN1_ITEM_ref(ASN1_ENUMERATED),
+     0, 0, 0, 0,
+-    (X509V3_EXT_I2S)i2s_ASN1_ENUMERATED_TABLE,
++    i2s_ASN1_ENUMERATED_TABLE,
+     0,
+     0, 0, 0, 0,
+     (void *)crl_reasons
+ };
+-
+-char *i2s_ASN1_ENUMERATED_TABLE(X509V3_EXT_METHOD *method,
+-                                const ASN1_ENUMERATED *e)
+-{
+-    const ENUMERATED_NAMES *enam;
+-    long strval;
+-    strval = ASN1_ENUMERATED_get(e);
+-    for (enam = method->usr_data; enam->lname; enam++) {
+-        if (strval == enam->bitnum)
+-            return OPENSSL_strdup(enam->lname);
+-    }
+-    return i2s_ASN1_ENUMERATED(method, e);
+-}
+diff --git a/crypto/x509v3/v3_ia5.c b/crypto/x509v3/v3_ia5.c
+index 700200c52..6f5ce1d7f 100644
+--- a/crypto/x509v3/v3_ia5.c
++++ b/crypto/x509v3/v3_ia5.c
+@@ -70,24 +70,9 @@
+ #include "../internal.h"
+ 
+ 
+-static char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+-                                ASN1_IA5STRING *ia5);
+-static ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+-                                          X509V3_CTX *ctx, char *str);
+-const X509V3_EXT_METHOD v3_ns_ia5_list[] = {
+-    EXT_IA5STRING(NID_netscape_base_url),
+-    EXT_IA5STRING(NID_netscape_revocation_url),
+-    EXT_IA5STRING(NID_netscape_ca_revocation_url),
+-    EXT_IA5STRING(NID_netscape_renewal_url),
+-    EXT_IA5STRING(NID_netscape_ca_policy_url),
+-    EXT_IA5STRING(NID_netscape_ssl_server_name),
+-    EXT_IA5STRING(NID_netscape_comment),
+-    EXT_END
+-};
+-
+-static char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+-                                ASN1_IA5STRING *ia5)
++static char *i2s_ASN1_IA5STRING(const X509V3_EXT_METHOD *method, void *ext)
+ {
++    const ASN1_IA5STRING *ia5 = ext;
+     char *tmp;
+     if (!ia5 || !ia5->length)
+         return NULL;
+@@ -100,8 +85,8 @@ static char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+     return tmp;
+ }
+ 
+-static ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+-                                          X509V3_CTX *ctx, char *str)
++static void *s2i_ASN1_IA5STRING(const X509V3_EXT_METHOD *method,
++                                X509V3_CTX *ctx, const char *str)
+ {
+     ASN1_IA5STRING *ia5;
+     if (!str) {
+@@ -119,3 +104,23 @@ static ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
+     OPENSSL_PUT_ERROR(X509V3, ERR_R_MALLOC_FAILURE);
+     return NULL;
+ }
++
++#define EXT_IA5STRING(nid)                                                 \
++  {                                                                        \
++    nid, 0, ASN1_ITEM_ref(ASN1_IA5STRING), 0, 0, 0, 0, i2s_ASN1_IA5STRING, \
++        s2i_ASN1_IA5STRING, 0, 0, 0, 0, NULL                               \
++  }
++
++#define EXT_END \
++  { -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
++
++const X509V3_EXT_METHOD v3_ns_ia5_list[] = {
++    EXT_IA5STRING(NID_netscape_base_url),
++    EXT_IA5STRING(NID_netscape_revocation_url),
++    EXT_IA5STRING(NID_netscape_ca_revocation_url),
++    EXT_IA5STRING(NID_netscape_renewal_url),
++    EXT_IA5STRING(NID_netscape_ca_policy_url),
++    EXT_IA5STRING(NID_netscape_ssl_server_name),
++    EXT_IA5STRING(NID_netscape_comment),
++    EXT_END
++};
+diff --git a/crypto/x509v3/v3_info.c b/crypto/x509v3/v3_info.c
+index 3615c71d5..e314019f1 100644
+--- a/crypto/x509v3/v3_info.c
++++ b/crypto/x509v3/v3_info.c
+@@ -68,22 +68,18 @@
+ #include <openssl/obj.h>
+ #include <openssl/x509v3.h>
+ 
+-static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
+-                                                       *method, AUTHORITY_INFO_ACCESS
+-                                                       *ainfo, STACK_OF(CONF_VALUE)
+-                                                       *ret);
+-static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
+-                                                        *method,
+-                                                        X509V3_CTX *ctx,
+-                                                        STACK_OF(CONF_VALUE)
+-                                                        *nval);
++static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *ret);
++static void *v2i_AUTHORITY_INFO_ACCESS(const X509V3_EXT_METHOD *method,
++                                       X509V3_CTX *ctx,
++                                       STACK_OF(CONF_VALUE) *nval);
+ 
+ const X509V3_EXT_METHOD v3_info = { NID_info_access, X509V3_EXT_MULTILINE,
+     ASN1_ITEM_ref(AUTHORITY_INFO_ACCESS),
+     0, 0, 0, 0,
+     0, 0,
+-    (X509V3_EXT_I2V) i2v_AUTHORITY_INFO_ACCESS,
+-    (X509V3_EXT_V2I)v2i_AUTHORITY_INFO_ACCESS,
++    i2v_AUTHORITY_INFO_ACCESS,
++    v2i_AUTHORITY_INFO_ACCESS,
+     0, 0,
+     NULL
+ };
+@@ -92,8 +88,8 @@ const X509V3_EXT_METHOD v3_sinfo = { NID_sinfo_access, X509V3_EXT_MULTILINE,
+     ASN1_ITEM_ref(AUTHORITY_INFO_ACCESS),
+     0, 0, 0, 0,
+     0, 0,
+-    (X509V3_EXT_I2V) i2v_AUTHORITY_INFO_ACCESS,
+-    (X509V3_EXT_V2I)v2i_AUTHORITY_INFO_ACCESS,
++    i2v_AUTHORITY_INFO_ACCESS,
++    v2i_AUTHORITY_INFO_ACCESS,
+     0, 0,
+     NULL
+ };
+@@ -112,17 +108,16 @@ ASN1_ITEM_TEMPLATE_END(AUTHORITY_INFO_ACCESS)
+ IMPLEMENT_ASN1_FUNCTIONS(AUTHORITY_INFO_ACCESS)
+ 
+ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
+-    X509V3_EXT_METHOD *method, AUTHORITY_INFO_ACCESS *ainfo,
+-    STACK_OF(CONF_VALUE) *ret)
++    const X509V3_EXT_METHOD *method, void *ext, STACK_OF(CONF_VALUE) *ret)
+ {
++    const AUTHORITY_INFO_ACCESS *ainfo = ext;
+     ACCESS_DESCRIPTION *desc;
+-    size_t i;
+     int nlen;
+     char objtmp[80], *ntmp;
+     CONF_VALUE *vtmp;
+     STACK_OF(CONF_VALUE) *tret = ret;
+ 
+-    for (i = 0; i < sk_ACCESS_DESCRIPTION_num(ainfo); i++) {
++    for (size_t i = 0; i < sk_ACCESS_DESCRIPTION_num(ainfo); i++) {
+         STACK_OF(CONF_VALUE) *tmp;
+ 
+         desc = sk_ACCESS_DESCRIPTION_value(ainfo, i);
+@@ -154,24 +149,19 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
+     return NULL;
+ }
+ 
+-static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
+-                                                        *method,
+-                                                        X509V3_CTX *ctx,
+-                                                        STACK_OF(CONF_VALUE)
+-                                                        *nval)
++static void *v2i_AUTHORITY_INFO_ACCESS(const X509V3_EXT_METHOD *method,
++                                       X509V3_CTX *ctx,
++                                       STACK_OF(CONF_VALUE) *nval)
+ {
+     AUTHORITY_INFO_ACCESS *ainfo = NULL;
+-    CONF_VALUE *cnf, ctmp;
+     ACCESS_DESCRIPTION *acc;
+-    size_t i;
+-    int objlen;
+     char *objtmp, *ptmp;
+     if (!(ainfo = sk_ACCESS_DESCRIPTION_new_null())) {
+         OPENSSL_PUT_ERROR(X509V3, ERR_R_MALLOC_FAILURE);
+         return NULL;
+     }
+-    for (i = 0; i < sk_CONF_VALUE_num(nval); i++) {
+-        cnf = sk_CONF_VALUE_value(nval, i);
++    for (size_t i = 0; i < sk_CONF_VALUE_num(nval); i++) {
++        CONF_VALUE *cnf = sk_CONF_VALUE_value(nval, i);
+         if (!(acc = ACCESS_DESCRIPTION_new())
+             || !sk_ACCESS_DESCRIPTION_push(ainfo, acc)) {
+             OPENSSL_PUT_ERROR(X509V3, ERR_R_MALLOC_FAILURE);
+@@ -182,7 +172,8 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
+             OPENSSL_PUT_ERROR(X509V3, X509V3_R_INVALID_SYNTAX);
+             goto err;
+         }
+-        objlen = ptmp - cnf->name;
++        int objlen = ptmp - cnf->name;
++        CONF_VALUE ctmp;
+         ctmp.name = ptmp + 1;
+         ctmp.value = cnf->value;
+         if (!v2i_GENERAL_NAME_ex(acc->location, method, ctx, &ctmp, 0))
+@@ -211,8 +202,5 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
+ int i2a_ACCESS_DESCRIPTION(BIO *bp, const ACCESS_DESCRIPTION *a)
+ {
+     i2a_ASN1_OBJECT(bp, a->method);
+-#ifdef UNDEF
+-    i2a_GENERAL_NAME(bp, a->location);
+-#endif
+     return 2;
+ }
+diff --git a/crypto/x509v3/v3_int.c b/crypto/x509v3/v3_int.c
+index 7bde446c2..8b96796a6 100644
+--- a/crypto/x509v3/v3_int.c
++++ b/crypto/x509v3/v3_int.c
+@@ -60,10 +60,22 @@
+ #include <openssl/obj.h>
+ #include <openssl/x509v3.h>
+ 
++
++static char *i2s_ASN1_INTEGER_cb(const X509V3_EXT_METHOD *method, void *ext)
++{
++    return i2s_ASN1_INTEGER(method, ext);
++}
++
++static void *s2i_asn1_int(const X509V3_EXT_METHOD *meth, X509V3_CTX *ctx,
++                          const char *value)
++{
++    return s2i_ASN1_INTEGER(meth, value);
++}
++
+ const X509V3_EXT_METHOD v3_crl_num = {
+     NID_crl_number, 0, ASN1_ITEM_ref(ASN1_INTEGER),
+     0, 0, 0, 0,
+-    (X509V3_EXT_I2S)i2s_ASN1_INTEGER,
++    i2s_ASN1_INTEGER_cb,
+     0,
+     0, 0, 0, 0, NULL
+ };
+@@ -71,21 +83,15 @@ const X509V3_EXT_METHOD v3_crl_num = {
+ const X509V3_EXT_METHOD v3_delta_crl = {
+     NID_delta_crl, 0, ASN1_ITEM_ref(ASN1_INTEGER),
+     0, 0, 0, 0,
+-    (X509V3_EXT_I2S)i2s_ASN1_INTEGER,
++    i2s_ASN1_INTEGER_cb,
+     0,
+     0, 0, 0, 0, NULL
+ };
+ 
+-static void *s2i_asn1_int(X509V3_EXT_METHOD *meth, X509V3_CTX *ctx,
+-                          char *value)
+-{
+-    return s2i_ASN1_INTEGER(meth, value);
+-}
+-
+ const X509V3_EXT_METHOD v3_inhibit_anyp = {
+     NID_inhibit_any_policy, 0, ASN1_ITEM_ref(ASN1_INTEGER),
+     0, 0, 0, 0,
+-    (X509V3_EXT_I2S)i2s_ASN1_INTEGER,
+-    (X509V3_EXT_S2I)s2i_asn1_int,
++    i2s_ASN1_INTEGER_cb,
++    s2i_asn1_int,
+     0, 0, 0, 0, NULL
+ };
+diff --git a/crypto/x509v3/v3_pci.c b/crypto/x509v3/v3_pci.c
+index 57b64ef7e..b6ff148cb 100644
+--- a/crypto/x509v3/v3_pci.c
++++ b/crypto/x509v3/v3_pci.c
+@@ -47,24 +47,25 @@
+ #include "internal.h"
+ 
+ 
+-static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *ext,
+-                   BIO *out, int indent);
+-static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
+-                                          X509V3_CTX *ctx, char *str);
++static int i2r_pci(const X509V3_EXT_METHOD *method, void *ext, BIO *out,
++                   int indent);
++static void *r2i_pci(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                     const char *str);
+ 
+ const X509V3_EXT_METHOD v3_pci =
+     { NID_proxyCertInfo, 0, ASN1_ITEM_ref(PROXY_CERT_INFO_EXTENSION),
+     0, 0, 0, 0,
+     0, 0,
+     NULL, NULL,
+-    (X509V3_EXT_I2R)i2r_pci,
+-    (X509V3_EXT_R2I)r2i_pci,
++    i2r_pci,
++    r2i_pci,
+     NULL,
+ };
+ 
+-static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
+-                   BIO *out, int indent)
++static int i2r_pci(const X509V3_EXT_METHOD *method, void *ext, BIO *out,
++                   int indent)
+ {
++    const PROXY_CERT_INFO_EXTENSION *pci = ext;
+     BIO_printf(out, "%*sPath Length Constraint: ", indent, "");
+     if (pci->pcPathLengthConstraint)
+         i2a_ASN1_INTEGER(out, pci->pcPathLengthConstraint);
+@@ -195,8 +196,8 @@ static int process_pci_value(CONF_VALUE *val,
+     return 0;
+ }
+ 
+-static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
+-                                          X509V3_CTX *ctx, char *value)
++static void *r2i_pci(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                     const char *value)
+ {
+     PROXY_CERT_INFO_EXTENSION *pci = NULL;
+     STACK_OF(CONF_VALUE) *vals;
+diff --git a/crypto/x509v3/v3_skey.c b/crypto/x509v3/v3_skey.c
+index 1cae7e187..926eecd10 100644
+--- a/crypto/x509v3/v3_skey.c
++++ b/crypto/x509v3/v3_skey.c
+@@ -67,23 +67,13 @@
+ #include "internal.h"
+ 
+ 
+-static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
+-                                      X509V3_CTX *ctx, char *str);
+-const X509V3_EXT_METHOD v3_skey_id = {
+-    NID_subject_key_identifier, 0, ASN1_ITEM_ref(ASN1_OCTET_STRING),
+-    0, 0, 0, 0,
+-    (X509V3_EXT_I2S)i2s_ASN1_OCTET_STRING,
+-    (X509V3_EXT_S2I)s2i_skey_id,
+-    0, 0, 0, 0,
+-    NULL
+-};
+-
+-char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method, const ASN1_OCTET_STRING *oct)
++char *i2s_ASN1_OCTET_STRING(const X509V3_EXT_METHOD *method,
++                            const ASN1_OCTET_STRING *oct)
+ {
+     return x509v3_bytes_to_hex(oct->data, oct->length);
+ }
+ 
+-ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
++ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(const X509V3_EXT_METHOD *method,
+                                          X509V3_CTX *ctx, const char *str)
+ {
+     ASN1_OCTET_STRING *oct;
+@@ -105,8 +95,14 @@ ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
+ 
+ }
+ 
+-static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
+-                                      X509V3_CTX *ctx, char *str)
++static char *i2s_ASN1_OCTET_STRING_cb(const X509V3_EXT_METHOD *method,
++                                      void *ext)
++{
++    return i2s_ASN1_OCTET_STRING(method, ext);
++}
++
++static void *s2i_skey_id(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
++                         const char *str)
+ {
+     ASN1_OCTET_STRING *oct;
+     ASN1_BIT_STRING *pk;
+@@ -154,3 +150,12 @@ static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
+     ASN1_OCTET_STRING_free(oct);
+     return NULL;
+ }
++
++const X509V3_EXT_METHOD v3_skey_id = {
++    NID_subject_key_identifier, 0, ASN1_ITEM_ref(ASN1_OCTET_STRING),
++    0, 0, 0, 0,
++    i2s_ASN1_OCTET_STRING_cb,
++    s2i_skey_id,
++    0, 0, 0, 0,
++    NULL
++};
+diff --git a/crypto/x509v3/v3_utl.c b/crypto/x509v3/v3_utl.c
+index 960c407a1..064e71b9f 100644
+--- a/crypto/x509v3/v3_utl.c
++++ b/crypto/x509v3/v3_utl.c
+@@ -222,7 +222,8 @@ static char *bignum_to_string(const BIGNUM *bn)
+     return ret;
+ }
+ 
+-char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, const ASN1_ENUMERATED *a)
++char *i2s_ASN1_ENUMERATED(const X509V3_EXT_METHOD *method,
++                          const ASN1_ENUMERATED *a)
+ {
+     BIGNUM *bntmp = NULL;
+     char *strtmp = NULL;
+@@ -235,7 +236,7 @@ char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, const ASN1_ENUMERATED *a)
+     return strtmp;
+ }
+ 
+-char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
++char *i2s_ASN1_INTEGER(const X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
+ {
+     BIGNUM *bntmp = NULL;
+     char *strtmp = NULL;
+@@ -248,7 +249,8 @@ char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
+     return strtmp;
+ }
+ 
+-ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *method, const char *value)
++ASN1_INTEGER *s2i_ASN1_INTEGER(const X509V3_EXT_METHOD *method,
++                               const char *value)
+ {
+     BIGNUM *bn = NULL;
+     ASN1_INTEGER *aint;
+diff --git a/include/openssl/x509v3.h b/include/openssl/x509v3.h
+index c67dde6a3..afaf172f8 100644
+--- a/include/openssl/x509v3.h
++++ b/include/openssl/x509v3.h
+@@ -79,23 +79,24 @@ struct v3_ext_ctx;
+ 
+ // Useful typedefs
+ 
++typedef struct v3_ext_method X509V3_EXT_METHOD;
++
+ typedef void *(*X509V3_EXT_NEW)(void);
+ typedef void (*X509V3_EXT_FREE)(void *);
+ typedef void *(*X509V3_EXT_D2I)(void *, const unsigned char **, long);
+ typedef int (*X509V3_EXT_I2D)(void *, unsigned char **);
+-typedef STACK_OF(CONF_VALUE) *(*X509V3_EXT_I2V)(
+-    const struct v3_ext_method *method, void *ext,
+-    STACK_OF(CONF_VALUE) *extlist);
+-typedef void *(*X509V3_EXT_V2I)(const struct v3_ext_method *method,
+-                                struct v3_ext_ctx *ctx,
+-                                STACK_OF(CONF_VALUE) *values);
+-typedef char *(*X509V3_EXT_I2S)(const struct v3_ext_method *method, void *ext);
+-typedef void *(*X509V3_EXT_S2I)(const struct v3_ext_method *method,
+-                                struct v3_ext_ctx *ctx, const char *str);
+-typedef int (*X509V3_EXT_I2R)(const struct v3_ext_method *method, void *ext,
++typedef STACK_OF(CONF_VALUE) *(*X509V3_EXT_I2V)(const X509V3_EXT_METHOD *method,
++                                                void *ext,
++                                                STACK_OF(CONF_VALUE) *extlist);
++typedef void *(*X509V3_EXT_V2I)(const X509V3_EXT_METHOD *method,
++                                X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *values);
++typedef char *(*X509V3_EXT_I2S)(const X509V3_EXT_METHOD *method, void *ext);
++typedef void *(*X509V3_EXT_S2I)(const X509V3_EXT_METHOD *method,
++                                X509V3_CTX *ctx, const char *str);
++typedef int (*X509V3_EXT_I2R)(const X509V3_EXT_METHOD *method, void *ext,
+                               BIO *out, int indent);
+-typedef void *(*X509V3_EXT_R2I)(const struct v3_ext_method *method,
+-                                struct v3_ext_ctx *ctx, const char *str);
++typedef void *(*X509V3_EXT_R2I)(const X509V3_EXT_METHOD *method,
++                                X509V3_CTX *ctx, const char *str);
+ 
+ // V3 extension structure
+ 
+@@ -145,8 +146,6 @@ struct v3_ext_ctx {
+   // Maybe more here
+ };
+ 
+-typedef struct v3_ext_method X509V3_EXT_METHOD;
+-
+ DEFINE_STACK_OF(X509V3_EXT_METHOD)
+ 
+ // ext_flags values
+@@ -365,23 +364,6 @@ struct ISSUING_DIST_POINT_st {
+   X509V3_set_ctx(ctx, NULL, NULL, NULL, NULL, CTX_TEST)
+ #define X509V3_set_ctx_nodb(ctx) (ctx)->db = NULL;
+ 
+-#define EXT_BITSTRING(nid, table)                                        \
+-  {                                                                      \
+-    nid, 0, ASN1_ITEM_ref(ASN1_BIT_STRING), 0, 0, 0, 0, 0, 0,            \
+-        (X509V3_EXT_I2V)i2v_ASN1_BIT_STRING,                             \
+-        (X509V3_EXT_V2I)v2i_ASN1_BIT_STRING, NULL, NULL, (void *)(table) \
+-  }
+-
+-#define EXT_IA5STRING(nid)                                   \
+-  {                                                          \
+-    nid, 0, ASN1_ITEM_ref(ASN1_IA5STRING), 0, 0, 0, 0,       \
+-        (X509V3_EXT_I2S)i2s_ASN1_IA5STRING,                  \
+-        (X509V3_EXT_S2I)s2i_ASN1_IA5STRING, 0, 0, 0, 0, NULL \
+-  }
+-
+-#define EXT_END \
+-  { -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+-
+ 
+ // X509_PURPOSE stuff
+ 
+@@ -474,15 +456,6 @@ OPENSSL_EXPORT GENERAL_NAME *GENERAL_NAME_dup(GENERAL_NAME *a);
+ OPENSSL_EXPORT int GENERAL_NAME_cmp(const GENERAL_NAME *a,
+                                     const GENERAL_NAME *b);
+ 
+-
+-
+-OPENSSL_EXPORT ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
+-                                                    X509V3_CTX *ctx,
+-                                                    STACK_OF(CONF_VALUE) *nval);
+-OPENSSL_EXPORT STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(
+-    X509V3_EXT_METHOD *method, ASN1_BIT_STRING *bits,
+-    STACK_OF(CONF_VALUE) *extlist);
+-
+ // i2v_GENERAL_NAME serializes |gen| as a |CONF_VALUE|. If |ret| is non-NULL, it
+ // appends the value to |ret| and returns |ret| on success or NULL on error. If
+ // it returns NULL, the caller is still responsible for freeing |ret|. If |ret|
+@@ -493,7 +466,8 @@ OPENSSL_EXPORT STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(
+ // human-readable print functions. If extracting a SAN list from a certificate,
+ // look at |gen| directly.
+ OPENSSL_EXPORT STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(
+-    X509V3_EXT_METHOD *method, GENERAL_NAME *gen, STACK_OF(CONF_VALUE) *ret);
++    const X509V3_EXT_METHOD *method, GENERAL_NAME *gen,
++    STACK_OF(CONF_VALUE) *ret);
+ OPENSSL_EXPORT int GENERAL_NAME_print(BIO *out, GENERAL_NAME *gen);
+ 
+ DECLARE_ASN1_FUNCTIONS(GENERAL_NAMES)
+@@ -508,7 +482,7 @@ DECLARE_ASN1_FUNCTIONS(GENERAL_NAMES)
+ // human-readable print functions. If extracting a SAN list from a certificate,
+ // look at |gen| directly.
+ OPENSSL_EXPORT STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(
+-    X509V3_EXT_METHOD *method, GENERAL_NAMES *gen,
++    const X509V3_EXT_METHOD *method, GENERAL_NAMES *gen,
+     STACK_OF(CONF_VALUE) *extlist);
+ OPENSSL_EXPORT GENERAL_NAMES *v2i_GENERAL_NAMES(const X509V3_EXT_METHOD *method,
+                                                 X509V3_CTX *ctx,
+@@ -527,10 +501,10 @@ OPENSSL_EXPORT int GENERAL_NAME_get0_otherName(const GENERAL_NAME *gen,
+                                                ASN1_OBJECT **poid,
+                                                ASN1_TYPE **pvalue);
+ 
+-OPENSSL_EXPORT char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
++OPENSSL_EXPORT char *i2s_ASN1_OCTET_STRING(const X509V3_EXT_METHOD *method,
+                                            const ASN1_OCTET_STRING *ia5);
+ OPENSSL_EXPORT ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(
+-    X509V3_EXT_METHOD *method, X509V3_CTX *ctx, const char *str);
++    const X509V3_EXT_METHOD *method, X509V3_CTX *ctx, const char *str);
+ 
+ DECLARE_ASN1_FUNCTIONS(EXTENDED_KEY_USAGE)
+ OPENSSL_EXPORT int i2a_ACCESS_DESCRIPTION(BIO *bp, const ACCESS_DESCRIPTION *a);
+@@ -649,14 +623,12 @@ OPENSSL_EXPORT int X509V3_add_value_int(const char *name,
+                                         const ASN1_INTEGER *aint,
+                                         STACK_OF(CONF_VALUE) **extlist);
+ 
+-OPENSSL_EXPORT char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *meth,
++OPENSSL_EXPORT char *i2s_ASN1_INTEGER(const X509V3_EXT_METHOD *meth,
+                                       const ASN1_INTEGER *aint);
+-OPENSSL_EXPORT ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *meth,
++OPENSSL_EXPORT ASN1_INTEGER *s2i_ASN1_INTEGER(const X509V3_EXT_METHOD *meth,
+                                               const char *value);
+-OPENSSL_EXPORT char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *meth,
++OPENSSL_EXPORT char *i2s_ASN1_ENUMERATED(const X509V3_EXT_METHOD *meth,
+                                          const ASN1_ENUMERATED *aint);
+-OPENSSL_EXPORT char *i2s_ASN1_ENUMERATED_TABLE(X509V3_EXT_METHOD *meth,
+-                                               const ASN1_ENUMERATED *aint);
+ OPENSSL_EXPORT int X509V3_EXT_add(X509V3_EXT_METHOD *ext);
+ OPENSSL_EXPORT int X509V3_EXT_add_list(X509V3_EXT_METHOD *extlist);
+ OPENSSL_EXPORT int X509V3_EXT_add_alias(int nid_to, int nid_from);
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/patches/0007-Fix-build-with-MSVC-2022.patch
+++ b/ports/boringssl/patches/0007-Fix-build-with-MSVC-2022.patch
@@ -1,0 +1,370 @@
+From 8053a3a9951a6ad402d24bbb845985aa33a950b2 Mon Sep 17 00:00:00 2001
+From: David Benjamin <davidben@google.com>
+Date: Sun, 12 Jun 2022 13:47:08 -0400
+Subject: [PATCH] Fix build with MSVC 2022.
+
+MSVC 2022's C4191 warns on most function pointer casts. Fix and/or
+silence them:
+
+connect.c is an unavoidable false positive. We're casting the pointer to
+the correct type. The problem was that the caller is required to first
+cast it to the wrong type in OpenSSL's API, due to the BIO_callback_ctrl
+calling convention. Suppress it.
+
+LHASH_OF(T) and STACK_OF(T)'s defintions also have a false positive.
+Suppress that warning. Calling the functions through the casted types
+would indeed be UB, but we don't do that. We use them as goofy
+type-erased types. The problem is there is no function pointer
+equivalent of void*. (Using actual void* instead trips a GCC warning.)
+
+The sk_sort instance is a true instance of UB. The problem is qsort
+lacks a context parameter. I've made sk_sort call qsort_s on _MSC_VER,
+to silence the warning. Ideally we'd fix it on other platforms, but
+qsort_r and qsort_s are a disaster. See
+https://stackoverflow.com/a/39561369
+
+Fixed: 495
+Change-Id: I0dca80670c74afaa03fc5c8fd7059b4cfadfac72
+Reviewed-on: https://boringssl-review.googlesource.com/c/boringssl/+/53005
+Reviewed-by: Adam Langley <agl@google.com>
+Commit-Queue: Adam Langley <agl@google.com>
+---
+ crypto/bio/connect.c    | 12 +++++--
+ crypto/lhash/internal.h | 14 ++++++++-
+ crypto/stack/stack.c    | 49 +++++++++++++++++++----------
+ include/openssl/stack.h | 69 +++++++++++++++++++++++++++--------------
+ 4 files changed, 101 insertions(+), 43 deletions(-)
+
+diff --git a/crypto/bio/connect.c b/crypto/bio/connect.c
+index 3b65acfca..9b86e5138 100644
+--- a/crypto/bio/connect.c
++++ b/crypto/bio/connect.c
+@@ -117,7 +117,8 @@ static int closesocket(int sock) {
+ // split_host_and_port sets |*out_host| and |*out_port| to the host and port
+ // parsed from |name|. It returns one on success or zero on error. Even when
+ // successful, |*out_port| may be NULL on return if no port was specified.
+-static int split_host_and_port(char **out_host, char **out_port, const char *name) {
++static int split_host_and_port(char **out_host, char **out_port,
++                               const char *name) {
+   const char *host, *port = NULL;
+   size_t host_len = 0;
+ 
+@@ -466,8 +467,7 @@ static long conn_ctrl(BIO *bio, int cmd, long num, void *ptr) {
+     case BIO_CTRL_FLUSH:
+       break;
+     case BIO_CTRL_GET_CALLBACK: {
+-      int (**fptr)(const BIO *bio, int state, int xret);
+-      fptr = (int (**)(const BIO *bio, int state, int xret))ptr;
++      int (**fptr)(const BIO *bio, int state, int xret) = ptr;
+       *fptr = data->info_callback;
+     } break;
+     default:
+@@ -485,7 +485,13 @@ static long conn_callback_ctrl(BIO *bio, int cmd, bio_info_cb fp) {
+ 
+   switch (cmd) {
+     case BIO_CTRL_SET_CALLBACK:
++      // This is the actual type signature of |fp|. The caller is expected to
++      // cast it to |bio_info_cb| due to the |BIO_callback_ctrl| calling
++      // convention.
++      OPENSSL_MSVC_PRAGMA(warning(push))
++      OPENSSL_MSVC_PRAGMA(warning(disable : 4191))
+       data->info_callback = (int (*)(const struct bio_st *, int, int))fp;
++      OPENSSL_MSVC_PRAGMA(warning(pop))
+       break;
+     default:
+       ret = 0;
+diff --git a/crypto/lhash/internal.h b/crypto/lhash/internal.h
+index 64dca1d36..512f06df4 100644
+--- a/crypto/lhash/internal.h
++++ b/crypto/lhash/internal.h
+@@ -157,6 +157,16 @@ OPENSSL_EXPORT void OPENSSL_lh_doall_arg(_LHASH *lh,
+                                          void *arg);
+ 
+ #define DEFINE_LHASH_OF(type)                                                  \
++  /* We disable MSVC C4191 in this macro, which warns when pointers are cast   \
++   * to the wrong type. While the cast itself is valid, it is often a bug      \
++   * because calling it through the cast is UB. However, we never actually     \
++   * call functions as |lhash_cmp_func|. The type is just a type-erased        \
++   * function pointer. (C does not guarantee function pointers fit in          \
++   * |void*|, and GCC will warn on this.) Thus we just disable the false       \
++   * positive warning. */                                                      \
++  OPENSSL_MSVC_PRAGMA(warning(push))                                           \
++  OPENSSL_MSVC_PRAGMA(warning(disable : 4191))                                 \
++                                                                               \
+   DECLARE_LHASH_OF(type)                                                       \
+                                                                                \
+   typedef int (*lhash_##type##_cmp_func)(const type *, const type *);          \
+@@ -243,7 +253,9 @@ OPENSSL_EXPORT void OPENSSL_lh_doall_arg(_LHASH *lh,
+       LHASH_OF(type) *lh, void (*func)(type *, void *), void *arg) {           \
+     LHASH_DOALL_##type cb = {func, arg};                                       \
+     OPENSSL_lh_doall_arg((_LHASH *)lh, lh_##type##_call_doall_arg, &cb);       \
+-  }
++  }                                                                            \
++                                                                               \
++  OPENSSL_MSVC_PRAGMA(warning(pop))
+ 
+ 
+ #if defined(__cplusplus)
+diff --git a/crypto/stack/stack.c b/crypto/stack/stack.c
+index 6da6e3b23..6412e07bd 100644
+--- a/crypto/stack/stack.c
++++ b/crypto/stack/stack.c
+@@ -131,7 +131,7 @@ void sk_free(_STACK *sk) {
+   OPENSSL_free(sk);
+ }
+ 
+-void sk_pop_free_ex(_STACK *sk, void (*call_free_func)(stack_free_func, void *),
++void sk_pop_free_ex(_STACK *sk, stack_call_free_func call_free_func,
+                     stack_free_func free_func) {
+   if (sk == NULL) {
+     return;
+@@ -234,8 +234,7 @@ void *sk_delete_ptr(_STACK *sk, const void *p) {
+ }
+ 
+ int sk_find(const _STACK *sk, size_t *out_index, const void *p,
+-            int (*call_cmp_func)(stack_cmp_func, const void **,
+-                                 const void **)) {
++            stack_call_cmp_func call_cmp_func) {
+   if (sk == NULL) {
+     return 0;
+   }
+@@ -355,24 +354,43 @@ err:
+   return NULL;
+ }
+ 
+-void sk_sort(_STACK *sk) {
++#if defined(_MSC_VER)
++struct sort_compare_ctx {
++  stack_call_cmp_func call_cmp_func;
++  stack_cmp_func cmp_func;
++};
++
++static int sort_compare(void *ctx_v, const void *a, const void *b) {
++  struct sort_compare_ctx *ctx = ctx_v;
++  return ctx->call_cmp_func(ctx->cmp_func, a, b);
++}
++#endif
++
++void sk_sort(_STACK *sk, stack_call_cmp_func call_cmp_func) {
+   if (sk == NULL || sk->comp == NULL || sk->sorted) {
+     return;
+   }
+ 
+-  // sk->comp is a function that takes pointers to pointers to elements, but
+-  // qsort take a comparison function that just takes pointers to elements.
+-  // However, since we're passing an array of pointers to qsort, we can just
+-  // cast the comparison function and everything works.
+-  //
+-  // TODO(davidben): This is undefined behavior, but the call is in libc so,
+-  // e.g., CFI does not notice. Unfortunately, |qsort| is missing a void*
+-  // parameter in its callback and |qsort_s| / |qsort_r| are a mess of
+-  // incompatibility.
+   if (sk->num >= 2) {
++#if defined(_MSC_VER)
++    // MSVC's |qsort_s| is different from the C11 one.
++    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/qsort-s?view=msvc-170
++    struct sort_compare_ctx ctx = {call_cmp_func, sk->comp};
++    qsort_s(sk->data, sk->num, sizeof(void *), sort_compare, &ctx);
++#else
++    // sk->comp is a function that takes pointers to pointers to elements, but
++    // qsort take a comparison function that just takes pointers to elements.
++    // However, since we're passing an array of pointers to qsort, we can just
++    // cast the comparison function and everything works.
++    //
++    // TODO(davidben): This is undefined behavior, but the call is in libc so,
++    // e.g., CFI does not notice. |qsort| is missing a void* parameter in its
++    // callback, while no one defines |qsort_r| or |qsort_s| consistently. See
++    // https://stackoverflow.com/a/39561369
+     int (*comp_func)(const void *, const void *) =
+         (int (*)(const void *, const void *))(sk->comp);
+     qsort(sk->data, sk->num, sizeof(void *), comp_func);
++#endif
+   }
+   sk->sorted = 1;
+ }
+@@ -395,10 +413,9 @@ stack_cmp_func sk_set_cmp_func(_STACK *sk, stack_cmp_func comp) {
+   return old;
+ }
+ 
+-_STACK *sk_deep_copy(const _STACK *sk,
+-                     void *(*call_copy_func)(stack_copy_func, void *),
++_STACK *sk_deep_copy(const _STACK *sk, stack_call_copy_func call_copy_func,
+                      stack_copy_func copy_func,
+-                     void (*call_free_func)(stack_free_func, void *),
++                     stack_call_free_func call_free_func,
+                      stack_free_func free_func) {
+   _STACK *ret = sk_dup(sk);
+   if (ret == NULL) {
+diff --git a/include/openssl/stack.h b/include/openssl/stack.h
+index 04e942cb9..595a135eb 100644
+--- a/include/openssl/stack.h
++++ b/include/openssl/stack.h
+@@ -101,10 +101,20 @@ typedef void *(*stack_copy_func)(void *ptr);
+ // extra indirection - the function is given a pointer to a pointer to the
+ // element. This differs from the usual qsort/bsearch comparison function.
+ //
+-// Note its actual type is int (*)(const T **, const T **). Low-level |sk_*|
++// Note its actual type is |int (*)(const T **a, const T **b)|. Low-level |sk_*|
+ // functions will be passed a type-specific wrapper to call it correctly.
++//
++// TODO(davidben): This type should be |const T *const *|. It is already fixed
++// in OpenSSL 1.1.1, so hopefully we can fix this compatibly.
+ typedef int (*stack_cmp_func)(const void **a, const void **b);
+ 
++// The following function types call the above type-erased signatures with the
++// true types.
++typedef void (*stack_call_free_func)(stack_free_func, void *);
++typedef void *(*stack_call_copy_func)(stack_copy_func, void *);
++typedef int (*stack_call_cmp_func)(stack_cmp_func, const void *const *,
++                                   const void *const *);
++
+ // stack_st contains an array of pointers. It is not designed to be used
+ // directly, rather the wrapper macros should be used.
+ typedef struct stack_st {
+@@ -161,8 +171,7 @@ OPENSSL_EXPORT void sk_free(_STACK *sk);
+ // |sk_pop_free_ex| as a workaround for existing code calling an older version
+ // of |sk_pop_free|.
+ OPENSSL_EXPORT void sk_pop_free_ex(_STACK *sk,
+-                                   void (*call_free_func)(stack_free_func,
+-                                                          void *),
++                                   stack_call_free_func call_free_func,
+                                    stack_free_func free_func);
+ 
+ // sk_insert inserts |p| into the stack at index |where|, moving existing
+@@ -192,8 +201,7 @@ OPENSSL_EXPORT void *sk_delete_ptr(_STACK *sk, const void *p);
+ // OpenSSL's sk_find will implicitly sort |sk| if it has a comparison function
+ // defined.
+ OPENSSL_EXPORT int sk_find(const _STACK *sk, size_t *out_index, const void *p,
+-                           int (*call_cmp_func)(stack_cmp_func, const void **,
+-                                                const void **));
++                           stack_call_cmp_func call_cmp_func);
+ 
+ // sk_shift removes and returns the first element in the stack, or returns NULL
+ // if the stack is empty.
+@@ -214,7 +222,7 @@ OPENSSL_EXPORT _STACK *sk_dup(const _STACK *sk);
+ // sk_sort sorts the elements of |sk| into ascending order based on the
+ // comparison function. The stack maintains a |sorted| flag and sorting an
+ // already sorted stack is a no-op.
+-OPENSSL_EXPORT void sk_sort(_STACK *sk);
++OPENSSL_EXPORT void sk_sort(_STACK *sk, stack_call_cmp_func call_cmp_func);
+ 
+ // sk_is_sorted returns one if |sk| is known to be sorted and zero
+ // otherwise.
+@@ -227,10 +235,11 @@ OPENSSL_EXPORT stack_cmp_func sk_set_cmp_func(_STACK *sk, stack_cmp_func comp);
+ // sk_deep_copy performs a copy of |sk| and of each of the non-NULL elements in
+ // |sk| by using |copy_func|. If an error occurs, |free_func| is used to free
+ // any copies already made and NULL is returned.
+-OPENSSL_EXPORT _STACK *sk_deep_copy(
+-    const _STACK *sk, void *(*call_copy_func)(stack_copy_func, void *),
+-    stack_copy_func copy_func, void (*call_free_func)(stack_free_func, void *),
+-    stack_free_func free_func);
++OPENSSL_EXPORT _STACK *sk_deep_copy(const _STACK *sk,
++                                    stack_call_copy_func call_copy_func,
++                                    stack_copy_func copy_func,
++                                    stack_call_free_func call_free_func,
++                                    stack_free_func free_func);
+ 
+ 
+ // Deprecated functions.
+@@ -277,6 +286,16 @@ BSSL_NAMESPACE_END
+ #endif
+ 
+ #define BORINGSSL_DEFINE_STACK_OF_IMPL(name, ptrtype, constptrtype)            \
++  /* We disable MSVC C4191 in this macro, which warns when pointers are cast   \
++   * to the wrong type. While the cast itself is valid, it is often a bug      \
++   * because calling it through the cast is UB. However, we never actually     \
++   * call functions as |stack_cmp_func|. The type is just a type-erased        \
++   * function pointer. (C does not guarantee function pointers fit in          \
++   * |void*|, and GCC will warn on this.) Thus we just disable the false       \
++   * positive warning. */                                                      \
++  OPENSSL_MSVC_PRAGMA(warning(push))                                           \
++  OPENSSL_MSVC_PRAGMA(warning(disable : 4191))                                 \
++                                                                               \
+   DECLARE_STACK_OF(name)                                                       \
+                                                                                \
+   typedef void (*stack_##name##_free_func)(ptrtype);                           \
+@@ -294,14 +313,17 @@ BSSL_NAMESPACE_END
+   }                                                                            \
+                                                                                \
+   OPENSSL_INLINE int sk_##name##_call_cmp_func(                                \
+-      stack_cmp_func cmp_func, const void **a, const void **b) {               \
++      stack_cmp_func cmp_func, const void *const *a, const void *const *b) {   \
++    /* The data is actually stored as |void*| pointers, so read the pointer    \
++     * as |void*| and then pass the corrected type into the caller-supplied    \
++     * function, which expects |constptrtype*|. */                             \
+     constptrtype a_ptr = (constptrtype)*a;                                     \
+     constptrtype b_ptr = (constptrtype)*b;                                     \
+     return ((stack_##name##_cmp_func)cmp_func)(&a_ptr, &b_ptr);                \
+   }                                                                            \
+                                                                                \
+-  OPENSSL_INLINE STACK_OF(name) *                                              \
+-      sk_##name##_new(stack_##name##_cmp_func comp) {                          \
++  OPENSSL_INLINE STACK_OF(name) *sk_##name##_new(                              \
++      stack_##name##_cmp_func comp) {                                          \
+     return (STACK_OF(name) *)sk_new((stack_cmp_func)comp);                     \
+   }                                                                            \
+                                                                                \
+@@ -327,12 +349,12 @@ BSSL_NAMESPACE_END
+     return (ptrtype)sk_set((_STACK *)sk, i, (void *)p);                        \
+   }                                                                            \
+                                                                                \
+-  OPENSSL_INLINE void sk_##name##_free(STACK_OF(name) * sk) {                  \
++  OPENSSL_INLINE void sk_##name##_free(STACK_OF(name) *sk) {                   \
+     sk_free((_STACK *)sk);                                                     \
+   }                                                                            \
+                                                                                \
+   OPENSSL_INLINE void sk_##name##_pop_free(                                    \
+-      STACK_OF(name) * sk, stack_##name##_free_func free_func) {               \
++      STACK_OF(name) *sk, stack_##name##_free_func free_func) {                \
+     sk_pop_free_ex((_STACK *)sk, sk_##name##_call_free_func,                   \
+                    (stack_free_func)free_func);                                \
+   }                                                                            \
+@@ -353,7 +375,7 @@ BSSL_NAMESPACE_END
+   }                                                                            \
+                                                                                \
+   OPENSSL_INLINE int sk_##name##_find(const STACK_OF(name) *sk,                \
+-                                      size_t * out_index, constptrtype p) {    \
++                                      size_t *out_index, constptrtype p) {     \
+     return sk_find((const _STACK *)sk, out_index, (const void *)p,             \
+                    sk_##name##_call_cmp_func);                                 \
+   }                                                                            \
+@@ -370,12 +392,12 @@ BSSL_NAMESPACE_END
+     return (ptrtype)sk_pop((_STACK *)sk);                                      \
+   }                                                                            \
+                                                                                \
+-  OPENSSL_INLINE STACK_OF(name) * sk_##name##_dup(const STACK_OF(name) *sk) {  \
++  OPENSSL_INLINE STACK_OF(name) *sk_##name##_dup(const STACK_OF(name) *sk) {   \
+     return (STACK_OF(name) *)sk_dup((const _STACK *)sk);                       \
+   }                                                                            \
+                                                                                \
+   OPENSSL_INLINE void sk_##name##_sort(STACK_OF(name) *sk) {                   \
+-    sk_sort((_STACK *)sk);                                                     \
++    sk_sort((_STACK *)sk, sk_##name##_call_cmp_func);                          \
+   }                                                                            \
+                                                                                \
+   OPENSSL_INLINE int sk_##name##_is_sorted(const STACK_OF(name) *sk) {         \
+@@ -388,15 +410,16 @@ BSSL_NAMESPACE_END
+                                                     (stack_cmp_func)comp);     \
+   }                                                                            \
+                                                                                \
+-  OPENSSL_INLINE STACK_OF(name) *                                              \
+-      sk_##name##_deep_copy(const STACK_OF(name) *sk,                          \
+-                            ptrtype(*copy_func)(ptrtype),                      \
+-                            void (*free_func)(ptrtype)) {                      \
++  OPENSSL_INLINE STACK_OF(name) *sk_##name##_deep_copy(                        \
++      const STACK_OF(name) *sk, ptrtype (*copy_func)(ptrtype),                 \
++      void (*free_func)(ptrtype)) {                                            \
+     return (STACK_OF(name) *)sk_deep_copy(                                     \
+         (const _STACK *)sk, sk_##name##_call_copy_func,                        \
+         (stack_copy_func)copy_func, sk_##name##_call_free_func,                \
+         (stack_free_func)free_func);                                           \
+-  }
++  }                                                                            \
++                                                                               \
++  OPENSSL_MSVC_PRAGMA(warning(pop))
+ 
+ // DEFINE_NAMED_STACK_OF defines |STACK_OF(name)| to be a stack whose elements
+ // are |type| *.
+-- 
+2.37.0.windows.1
+

--- a/ports/boringssl/portfile.cmake
+++ b/ports/boringssl/portfile.cmake
@@ -1,0 +1,65 @@
+if (EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
+    message(FATAL_ERROR "Can't build BoringSSL if OpenSSL is installed. Please remove OpenSSL, and try to install BoringSSL again if you need it. Build will continue since BoringSSL is a drop-in replacement for OpenSSL")
+endif()
+
+# BoringSSL doesn't have releases so use the commit used by ngtcp2 to test
+# https://github.com/ngtcp2/ngtcp2/blob/main/ci/build_boringssl.sh
+set(VERSION 27ffcc6e19bbafddf1b59ec0bc6df2904de7eb2c)
+
+# Patches
+set(PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Find-threading-library.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Make-gtest-library-static.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Make-building-tests-optional.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0004-Make-building-tools-optional.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0005-Add-install-targets.patch
+    # Remove after 2022-06-12 version
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0006-Use-the-correct-function-types-in-X509V3_EXT_METHODs.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0007-Fix-build-with-MSVC-2022.patch
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/boringssl
+    REF ${VERSION}
+    SHA512 b20b97c61a31861c4f210e90f7908f5bad5f5238c882ab14aa1d5e46e26aa4aa3cda3171e9e050f114fe453a040b7785eda5404189727db1835e5e2655b66c54
+    PATCHES ${PATCHES}
+)
+
+# Install tools
+vcpkg_find_acquire_program(PERL)
+get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
+vcpkg_add_to_path(${PERL_EXE_PATH})
+
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+vcpkg_add_to_path(${NASM_EXE_PATH})
+
+vcpkg_find_acquire_program(GO)
+get_filename_component(GO_EXE_PATH ${GO} DIRECTORY)
+vcpkg_add_to_path(${GO_EXE_PATH})
+
+if (tools IN_LIST FEATURES)
+    set(ENABLE_TOOLS ON)
+else ()
+    set(ENABLE_TOOLS OFF)
+endif ()
+
+# Run CMake build
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DENABLE_TOOLS=${ENABLE_TOOLS}
+    OPTIONS_DEBUG
+        -DENABLE_TOOLS=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+# Prepare distribution
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/boringssl RENAME copyright)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/boringssl/version ${VERSION})


### PR DESCRIPTION
Fleshes out a port of BoringSSL for WebKit use in order to enable HTTP/3. Targets the latest version referenced by ngtcp2 repositories which will be used as the backend for HTTP/3 in cURL.

Build modified to install targets and to toggle on and off testing and tooling.

Some additional patches were added that address compilation errors in MSVC 2022. Those can be removed at a later date.