### PR TITLE
Add nghttp3 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | [brotli](https://github.com/google/brotli) | 1.0.9 | 2020-08-27 |
 | [libressl](https://www.libressl.org) | 3.5.2 | 2022-04-23 |
 | [nghttp2](https://nghttp2.org) | 1.48.0 | 2022-06-24 |
+| [nghttp3](https://github.com/ngtcp2/nghttp3) | 0.5.0 | 2022-06-20 |
 | [c-ares](https://c-ares.org) | 1.18.1 | 2021-10-27 |
 | [curl](https://curl.se) | 7.84.0 | 2022-06-27 |
 | [libxml2](http://xmlsoft.org/) | 2.9.14 | 2022-05-02 |

--- a/ports/nghttp3/CONTROL
+++ b/ports/nghttp3/CONTROL
@@ -1,0 +1,3 @@
+Source: nghttp3
+Version: 0.5.0
+Description: An implementation of HTTP/3 mapping over QUIC and QPACK in C.

--- a/ports/nghttp3/portfile.cmake
+++ b/ports/nghttp3/portfile.cmake
@@ -1,0 +1,51 @@
+set(VERSION 0.5.0)
+
+# Get archive
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/ngtcp2/nghttp3/releases/download/v${VERSION}/nghttp3-${VERSION}.tar.bz2"
+    FILENAME "nghttp3-${VERSION}.tar.bz2"
+    SHA512 dce1f70091fc61946550a85072054d8e4136fb027b2fb187ae7823616c7c5a37c6abae332e16a78a38480be7b99f09ac37d031facb4323d06017e80d1affee15
+)
+
+# Extract archive
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${VERSION}
+    PATCHES ${PATCHES}
+)
+
+# Run CMake build
+set(BUILD_OPTIONS
+    # ENABLE options
+    -DENABLE_LIB_ONLY=ON
+)
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES static)
+    set(NGHTTP3_SHARED_LIB OFF)
+    set(NGHTTP3_STATIC_LIB ON)
+else ()
+    set(NGHTTP3_SHARED_LIB ON)
+    set(NGHTTP3_STATIC_LIB OFF)
+endif ()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        ${BUILD_OPTIONS}
+        -DENABLE_SHARED_LIB=${NGHTTP3_SHARED_LIB}
+        -DENABLE_STATIC_LIB=${NGHTTP3_STATIC_LIB}
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+# Prepare distribution
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/man)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/nghttp3 RENAME copyright)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/nghttp3/version ${VERSION})


### PR DESCRIPTION
The nghttp3 library will be used to enable HTTP/3 in curl.