### PR TITLE
Add patch for curl v8.3.0

### DIFF
--- a/ports/curl/patches/0001-h2-testcase-and-fix-for-pausing-h2-streams.patch
+++ b/ports/curl/patches/0001-h2-testcase-and-fix-for-pausing-h2-streams.patch
@@ -1,0 +1,67 @@
+From fb5b9a505c673c8f6c0dc2f636dfc34935496abc Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Fri, 29 Sep 2023 14:17:08 +0200
+Subject: [PATCH] h2: testcase and fix for pausing h2 streams
+
+- refs #11982 where it was noted that paused transfers may
+  close successfully without delivering the complete data
+- made sample poc into tests/http/client/h2-pausing.c and
+  added test_02_27 to reproduce
+
+Closes #11989
+Fixes #11982
+Reported-by: Harry Sintonen
+---
+ lib/transfer.c                  |  23 ++-
+ 1 file changed, 23 insertions(+), 1 deletions(-)
+ create mode 100644 tests/http/clients/h2-pausing.c
+
+diff --git a/lib/transfer.c b/lib/transfer.c
+index d0602b875..548fbb9e3 100644
+--- a/lib/transfer.c
++++ b/lib/transfer.c
+@@ -1050,6 +1050,19 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
+   return CURLE_OK;
+ }
+ 
++static int select_bits_paused(struct Curl_easy *data, int select_bits)
++{
++  /* See issue #11982: we really need to be careful not to progress
++   * a transfer direction when that direction is paused. Not all parts
++   * of our state machine are handling PAUSED transfers correctly. So, we
++   * do not want to go there.
++   * NOTE: we are only interested in PAUSE, not HOLD. */
++  return (((select_bits & CURL_CSELECT_IN) &&
++           (data->req.keepon & KEEP_RECV_PAUSE)) ||
++          ((select_bits & CURL_CSELECT_OUT) &&
++           (data->req.keepon & KEEP_SEND_PAUSE)));
++}
++
+ /*
+  * Curl_readwrite() is the low-level function to be called when data is to
+  * be read and written to/from the connection.
+@@ -1068,12 +1081,20 @@ CURLcode Curl_readwrite(struct connectdata *conn,
+   int didwhat = 0;
+   int select_bits;
+ 
+-
+   if(data->state.dselect_bits) {
++    if(select_bits_paused(data, data->state.dselect_bits)) {
++      /* leave the bits unchanged, so they'll tell us what to do when
++       * this transfer gets unpaused. */
++      DEBUGF(infof(data, "readwrite, dselect_bits, early return on PAUSED"));
++      result = CURLE_OK;
++      goto out;
++    }
+     select_bits = data->state.dselect_bits;
+     data->state.dselect_bits = 0;
+   }
+   else if(conn->cselect_bits) {
++    /* CAVEAT: adding `select_bits_paused()` check here makes test640 hang
++     * (among others). Which hints at strange state handling in FTP land... */
+     select_bits = conn->cselect_bits;
+     conn->cselect_bits = 0;
+   }
+-- 
+2.42.0.windows.2
+

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -11,6 +11,8 @@ vcpkg_download_distfile(ARCHIVE
 # Patches
 set(PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/patches/0001-Adjust-CMake-for-vcpkg.patch
+    # Remove in next release 8.4.0
+    ${CMAKE_CURRENT_LIST_DIR}/patches/0001-h2-testcase-and-fix-for-pausing-h2-streams.patch
 )
 
 # Extract archive


### PR DESCRIPTION
During testing it was found that content from https://webkit.org would not load in MiniBrowser. A user reported this issue with a reproduction and this patch resolved the issue.