### PR TITLE
Use parallel configure in libxml2

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -79,12 +79,9 @@ else ()
     )
 endif ()
 
-# Disable parallel configure due to configure file writing back into the
-# include directory
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS ${BUILD_OPTIONS}
 )
 


### PR DESCRIPTION
Remove the `DISABLE_PARALLEL_CONFIGURE` option when building libxml2. This was from the previous CMake port of libxml2 and is no longer necessary with the official CMake files.

This is no longer a problem since the official CMake generates `xmlversion.h` into `CMAKE_BINARY_DIR`.