### PR TITLE
Support multiple ssl backends in ngtcp2

### DIFF
--- a/ports/ngtcp2/CONTROL
+++ b/ports/ngtcp2/CONTROL
@@ -1,4 +1,13 @@
 Source: ngtcp2
 Version: 0.9.0
-Build-Depends: boringssl
 Description: An effort to implement RFC9000 QUIC protocol.
+
+Feature: boringssl
+Build-Depends: boringssl
+Description: |
+  SSL support through boringssl.
+
+Feature: libressl
+Build-Depends: libressl
+Description: |
+  SSL support through libressl.

--- a/ports/ngtcp2/portfile.cmake
+++ b/ports/ngtcp2/portfile.cmake
@@ -22,10 +22,13 @@ vcpkg_extract_source_archive_ex(
 )
 
 # Run CMake build
-set(BUILD_OPTIONS
-    # ENABLE options
-    -DENABLE_BORINGSSL=ON
-)
+if (boringssl IN_LIST FEATURES)
+    set(BUILD_OPTIONS -DENABLE_BORINGSSL=ON)
+elseif (libressl IN_LIST FEATURES)
+    set(BUILD_OPTIONS -DENABLE_OPENSSL=ON)
+else ()
+    message(FATAL_ERROR "No SSL backend specified")
+endif ()
 
 if (VCPKG_LIBRARY_LINKAGE MATCHES static)
     set(NGTCP2_SHARED_LIB OFF)


### PR DESCRIPTION
With the 3.6.0 release libressl now has support for the QUIC APIs needed by ngtcp2. Add the option to compile with either the libressl or boringssl port.