### PR TITLE
Install vcpkg ports locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /scripts/*
 vcpkg.exe
 
+# Ignore vpckg ports
+/ports/vcpkg-*
+
 # Ignore community triplets
 /triplets/*
 !/triplets/x64-windows-webkit.cmake

--- a/Install-Vcpkg.ps1
+++ b/Install-Vcpkg.ps1
@@ -115,5 +115,17 @@ Copy-DirectoryStructure `
    -Path (Join-Path $vcpkgPath -ChildPath 'triplets') `
    -Destination (Join-Path $PSScriptRoot -ChildPath 'triplets');
 
+$portsDir = Join-Path $PSScriptRoot 'ports';
+$vcpkgPortsDir = Join-Path $vcpkgPath 'ports';
+
+$ports = Get-ChildItem -Path $vcpkgPortsDir;
+foreach ($port in $ports) {
+  if ($port.PSIsContainer -and $port.Name.StartsWith('vcpkg-')) {
+    Copy-DirectoryStructure `
+      -Path (Join-Path $vcpkgPortsDir $port.Name) `
+      -Destination (Join-Path $portsDir -ChildPath $port.Name);
+  }
+}
+
 # Restore location
 Set-Location $currentPath;

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation
+Copyright (c) the WebKit for Windows project authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Additional commands for `portfile.cmake` files, such as `vcpkg_cmake_config_fixup`, are being pushed as ports. Search for `vcpkg-*` ports within the vcpkg tree and copy them locally.

Ignore them in git to avoid checking them in.