### PR TITLE
Prevent -d postfix on built products

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -23,6 +23,8 @@ vcpkg_extract_source_archive_ex(
 
 # Run CMake build
 set(BUILD_OPTIONS
+    # Remove debug postfix (prevent -d postfix on built products)
+    -DCMAKE_DEBUG_POSTFIX=
     # BUILD options
     -DBUILD_CURL_EXE=OFF
     -DBUILD_TESTING=OFF


### PR DESCRIPTION
In curl the debug builds have a -d suffix on their names. The names for release and debug products should be the same to allow them to be easily swapped.