### PR TITLE
sqlite3: Turn on ENABLE_THREADSAFE

### DIFF
--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_configure_cmake(
         -DENABLE_FTS3=ON
         -DENABLE_LOAD_EXTENSION=OFF
         -DENABLE_RTREE=ON
+        -DENABLE_THREADSAFE=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Windows WebKit was crashing due to sqlite3 multi-threading issue.
<https://github.com/WebKit/WebKit/pull/14904#issuecomment-1588722390>
SQLITE_THREADSAFE should be enabled.
ENABLE_THREADSAFE is the CMake switch to enable it.
