### PR TITLE
Provide pkgconfig files for icu

### DIFF
--- a/ports/icu/pkgconfig/debug/icu-i18n.pc
+++ b/ports/icu/pkgconfig/debug/icu-i18n.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/../tools/icu/debug/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/../include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/../share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/../tools/icu/debug/sbin
+#mandir = ${datarootdir}/man
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Internationalization library
+Name: icu-i18n
+Requires.private: icu-uc
+Libs: "-L${libdir}" -licuind
+

--- a/ports/icu/pkgconfig/debug/icu-io.pc
+++ b/ports/icu/pkgconfig/debug/icu-io.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/../tools/icu/debug/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/../include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/../share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/../tools/icu/debug/sbin
+#mandir = ${datarootdir}/man
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Stream and I/O Library
+Name: icu-io
+Requires.private: icu-i18n
+Libs: "-L${libdir}" -licuiod
+

--- a/ports/icu/pkgconfig/debug/icu-uc.pc
+++ b/ports/icu/pkgconfig/debug/icu-uc.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/../tools/icu/debug/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/../include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/../share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/../tools/icu/debug/sbin
+#mandir = ${datarootdir}/man
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Common and Data libraries
+Name: icu-uc
+Libs: "-L${libdir}" -licuucd
+Libs.private: -licudtd ${baselibs}
+

--- a/ports/icu/pkgconfig/release/icu-i18n.pc
+++ b/ports/icu/pkgconfig/release/icu-i18n.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/tools/icu/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/tools/icu/sbin
+#mandir = ${prefix}/share/icu
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Internationalization library
+Name: icu-i18n
+Requires.private: icu-uc
+Libs: "-L${libdir}" -licuin
+

--- a/ports/icu/pkgconfig/release/icu-io.pc
+++ b/ports/icu/pkgconfig/release/icu-io.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/tools/icu/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/tools/icu/sbin
+#mandir = ${prefix}/share/icu
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Stream and I/O Library
+Name: icu-io
+Requires.private: icu-i18n
+Libs: "-L${libdir}" -licuio
+

--- a/ports/icu/pkgconfig/release/icu-uc.pc
+++ b/ports/icu/pkgconfig/release/icu-uc.pc
@@ -1,0 +1,41 @@
+prefix=${pcfiledir}/../..
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Copyright (C) 2010-2013, International Business Machines Corporation. All Rights Reserved.
+
+# CFLAGS contains only anything end users should set
+CFLAGS = 
+# CXXFLAGS contains only anything end users should set
+CXXFLAGS = 
+# DEFS only contains those UCONFIG_CPPFLAGS which are not auto-set by platform.h
+DEFS = 
+exec_prefix = ${prefix}
+#bindir = ${prefix}/tools/icu/bin
+libdir = ${prefix}/lib
+includedir = ${prefix}/include
+baselibs = -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -lcomdlg32 -ladvapi32
+#datarootdir = ${prefix}/share/icu
+#datadir = ${datarootdir}
+#sbindir = ${prefix}/tools/icu/sbin
+#mandir = ${prefix}/share/icu
+#sysconfdir = ${prefix}/etc
+UNICODE_VERSION=16.0
+ICUPREFIX=icu
+ICULIBSUFFIX=
+LIBICU=lib${ICUPREFIX}
+#SHAREDLIBCFLAGS=-fPIC
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+ICUDATA_NAME = icudt76l
+#ICUPKGDATA_DIR=${prefix}/lib
+#ICUDATA_DIR=${pkgdatadir}
+ICUDESC=International Components for Unicode
+
+Version: 76.1
+Cflags: "-I${includedir}"
+# end of icu.pc.in
+Description: International Components for Unicode: Common and Data libraries
+Name: icu-uc
+Libs: "-L${libdir}" -licuuc
+Libs.private: -licudt ${baselibs}
+

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -61,6 +61,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ICU)
 vcpkg_fixup_pkgconfig()
 
 if (ENABLE_TOOLS)
@@ -109,17 +110,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/sbin)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/sbin)
 
-# Merge cmake configs
-file(COPY
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu
-    PATTERN ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/*.cmake
-)
-file(COPY
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu
-    PATTERN ${CURRENT_PACKAGES_DIR}/lib/cmake/*.cmake
-)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+# Meson requires a pkgconfig file to properly build libraries with ICU
+# The CMake here doesn't create one so just use a generated one
+if (VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/pkgconfig/release DESTINATION ${CURRENT_PACKAGES_DIR}/lib RENAME pkgconfig)
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/pkgconfig/debug DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib RENAME pkgconfig)
+endif ()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu RENAME copyright)
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/icu/version "${VERSION_MAJOR}.${VERSION_MINOR}.0")


### PR DESCRIPTION
The CMake build of ICU does not generate pkgconfig files for icu. Unfortunately both harfbuzz and libpsl use meson which strongly prefers pkgconfig files. CMake modules are supported in meson but it fails to associate debug and release builds properly.

The pkgconfig files were just generated from a autotools install of icu and copied over. On version bumps these will need to be modified.