### PR TITLE
Add ngtcp2 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ the requirements.
 | [libressl](https://www.libressl.org) | 3.5.2 | 2022-04-23 |
 | [nghttp2](https://nghttp2.org) | 1.48.0 | 2022-06-24 |
 | [nghttp3](https://github.com/ngtcp2/nghttp3) | 0.5.0 | 2022-06-20 |
+| [ngtcp2](https://github.com/ngtcp2/ngtcp2) | 0.6.0 | 2022-06-20 |
 | [c-ares](https://c-ares.org) | 1.18.1 | 2021-10-27 |
 | [curl](https://curl.se) | 7.84.0 | 2022-06-27 |
 | [libxml2](http://xmlsoft.org/) | 2.9.14 | 2022-05-02 |

--- a/ports/ngtcp2/CONTROL
+++ b/ports/ngtcp2/CONTROL
@@ -1,0 +1,4 @@
+Source: ngtcp2
+Version: 0.6.0
+Build-Depends: boringssl
+Description: An effort to implement RFC9000 QUIC protocol.

--- a/ports/ngtcp2/patches/0001-Use-find_package-for-boringssl.patch
+++ b/ports/ngtcp2/patches/0001-Use-find_package-for-boringssl.patch
@@ -1,0 +1,34 @@
+From c7a863ec459418019c66457fb70d39986b354852 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Fri, 1 Jul 2022 14:43:37 -0700
+Subject: [PATCH 1/2] Use find_package for boringssl
+
+The ngtcp2 build seems to allow for multiple backends but in vcpkg we only need one. FindOpenSSL can detect BoringSSL so just use that rather than trying to pass in a list of libraries.
+---
+ CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ae1c919..b518bd51 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -132,12 +132,15 @@ endif()
+ 
+ # BoringSSL (required for libngtcp2_crypto_boringssl)
+ if(ENABLE_BORINGSSL)
++  find_package(OpenSSL REQUIRED)
++  set(BORINGSSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
++  set(BORINGSSL_LIBRARIES ${OPENSSL_LIBRARIES})
+   cmake_push_check_state()
+   set(CMAKE_REQUIRED_INCLUDES   "${BORINGSSL_INCLUDE_DIR}")
+   set(CMAKE_REQUIRED_LIBRARIES  "${BORINGSSL_LIBRARIES}")
+   check_symbol_exists(SSL_set_quic_early_data_context "openssl/ssl.h" HAVE_SSL_SET_QUIC_EARLY_DATA_CONTEXT)
+   if(NOT HAVE_SSL_SET_QUIC_EARLY_DATA_CONTEXT)
+-    message(WARNING "Disabling BoringSSL due to lack of QUIC support in ${BORINGSSL_LIBRARIES}")
++    message(FATAL_ERROR "Disabling BoringSSL due to lack of QUIC support in libraries at ${BORINGSSL_LIBRARIES} and incudes at ${BORINGSSL_INCLUDE_DIR}")
+   endif()
+   cmake_pop_check_state()
+ endif()
+-- 
+2.37.0.windows.1
+

--- a/ports/ngtcp2/patches/0002-Add-a-shared-ngtcp2_crypto_boringssl-target.patch
+++ b/ports/ngtcp2/patches/0002-Add-a-shared-ngtcp2_crypto_boringssl-target.patch
@@ -1,0 +1,43 @@
+From 68675d2ad057bbdcf8bfd54cd4f5d525b6fb83c3 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Mon, 27 Jun 2022 18:34:05 -0700
+Subject: [PATCH 2/2] Add a shared ngtcp2_crypto_boringssl target
+
+---
+ crypto/boringssl/CMakeLists.txt | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/crypto/boringssl/CMakeLists.txt b/crypto/boringssl/CMakeLists.txt
+index ebaae3de..004fb6a9 100644
+--- a/crypto/boringssl/CMakeLists.txt
++++ b/crypto/boringssl/CMakeLists.txt
+@@ -43,6 +43,26 @@ foreach(name libngtcp2_crypto_boringssl.pc)
+   configure_file("${name}.in" "${name}" @ONLY)
+ endforeach()
+ 
++# Public shared library
++if(ENABLE_SHARED_LIB)
++  add_library(ngtcp2_crypto_boringssl SHARED ${ngtcp2_crypto_boringssl_SOURCES})
++  set_target_properties(ngtcp2_crypto_boringssl PROPERTIES
++    COMPILE_FLAGS "${WARNCFLAGS}"
++    VERSION ${LT_VERSION}
++    SOVERSION ${LT_VERSION}
++    C_VISIBILITY_PRESET hidden
++    POSITION_INDEPENDENT_CODE ON
++  )
++  target_include_directories(ngtcp2_crypto_boringssl PUBLIC
++    ${ngtcp2_crypto_boringssl_INCLUDE_DIRS})
++  target_link_libraries(ngtcp2_crypto_boringssl ngtcp2 ${BORINGSSL_LIBRARIES})
++
++  install(TARGETS ngtcp2_crypto_boringssl
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++endif()
++
+ if(ENABLE_STATIC_LIB)
+   # Public static library
+   add_library(ngtcp2_crypto_boringssl_static ${ngtcp2_crypto_boringssl_SOURCES})
+-- 
+2.37.0.windows.1
+

--- a/ports/ngtcp2/patches/0003-Define-WIN32_LEAN_AND_MEAN-before-ws2tcpip.h.patch
+++ b/ports/ngtcp2/patches/0003-Define-WIN32_LEAN_AND_MEAN-before-ws2tcpip.h.patch
@@ -1,0 +1,42 @@
+From 9a5c51a3c56c089890832560e27cf1d46795c255 Mon Sep 17 00:00:00 2001
+From: Don <don.j.olmstead@gmail.com>
+Date: Tue, 28 Jun 2022 12:18:32 -0700
+Subject: [PATCH] Define WIN32_LEAN_AND_MEAN before ws2tcpip.h
+
+Including `ws2tcpip.h` ends up including `wincrypt.h` which defines symbols which collide with OpenSSL structures, such as `X509_NAME`, unless `WIN32_LEAN_AND_MEAN` is present.
+---
+ crypto/includes/ngtcp2/ngtcp2_crypto.h | 3 +++
+ lib/includes/ngtcp2/ngtcp2.h           | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/crypto/includes/ngtcp2/ngtcp2_crypto.h b/crypto/includes/ngtcp2/ngtcp2_crypto.h
+index d0df5dfe..7ddba40d 100644
+--- a/crypto/includes/ngtcp2/ngtcp2_crypto.h
++++ b/crypto/includes/ngtcp2/ngtcp2_crypto.h
+@@ -32,6 +32,9 @@ extern "C" {
+ #endif
+ 
+ #ifdef WIN32
++#  ifndef WIN32_LEAN_AND_MEAN
++#    define WIN32_LEAN_AND_MEAN
++#  endif
+ #  include <ws2tcpip.h>
+ #endif /* WIN32 */
+ 
+diff --git a/lib/includes/ngtcp2/ngtcp2.h b/lib/includes/ngtcp2/ngtcp2.h
+index a896decf..d29a45fd 100644
+--- a/lib/includes/ngtcp2/ngtcp2.h
++++ b/lib/includes/ngtcp2/ngtcp2.h
+@@ -52,6 +52,9 @@
+ 
+ #ifndef NGTCP2_USE_GENERIC_SOCKADDR
+ #  ifdef WIN32
++#    ifndef WIN32_LEAN_AND_MEAN
++#      define WIN32_LEAN_AND_MEAN
++#    endif
+ #    include <ws2tcpip.h>
+ #  else
+ #    include <sys/socket.h>
+-- 
+2.37.0.windows.1
+

--- a/ports/ngtcp2/patches/0004-fix-ngtcp2_htons-for-windows.patch
+++ b/ports/ngtcp2/patches/0004-fix-ngtcp2_htons-for-windows.patch
@@ -1,0 +1,22 @@
+From ebb51f12bb7c0075b1031d7db9de45ab6d52e8bc Mon Sep 17 00:00:00 2001
+From: rhoxn <63946344+rhoxn@users.noreply.github.com>
+Date: Wed, 29 Jun 2022 12:28:40 +0900
+Subject: [PATCH] fix ngtcp2_htons for windows
+
+---
+ lib/ngtcp2_net.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/ngtcp2_net.h b/lib/ngtcp2_net.h
+index f8d8e518..b1f28096 100644
+--- a/lib/ngtcp2_net.h
++++ b/lib/ngtcp2_net.h
+@@ -101,7 +101,7 @@ STIN uint32_t ngtcp2_htonl(uint32_t hostlong) {
+ STIN uint16_t ngtcp2_htons(uint16_t hostshort) {
+   uint16_t res;
+   unsigned char *p = (unsigned char *)&res;
+-  *p++ = (unsigned char)hostshort >> 8;
++  *p++ = (unsigned char)(hostshort >> 8);
+   *p = hostshort & 0xffu;
+   return res;
+ }

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -1,0 +1,64 @@
+set(VERSION 0.6.0)
+
+# Get archive
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/ngtcp2/ngtcp2/releases/download/v${VERSION}/ngtcp2-${VERSION}.tar.bz2"
+    FILENAME "ngtcp2-${VERSION}.tar.bz2"
+    SHA512 5230bc9abcd7ddd570fa3241d24bc15417a8378c3a3e059f1a7565c74da56e2519538cb33064519ea38b51aef4e460d3377f45d2aa490fcf29867f497c516941
+)
+
+# Patches
+set(PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Use-find_package-for-boringssl.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Add-a-shared-ngtcp2_crypto_boringssl-target.patch
+    # Remove after next release
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0003-Define-WIN32_LEAN_AND_MEAN-before-ws2tcpip.h.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0004-fix-ngtcp2_htons-for-windows.patch
+)
+
+# Extract archive
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${VERSION}
+    PATCHES ${PATCHES}
+)
+
+# Run CMake build
+set(BUILD_OPTIONS
+    # ENABLE options
+    -DENABLE_BORINGSSL=ON
+)
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES static)
+    set(NGTCP2_SHARED_LIB OFF)
+    set(NGTCP2_STATIC_LIB ON)
+else ()
+    set(NGTCP2_SHARED_LIB ON)
+    set(NGTCP2_STATIC_LIB OFF)
+endif ()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        ${BUILD_OPTIONS}
+        -DENABLE_SHARED_LIB=${NGTCP2_SHARED_LIB}
+        -DENABLE_STATIC_LIB=${NGTCP2_STATIC_LIB}
+    OPTIONS_RELEASE
+        -DBORINGSSL_LIBRARIES_ENV=BORINGSSL_LIBRARIES
+    OPTIONS_DEBUG
+        -DBORINGSSL_LIBRARIES_ENV=BORINGSSL_DEBUG_LIBRARIES
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+# Prepare distribution
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/man)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/ngtcp2 RENAME copyright)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/ngtcp2/version ${VERSION})


### PR DESCRIPTION
The ngtcp2 library will be used to enable HTTP/3 in curl.