### PR TITLE
Map openssl to libressl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,7 +112,7 @@ jobs:
         id: ngtcp2
         if: steps.libressl.outcome == 'success'
         continue-on-error: true
-        run: ./vcpkg.exe install ngtcp2[libressl] --overlay-ports ./WebKitRequirements/ports --overlay-triplets ./WebKitRequirements/triplets --triplet ${{ matrix.triplet }}
+        run: ./vcpkg.exe install ngtcp2[openssl] --overlay-ports ./WebKitRequirements/ports --overlay-triplets ./WebKitRequirements/triplets --triplet ${{ matrix.triplet }}
       - name: Read ngtcp2 config
         if: steps.ngtcp2.outcome == 'success' || steps.ngtcp2.outcome == 'failure'
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ of third party libraries used in the Windows port of WebKit.
 | Library | Version | Release Date | Reason for Overlay |
 |---|:---:|:---:|---|
 | [icu](http://site.icu-project.org) | 77.1 | 2025-03-13 | CMake port. Upstream pinned to 74.1 |
+| [openssl](https://www.libressl.org/) | libressl | N/A | Map openssl to libressl |
 | [zlib](https://github.com/zlib-ng/zlib-ng) | zlib-ng | N/A | Map zlib to zlib-ng |
 | [curl](https://curl.se) | 8.13.0 | 2025-04-02 | Customization of build options, and release candidates |
 | [cairo](https://gitlab.freedesktop.org/cairo/cairo) | 1.18.2 | 2024-09-01 | CMake port. Will remove when cairo taken out of WebKit |

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -1,0 +1,2 @@
+# Mapping openssl to libressl
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "openssl",
+  "version-string": "libressl",
+  "description": [
+    "LibreSSL is a TLS/crypto stack.",
+    "It was forked from OpenSSL in 2014 by the OpenBSD project, with goals of modernizing the codebase, improving security, and applying best practice development processes.",
+    "LibreSSL provides much of the OpenSSL 1.1 API. Incompatibilities between the projects exist and are unavoidable since both evolve with different goals and priorities."
+  ],
+  "homepage": "https://www.libressl.org",
+  "license": "ISC",
+  "dependencies": [
+    "libressl"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -12,6 +12,10 @@
       "baseline": "77.1.0",
       "port-version": 0
     },
+    "openssl": {
+      "baseline": "libressl",
+      "port-version": 0
+    },
     "zlib": {
       "baseline": "zlib-ng",
       "port-version": 0

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "49722904b3d436ac499fc122102558b10ee73be1",
+      "version-string": "libressl",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
OpenSSL gained support for the QUIC APIs that ngtcp2 needed so it replaced the libressl feature with openssl.