### PR TITLE
Update icu to v77.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ of third party libraries used in the Windows port of WebKit.
 
 | Library | Version | Release Date | Reason for Overlay |
 |---|:---:|:---:|---|
-| [icu](http://site.icu-project.org) | 76.1 | 2024-10-24 | CMake port. Upstream pinned to 74.1 |
+| [icu](http://site.icu-project.org) | 77.1 | 2025-03-13 | CMake port. Upstream pinned to 74.1 |
 | [zlib](https://github.com/zlib-ng/zlib-ng) | zlib-ng | N/A | Map zlib to zlib-ng |
 | [curl](https://curl.se) | 8.13.0-rc2 | 2025-03-17 | Customization of build options, and release candidates |
 | [cairo](https://gitlab.freedesktop.org/cairo/cairo) | 1.18.2 | 2024-09-01 | CMake port. Will remove when cairo taken out of WebKit |

--- a/ports/icu/patches/0001-Add-CMake-platform.patch
+++ b/ports/icu/patches/0001-Add-CMake-platform.patch
@@ -1,4 +1,4 @@
-From 7e63d74cc82685e08681a24452823cc6b1f8fa8b Mon Sep 17 00:00:00 2001
+From 978fa445319a5982c6d06b46eee8d1fa4cc8e0a7 Mon Sep 17 00:00:00 2001
 From: foopoiuyt <github@zombiestormtrooper.com>
 Date: Tue, 3 Nov 2020 08:58:19 -0800
 Subject: [PATCH 1/2] Add CMake platform
@@ -7,7 +7,7 @@ Modified version of the LibCMaker ICU files.
 ---
  LICENSE_CMakeLists                      |   60 +
  README_CMakeLists.txt                   |  146 +
- source/CMakeLists.txt                   |  175 +
+ source/CMakeLists.txt                   |  167 +
  source/cmake/Config.in.cmake            |  127 +
  source/common/CMakeLists.txt            |   98 +
  source/common_icu_lib_flags.cmake       |  127 +
@@ -56,7 +56,7 @@ Modified version of the LibCMaker ICU files.
  source/tools/makeconv/CMakeLists.txt    |   31 +
  source/tools/pkgdata/CMakeLists.txt     |   35 +
  source/tools/toolutil/CMakeLists.txt    |   59 +
- 51 files changed, 20125 insertions(+)
+ 51 files changed, 20117 insertions(+)
  create mode 100644 LICENSE_CMakeLists
  create mode 100644 README_CMakeLists.txt
  create mode 100644 source/CMakeLists.txt
@@ -329,10 +329,10 @@ index 00000000000..356e81fa505
 +See file 'LICENSE_CMakeLists' for license information.
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
 new file mode 100644
-index 00000000000..81392799232
+index 00000000000..ceb4f8986e7
 --- /dev/null
 +++ b/source/CMakeLists.txt
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,167 @@
 +# Copyright (c) 2018, NikitaFeodonit. All rights reserved.
 +# Copyright (c) 2014, 2018, Ruslan Baratov. All rights reserved.
 +#
@@ -356,15 +356,7 @@ index 00000000000..81392799232
 +# Configure CMake itself
 +# #######################################################################################################
 +
-+if(CMAKE_GENERATOR MATCHES "Visual Studio.*")
-+    message(STATUS "CMake 3.11+ is required for Visual Studio generator.")
-+    cmake_minimum_required(VERSION 3.11)
-+elseif(CMAKE_GENERATOR MATCHES "Xcode")
-+    message(STATUS "CMake 3.12+ is required for Xcode generator.")
-+    cmake_minimum_required(VERSION 3.12)
-+else()
-+    cmake_minimum_required(VERSION 3.4)
-+endif()
++cmake_minimum_required(VERSION 3.12)
 +
 +if(POLICY CMP0067)
 +    # Honor language standard in try_compile() source-file signature. Introduced in CMake 3.8.
@@ -20541,4 +20533,4 @@ index 00000000000..36b15d4783d
 +    DESTINATION "${includedir}"
 +)
 -- 
-2.47.0.windows.1
+2.49.0.windows.1

--- a/ports/icu/patches/0002-Remove-install-suffix-on-Windows.patch
+++ b/ports/icu/patches/0002-Remove-install-suffix-on-Windows.patch
@@ -1,4 +1,4 @@
-From a0a875c2d9c900399a1f54e92ed2c5005251b51f Mon Sep 17 00:00:00 2001
+From b8c2406b2bd0e6d5f0902650ae963637a2be7ccc Mon Sep 17 00:00:00 2001
 From: foopoiuyt <github@zombiestormtrooper.com>
 Date: Tue, 3 Nov 2020 09:02:25 -0800
 Subject: [PATCH 2/2] Remove install suffix on Windows
@@ -27,4 +27,4 @@ index 34688e43176..f1e1ba7b13e 100644
  # Package information
  set(PACKAGE_ICU_DESCRIPTION "International Components for Unicode")
 -- 
-2.47.0.windows.1
+2.49.0.windows.1

--- a/ports/icu/pkgconfig/debug/icu-i18n.pc
+++ b/ports/icu/pkgconfig/debug/icu-i18n.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Internationalization library
 Name: icu-i18n
 Requires.private: icu-uc
 Libs: "-L${libdir}" -licuind
-

--- a/ports/icu/pkgconfig/debug/icu-io.pc
+++ b/ports/icu/pkgconfig/debug/icu-io.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Stream and I/O Library
 Name: icu-io
 Requires.private: icu-i18n
 Libs: "-L${libdir}" -licuiod
-

--- a/ports/icu/pkgconfig/debug/icu-uc.pc
+++ b/ports/icu/pkgconfig/debug/icu-uc.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Common and Data libraries
 Name: icu-uc
 Libs: "-L${libdir}" -licuucd
 Libs.private: -licudtd ${baselibs}
-

--- a/ports/icu/pkgconfig/release/icu-i18n.pc
+++ b/ports/icu/pkgconfig/release/icu-i18n.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Internationalization library
 Name: icu-i18n
 Requires.private: icu-uc
 Libs: "-L${libdir}" -licuin
-

--- a/ports/icu/pkgconfig/release/icu-io.pc
+++ b/ports/icu/pkgconfig/release/icu-io.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Stream and I/O Library
 Name: icu-io
 Requires.private: icu-i18n
 Libs: "-L${libdir}" -licuio
-

--- a/ports/icu/pkgconfig/release/icu-uc.pc
+++ b/ports/icu/pkgconfig/release/icu-uc.pc
@@ -24,18 +24,17 @@ ICUPREFIX=icu
 ICULIBSUFFIX=
 LIBICU=lib${ICUPREFIX}
 #SHAREDLIBCFLAGS=-fPIC
-pkglibdir=${libdir}/icu${ICULIBSUFFIX}/76.1
-#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/76.1
+pkglibdir=${libdir}/icu${ICULIBSUFFIX}/77.1
+#pkgdatadir=${datadir}/icu${ICULIBSUFFIX}/77.1
 ICUDATA_NAME = icudt76l
 #ICUPKGDATA_DIR=${prefix}/lib
 #ICUDATA_DIR=${pkgdatadir}
 ICUDESC=International Components for Unicode
 
-Version: 76.1
+Version: 77.1
 Cflags: "-I${includedir}"
 # end of icu.pc.in
 Description: International Components for Unicode: Common and Data libraries
 Name: icu-uc
 Libs: "-L${libdir}" -licuuc
 Libs.private: -licudt ${baselibs}
-

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -1,4 +1,4 @@
-set(VERSION_MAJOR 76)
+set(VERSION_MAJOR 77)
 set(VERSION_MINOR 1)
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
 set(VERSION2 "${VERSION_MAJOR}_${VERSION_MINOR}")
@@ -11,7 +11,7 @@ set(URLS "https://github.com/unicode-org/icu/releases/download/release-${VERSION
 vcpkg_download_distfile(ARCHIVE
     URLS ${URLS}
     FILENAME ${FILENAME}
-    SHA512 b702ab62fb37a1574d5f4a768326d0f8fa30d9db5b015605b5f8215b5d8547f83d84880c586d3dcc7b6c76f8d47ef34e04b0f51baa55908f737024dd79a42a6c
+    SHA512 a47d6d9c327d037a05ea43d1d1a06b2fd757cc02a94f7c1a238f35cfc3dfd4ab78d0612790f3a3cca0292c77412a9c2c15c8f24b718f79a857e007e66f07e7cd
 )
 
 # Patches

--- a/ports/icu/vcpkg.json
+++ b/ports/icu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "icu",
-  "version": "76.1.0",
+  "version": "77.1.0",
   "description": "ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications. ICU is widely portable and gives applications the same results on all platforms and between C/C++ and Java software.",
   "homepage": "http://site.icu-project.org",
   "license": "ICU",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9,7 +9,7 @@
       "port-version": 0
     },
     "icu": {
-      "baseline": "76.1.0",
+      "baseline": "77.1.0",
       "port-version": 0
     },
     "zlib": {

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea40f10ddf278b30180b541393a9045baebe740c",
+      "version": "77.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "017ddcb2e0493fecbad3eb52acebc458353ccdb9",
       "version": "76.1.0",
       "port-version": 0


### PR DESCRIPTION
CMake 4.0.0 removes support for CMake 3.5 and earlier so set a later version of `cmake_minimum_version` to prevent a build error.