### PR TITLE
cairo: Added a patch of cherry-pick for WebKit bug#248299

### DIFF
--- a/ports/cairo/patches/0005-Fix-scaled_glyph-hash-lookup-on-Win64.patch
+++ b/ports/cairo/patches/0005-Fix-scaled_glyph-hash-lookup-on-Win64.patch
@@ -1,0 +1,36 @@
+From 1cc23206bde186d4aef948bba11e591120c99dcd Mon Sep 17 00:00:00 2001
+From: Adrian Johnson <ajohnson@redneon.com>
+Date: Sun, 17 Apr 2022 13:49:30 +0930
+Subject: [PATCH] Fix scaled_glyph hash lookup on Win64
+
+This was failing due to sizeof(uintptr_t) != sizeof(long) on Win64
+---
+ src/cairo-scaled-font.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/cairo-scaled-font.c b/src/cairo-scaled-font.c
+index e0b586589..30611dca4 100755
+--- a/src/cairo-scaled-font.c
++++ b/src/cairo-scaled-font.c
+@@ -3001,6 +3001,7 @@ _cairo_scaled_glyph_lookup (cairo_scaled_font_t *scaled_font,
+     cairo_int_status_t		 status = CAIRO_INT_STATUS_SUCCESS;
+     cairo_scaled_glyph_t	*scaled_glyph;
+     cairo_scaled_glyph_info_t	 need_info;
++    cairo_hash_entry_t           key;
+ 
+     *scaled_glyph_ret = NULL;
+ 
+@@ -3019,8 +3020,8 @@ _cairo_scaled_glyph_lookup (cairo_scaled_font_t *scaled_font,
+     /*
+      * Check cache for glyph
+      */
+-    scaled_glyph = _cairo_hash_table_lookup (scaled_font->glyphs,
+-					     (cairo_hash_entry_t *) &index);
++    key.hash = index;
++    scaled_glyph = _cairo_hash_table_lookup (scaled_font->glyphs, &key);
+     if (scaled_glyph == NULL) {
+ 	status = _cairo_scaled_font_allocate_glyph (scaled_font, &scaled_glyph);
+ 	if (unlikely (status))
+-- 
+2.34.1
+

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -14,6 +14,7 @@ set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0002-Rename-stat-to-stats.patch
     ${CMAKE_CURRENT_LIST_DIR}/patches/0003-win32-font-Ignore-GetGlyphOutlineW-failure.patch
     ${CMAKE_CURRENT_LIST_DIR}/patches/0004-Don-t-leave-a-font-face-an-error-state-after-a-scale.patch
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0005-Fix-scaled_glyph-hash-lookup-on-Win64.patch
 )
 
 # Extract archive


### PR DESCRIPTION
WebKit WinCairo port was observing MotionMark Design performance drop since Cairo 1.17.6.

Fix scaled_glyph hash lookup on Win64 · freedesktop/cairo@1cc2320 https://github.com/freedesktop/cairo/commit/1cc23206bde186d4aef948bba11e591120c99dcd

Bug 248299 – [WinCairo] MotionMark Design performance drop by Cairo 1.17.6 https://webkit.org/b/248299