### PR TITLE
Support building curl with boringssl

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -8,6 +8,12 @@ Build-Depends: c-ares
 Description: |
   Enable c-ares for asynchronous DNS requests.
 
+Feature: boringssl
+Build-Depends: boringssl
+Description: |
+  SSL support through boringssl. If no SSL libraries are specified then the
+  system SSL library will be used.
+
 Feature: ca-bundle
 Description: |
   Use the provided certificate bundle.

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -111,7 +111,7 @@ endif ()
 # Each port of an OpenSSL equivalent checks to see that no other variant is installed so
 # just check to see if any OpenSSL variants are requested and if not use the system one
 set(USE_OPENSSL ON)
-if (NOT libressl IN_LIST FEATURES)
+if (NOT libressl IN_LIST FEATURES AND NOT boringssl IN_LIST FEATURES)
     message(STATUS "Using system SSL library")
 
     if (VCPKG_WINDOWS)


### PR DESCRIPTION
Add a feature define for using boringssl. Check for libressl or boringssl when determining if the system SSL library is being used.